### PR TITLE
[chore] Modifying logo image in README to use an absolute path

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
   <h1>Hyperlight</h1>
-  <img src="docs/assets/hl-tentative-logo.png" width="150px" />
+  <img src="https://github.com/hyperlight-dev/hyperlight/blob/main/docs/assets/hl-tentative-logo.png" width="150px" />
   <p>
     <strong>Hyperlight is a lightweight Virtual Machine Manager (VMM) designed to be embedded within applications. It enables safe execution of untrusted code within <i>micro virtual machines</i> with very low latency and minimal overhead.
     </strong>


### PR DESCRIPTION
Currently, our logo doesn't show on crates.io. This is because we are using a relative path to the image. This PR changes the path of the image to be an absolute path. For more info, see: https://github.com/rust-lang/crates.io/issues/982.