### PR TITLE
Reset versioning for publishing to crates.io

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.9.0"
+version = "0.1.0"
 edition = "2021"
 rust-version = "1.79.0"
 license = "Apache-2.0"
@@ -36,9 +36,9 @@ readme = "README.md"
 mshv-bindings = { version = "=0.2.1" }
 mshv-ioctls = { version = "=0.2.1" }
 
-hyperlight-common = { path = "src/hyperlight_common", version = "0.9.0", default-features = false }
-hyperlight-host = { path = "src/hyperlight_host", version = "0.9.0", default-features = false }
-hyperlight-guest = { path = "src/hyperlight_guest", version = "0.9.0", default-features = false }
+hyperlight-common = { path = "src/hyperlight_common", version = "0.1.0", default-features = false }
+hyperlight-host = { path = "src/hyperlight_host", version = "0.1.0", default-features = false }
+hyperlight-guest = { path = "src/hyperlight_guest", version = "0.1.0", default-features = false }
 hyperlight-testing = { path = "src/hyperlight_testing", default-features = false }
 
 [workspace.lints.rust]

--- a/src/tests/rust_guests/callbackguest/Cargo.lock
+++ b/src/tests/rust_guests/callbackguest/Cargo.lock
@@ -70,7 +70,7 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hyperlight-common"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "anyhow",
  "flatbuffers",
@@ -81,7 +81,7 @@ dependencies = [
 
 [[package]]
 name = "hyperlight-guest"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "anyhow",
  "buddy_system_allocator",

--- a/src/tests/rust_guests/simpleguest/Cargo.lock
+++ b/src/tests/rust_guests/simpleguest/Cargo.lock
@@ -62,7 +62,7 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hyperlight-common"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "anyhow",
  "flatbuffers",
@@ -73,7 +73,7 @@ dependencies = [
 
 [[package]]
 name = "hyperlight-guest"
-version = "0.9.0"
+version = "0.1.0"
 dependencies = [
  "anyhow",
  "buddy_system_allocator",


### PR DESCRIPTION
This PR changes the crates versions to `0.1.0` to prepare for the first release to `crates.io`