### PR TITLE
Rename references to dev branch to main

### DIFF
--- a/.github/workflows/Benchmarks.yml
+++ b/.github/workflows/Benchmarks.yml
@@ -74,7 +74,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run Benchmarks
-        run: just bench-ci dev release
+        run: just bench-ci main release
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/CargoPublish.yml
+++ b/.github/workflows/CargoPublish.yml
@@ -14,8 +14,8 @@ jobs:
   publish-hyperlight-packages:
     runs-on: [self-hosted, Linux, X64, "1ES.Pool=hld-kvm-amd"]
 
-    # We should only publish from dev if minver contains `-preview`
-    if: ${{ contains(github.ref, 'refs/heads/release/') }} || ${{ github.ref=='refs/heads/dev' }}
+    # We should only publish from main if minver contains `-preview`
+    if: ${{ contains(github.ref, 'refs/heads/release/') }} || ${{ github.ref=='refs/heads/main' }}
 
     steps:
       - uses: actions/checkout@v4
@@ -46,7 +46,7 @@ jobs:
         run: |
           echo "github.ref=${{ github.ref }}"
           echo "HYPERLIGHT_VERSION=$HYPERLIGHT_VERSION"
-          if [[ ${{ github.ref }} =~ 'refs/heads/release/' || ( ${{ github.ref }} == 'refs/heads/dev' &&  $HYPERLIGHT_VERSION =~ '-preview' ) ]]
+          if [[ ${{ github.ref }} =~ 'refs/heads/release/' || ( ${{ github.ref }} == 'refs/heads/main' &&  $HYPERLIGHT_VERSION =~ '-preview' ) ]]
           then
             echo "Setting SHOULD_PUBLISH in GITHUB_ENV"
             echo "SHOULD_PUBLISH=true" >> "$GITHUB_ENV"

--- a/.github/workflows/CreateRelease.yml
+++ b/.github/workflows/CreateRelease.yml
@@ -5,7 +5,7 @@ name: Create a Release
 on:
   workflow_dispatch:
   push:
-    branches: [dev]
+    branches: [main]
 
 permissions:
   contents: write
@@ -17,7 +17,7 @@ jobs:
 
   build-rust-ubuntu:
     # see https://github.com/orgs/community/discussions/26286#discussioncomment-3251208 for why we need to check the ref
-    if: ${{ contains(github.ref, 'refs/heads/release/') }} ||  ${{ github.ref=='refs/heads/dev' }}
+    if: ${{ contains(github.ref, 'refs/heads/release/') }} ||  ${{ github.ref=='refs/heads/main' }}
     runs-on: [self-hosted, Linux, X64, "1ES.Pool=hld-kvm-amd"]
 
     steps:
@@ -46,7 +46,7 @@ jobs:
 
   build-rust-windows:
     # see https://github.com/orgs/community/discussions/26286#discussioncomment-3251208 for why we need to check the ref
-    if: ${{ contains(github.ref, 'refs/heads/release/') }} ||  ${{ github.ref=='refs/heads/dev' }}
+    if: ${{ contains(github.ref, 'refs/heads/release/') }} ||  ${{ github.ref=='refs/heads/main' }}
     runs-on: windows-2022
 
     steps:
@@ -92,7 +92,7 @@ jobs:
 
   publish:
     # see https://github.com/orgs/community/discussions/26286#discussioncomment-3251208 for why we need to check the ref
-    if: ${{ contains(github.ref, 'refs/heads/release/') }} ||  ${{ github.ref=='refs/heads/dev' }}
+    if: ${{ contains(github.ref, 'refs/heads/release/') }} ||  ${{ github.ref=='refs/heads/main' }}
     runs-on: windows-2022
     outputs:      
       HYPERLIGHT_VERSION: ${{ steps.set_hyperlight_version.outputs.HYPERLIGHT_VERSION }}
@@ -111,7 +111,7 @@ jobs:
 
     steps:
       - name: Set Debug Configuration
-        if: ${{ github.ref=='refs/heads/dev' }}
+        if: ${{ github.ref=='refs/heads/main' }}
         run: echo "CONFIG=debug" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
         shell: pwsh
 
@@ -188,7 +188,7 @@ jobs:
           echo "github.ref=${{ github.ref }}"
           echo "HYPERLIGHT_VERSION=$Env:HYPERLIGHT_VERSION"
           if (('${{ github.ref }}'.contains('refs/heads/release')) -or
-              (('${{ github.ref }}'.contains('refs/heads/dev')) -and
+              (('${{ github.ref }}'.contains('refs/heads/main')) -and
                ($Env:HYPERLIGHT_VERSION.contains('-preview')))) {
             echo "Setting SHOULD_PUBLISH in GITHUB_ENV"
             echo "SHOULD_PUBLISH=true" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
@@ -249,12 +249,12 @@ jobs:
             include.tar.gz
         env:
             GH_TOKEN: ${{ github.token }}
-      - name: Create release (dev)
-        # Only create a dev release if we are on the dev branch
-        if: ${{ github.ref=='refs/heads/dev' }}
+      - name: Create prerelease
+        # Only create a prerelease if we are on the main branch
+        if: ${{ github.ref=='refs/heads/main' }}
         run:  |    
             gh release delete dev-latest -y --cleanup-tag || $true
-            gh release create dev-latest -t "Latest Development Build From Dev Branch" --latest=false -p `
+            gh release create dev-latest -t "Latest prerelease from main branch" --latest=false -p `
             src/tests/rust_guests/bin/${{ env.CONFIG }}/callbackguest `
             src/tests/rust_guests/bin/${{ env.CONFIG }}/callbackguest.exe `
             src/tests/rust_guests/bin/${{ env.CONFIG }}/simpleguest `

--- a/.github/workflows/PRLabelChecker.yml
+++ b/.github/workflows/PRLabelChecker.yml
@@ -1,7 +1,7 @@
 name: Label Checker
 on:
   pull_request:
-    branches: dev
+    branches: main
     types: [opened, labeled, unlabeled, synchronize, reopened]
 permissions:
   pull-requests: read

--- a/.github/workflows/ValidatePullRequest.yml
+++ b/.github/workflows/ValidatePullRequest.yml
@@ -4,7 +4,7 @@ name: Validate Pull Request
 
 on:
   pull_request:
-    branches: [main, dev, "release/**"]
+    branches: [main, "release/**"]
   merge_group:
 
 permissions:

--- a/.github/workflows/dep_rust.yml
+++ b/.github/workflows/dep_rust.yml
@@ -126,7 +126,7 @@ jobs:
         run: sudo apt install gh -y
 
       - name: Download benchmarks from "latest"
-        run: just bench-download ${{ runner.os }} ${{ matrix.hypervisor }} dev-latest # compare to pre-release "dev"
+        run: just bench-download ${{ runner.os }} ${{ matrix.hypervisor }} dev-latest # compare to prerelease
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         continue-on-error: true
@@ -134,5 +134,5 @@ jobs:
 
       - name: Run benchmarks
         run: |
-          just bench-ci dev ${{ matrix.config }}
+          just bench-ci main ${{ matrix.config }}
         if: ${{ matrix.config == 'release' }}

--- a/docs/benchmarking-hyperlight.md
+++ b/docs/benchmarking-hyperlight.md
@@ -5,7 +5,7 @@ Hyperlight uses the [Criterion](https://bheisler.github.io/criterion.rs/book/ind
 ## When Benchmarks are ran
 
 1. Every time a branch gets a push
-    - Compares the current branch benchmarking results to the "dev-latest" release (which is the most recent push to "dev" branch). This is done as part of `dep_rust.yml`, which is invoked by `ValidatePullRequest.yml`. These benchmarks are for the developer to compare their branch to dev, and the results can only be seen in the GitHub action logs, and nothing is saved. 
+    - Compares the current branch benchmarking results to the "dev-latest" release (which is the most recent push to "main" branch). This is done as part of `dep_rust.yml`, which is invoked by `ValidatePullRequest.yml`. These benchmarks are for the developer to compare their branch to main, and the results can only be seen in the GitHub action logs, and nothing is saved. 
 
     ```
     sandboxes/create_sandbox
@@ -72,4 +72,4 @@ Found 1 outliers among 100 measurements (1.00%)
 
 ## Running benchmarks locally
 
-Use `just bench [debug/release]` parameter to run benchmarks. Comparing local benchmarks results to github-saved benchmarks doesn't make much sense, since you'd be using different hardware, but you can use `just bench-download os hypervisor [tag] ` to download and extract the GitHub release benchmarks to the correct place folder. You can then run `just bench-ci dev` to compare to (and overwrite) the previous release benchmarks. Note that `dev` is the name of the baselines stored in GitHub.
+Use `just bench [debug/release]` parameter to run benchmarks. Comparing local benchmarks results to github-saved benchmarks doesn't make much sense, since you'd be using different hardware, but you can use `just bench-download os hypervisor [tag] ` to download and extract the GitHub release benchmarks to the correct place folder. You can then run `just bench-ci main` to compare to (and overwrite) the previous release benchmarks. Note that `main` is the name of the baselines stored in GitHub.

--- a/docs/how-to-make-releases.md
+++ b/docs/how-to-make-releases.md
@@ -6,13 +6,13 @@ This document details the process of releasing a new version of Hyperlight to th
 
 Currently, we need to manually update the workspace `Cargo.toml` version number to match to whatever release we are making. This will affect the version of all the crates in the workspace.
 
-> Note: we'll use `v0.4.0` as the version for the above and all subsequent instructions. You should replace this with the version you're releasing. Make sure your version follows [SemVer](https://semver.org) conventions as closely as possible, and is prefixed with a `v` character. *In particular do not use a patch version unless you are patching an issue in a release branch, releases from dev should always be minor or major versions*.
+> Note: we'll use `v0.4.0` as the version for the above and all subsequent instructions. You should replace this with the version you're releasing. Make sure your version follows [SemVer](https://semver.org) conventions as closely as possible, and is prefixed with a `v` character. *In particular do not use a patch version unless you are patching an issue in a release branch, releases from main should always be minor or major versions*.
 
-Create a PR with this change and merge it into the dev branch.
+Create a PR with this change and merge it into the main branch.
 
 ## Create a tag
 
-When the above PR has merged into `dev` branch you should create a tag. ***Make sure you have pulled the recently updated `dev` branch***, and do the following on the `dev` branch:
+When the above PR has merged into `main` branch you should create a tag. ***Make sure you have pulled the recently updated `main` branch***, and do the following on the `main` branch:
 
 ```bash
 git tag -a v0.4.0 -m "A brief description of the release"
@@ -33,7 +33,7 @@ After the previous CI job runs to create the new release branch, go to the ["Cre
 2. In the Use workflow from dropdown, select the `release/v0.4.0` branch
 3. Click the green **Run workflow** button
 
-> Note: In case you see a "Create a Release" job already running before starting this step, that is because the "Create a Release" workflow also automatically runs on push to `dev` branch to create a pre-release. You must still do the steps outlined above.
+> Note: In case you see a "Create a Release" job already running before starting this step, that is because the "Create a Release" workflow also automatically runs on push to `main` branch to create a pre-release. You must still do the steps outlined above.
 
 When this job is done, a new [GitHub release](https://github.com/hyperlight-dev/hyperlight/releases) will be created for you. This job also publishes the following rust packages to the crates.io:
 - `hyperlight-common`


### PR DESCRIPTION
These are the necessary changes for once we rename the `dev` branch to `main`.