### PR TITLE
[github-actions] Made it so tests also run on intel

### DIFF
--- a/.github/workflows/Benchmarks.yml
+++ b/.github/workflows/Benchmarks.yml
@@ -17,17 +17,39 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        build: [windows-2022-release, linux-kvm-release, linux-hyperv-release]
+        build: [
+          windows-2022-release-amd,
+          linux-kvm-release-amd,
+          linux-hyperv-release-amd,
+          windows-2022-release-intel,
+          linux-kvm-release-intel,
+          linux-hyperv-release-intel,
+        ]
         include:
-          - build: windows-2022-release
+          - build: windows-2022-release-amd
             os: [self-hosted, Windows, X64, "1ES.Pool=hld-win2022-amd"]
             hypervisor: none
-          - build: linux-kvm-release
+            arch: amd
+          - build: linux-kvm-release-amd
             os: [self-hosted, Linux, X64, "1ES.Pool=hld-kvm-amd"]
             hypervisor: kvm
-          - build: linux-hyperv-release
+            arch: amd
+          - build: linux-hyperv-release-amd
             os: [self-hosted, Linux, X64, "1ES.Pool=hld-mshv-amd"]
             hypervisor: hyperv
+            arch: amd
+          - build: windows-2022-release-intel
+            os: [self-hosted, Windows, X64, "1ES.Pool=hld-win2022-intel"]
+            hypervisor: none
+            arch: intel
+          - build: linux-kvm-release-intel
+            os: [self-hosted, Linux, X64, "1ES.Pool=hld-kvm-intel"]
+            hypervisor: kvm
+            arch: intel
+          - build: linux-hyperv-release-intel
+            os: [self-hosted, Linux, X64, "1ES.Pool=hld-mshv-intel"]
+            hypervisor: hyperv
+            arch: intel
 
     runs-on: ${{ matrix.os }}
     steps:
@@ -68,7 +90,7 @@ jobs:
         run: git fetch --tags origin
 
       - name: Download benchmarks from most recent release
-        run: just bench-download ${{ runner.os }} ${{ matrix.hypervisor }} # skip tag parameter to compare to latest stable release
+        run: just bench-download ${{ runner.os }} ${{ matrix.hypervisor }} ${{ matrix.arch }} # skip tag parameter to compare to latest stable release
         continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -78,6 +100,6 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: benchmarks_${{runner.os}}_${{matrix.hypervisor}}
+          name: benchmarks_${{runner.os}}_${{matrix.hypervisor}}_${{ matrix.arch }}
           path: ./target/criterion/
           if-no-files-found: error

--- a/.github/workflows/Benchmarks.yml
+++ b/.github/workflows/Benchmarks.yml
@@ -28,7 +28,7 @@ jobs:
         include:
           - build: windows-2022-release-amd
             os: [self-hosted, Windows, X64, "1ES.Pool=hld-win2022-amd"]
-            hypervisor: none
+            hypervisor: hyperv
             arch: amd
           - build: linux-kvm-release-amd
             os: [self-hosted, Linux, X64, "1ES.Pool=hld-kvm-amd"]
@@ -40,7 +40,7 @@ jobs:
             arch: amd
           - build: windows-2022-release-intel
             os: [self-hosted, Windows, X64, "1ES.Pool=hld-win2022-intel"]
-            hypervisor: none
+            hypervisor: hyperv
             arch: intel
           - build: linux-kvm-release-intel
             os: [self-hosted, Linux, X64, "1ES.Pool=hld-kvm-intel"]

--- a/.github/workflows/CreateRelease.yml
+++ b/.github/workflows/CreateRelease.yml
@@ -155,29 +155,50 @@ jobs:
           just tar-headers
           just tar-static-lib
 
-      - name: Download benchmarks (Windows)
+      - name: Download benchmarks (Windows amd)
         uses: actions/download-artifact@v4
         with:
-          name: benchmarks_Windows_none
-          path: benchmarks_Windows_none
+          name: benchmarks_Windows_none_amd
+          path: benchmarks_Windows_none_amd
 
-      - name: Download benchmarks (Linux hyperv)
+      - name: Download benchmarks (Linux hyperv amd)
         uses: actions/download-artifact@v4
         with:
-          name: benchmarks_Linux_hyperv
-          path: benchmarks_Linux_hyperv
+          name: benchmarks_Linux_hyperv_amd
+          path: benchmarks_Linux_hyperv_amd
 
-      - name: Download benchmarks (Linux kvm)
+      - name: Download benchmarks (Linux kvm amd)
         uses: actions/download-artifact@v4
         with:
-          name: benchmarks_Linux_kvm
-          path: benchmarks_Linux_kvm
+          name: benchmarks_Linux_kvm_amd
+          path: benchmarks_Linux_kvm_amd
+
+      - name: Download benchmarks (Windows intel)
+        uses: actions/download-artifact@v4
+        with:
+          name: benchmarks_Windows_none_intel
+          path: benchmarks_Windows_none_intel
+
+      - name: Download benchmarks (Linux hyperv intel)
+        uses: actions/download-artifact@v4
+        with:
+          name: benchmarks_Linux_hyperv_intel
+          path: benchmarks_Linux_hyperv_intel
+
+      - name: Download benchmarks (Linux kvm intel)
+        uses: actions/download-artifact@v4
+        with:
+          name: benchmarks_Linux_kvm_intel
+          path: benchmarks_Linux_kvm_intel
 
       - name: Archive benchmarks
         run: |
-          tar -zcvf benchmarks_Windows_none.tar.gz benchmarks_Windows_none
-          tar -zcvf benchmarks_Linux_hyperv.tar.gz benchmarks_Linux_hyperv
-          tar -zcvf benchmarks_Linux_kvm.tar.gz benchmarks_Linux_kvm
+          tar -zcvf benchmarks_Windows_none.tar.gz benchmarks_Windows_none_amd
+          tar -zcvf benchmarks_Linux_hyperv.tar.gz benchmarks_Linux_hyperv_amd
+          tar -zcvf benchmarks_Linux_kvm.tar.gz benchmarks_Linux_kvm_amd
+          tar -zcvf benchmarks_Windows_none.tar.gz benchmarks_Windows_none_intel
+          tar -zcvf benchmarks_Linux_hyperv.tar.gz benchmarks_Linux_hyperv_intel
+          tar -zcvf benchmarks_Linux_kvm.tar.gz benchmarks_Linux_kvm_intel          
 
       - name: Install github-cli
         run: |
@@ -202,9 +223,12 @@ jobs:
             src/tests/rust_guests/bin/${{ env.CONFIG }}/simpleguest `
             src/tests/rust_guests/bin/${{ env.CONFIG }}/simpleguest.exe `
             src/tests/rust_guests/bin/${{ env.CONFIG }}/dummyguest `
-            benchmarks_Windows_none.tar.gz `
-            benchmarks_Linux_hyperv.tar.gz `
-            benchmarks_Linux_kvm.tar.gz `
+            benchmarks_Windows_none_amd.tar.gz `
+            benchmarks_Linux_hyperv_amd.tar.gz `
+            benchmarks_Linux_kvm_amd.tar.gz `
+            benchmarks_Windows_none_intel.tar.gz `
+            benchmarks_Linux_hyperv_intel.tar.gz `
+            benchmarks_Linux_kvm_intel.tar.gz `          
             hyperlight-guest-c-api-linux.tar.gz `
             hyperlight-guest-c-api-windows.tar.gz `
             include.tar.gz
@@ -221,9 +245,12 @@ jobs:
             src/tests/rust_guests/bin/${{ env.CONFIG }}/simpleguest `
             src/tests/rust_guests/bin/${{ env.CONFIG }}/simpleguest.exe `
             src/tests/rust_guests/bin/${{ env.CONFIG }}/dummyguest `
-            benchmarks_Windows_none.tar.gz `
-            benchmarks_Linux_hyperv.tar.gz `
-            benchmarks_Linux_kvm.tar.gz `
+            benchmarks_Windows_none_amd.tar.gz `
+            benchmarks_Linux_hyperv_amd.tar.gz `
+            benchmarks_Linux_kvm_amd.tar.gz `
+            benchmarks_Windows_none_intel.tar.gz `
+            benchmarks_Linux_hyperv_intel.tar.gz `
+            benchmarks_Linux_kvm_intel.tar.gz `          
             hyperlight-guest-c-api-linux.tar.gz `
             hyperlight-guest-c-api-windows.tar.gz `
             include.tar.gz

--- a/.github/workflows/CreateRelease.yml
+++ b/.github/workflows/CreateRelease.yml
@@ -155,7 +155,7 @@ jobs:
           just tar-headers
           just tar-static-lib
 
-      - name: Download benchmarks (Windows amd)
+      - name: Download benchmarks (Windows hyperv amd)
         uses: actions/download-artifact@v4
         with:
           name: benchmarks_Windows_none_amd
@@ -173,7 +173,7 @@ jobs:
           name: benchmarks_Linux_kvm_amd
           path: benchmarks_Linux_kvm_amd
 
-      - name: Download benchmarks (Windows intel)
+      - name: Download benchmarks (Windows hyperv intel)
         uses: actions/download-artifact@v4
         with:
           name: benchmarks_Windows_none_intel
@@ -193,10 +193,10 @@ jobs:
 
       - name: Archive benchmarks
         run: |
-          tar -zcvf benchmarks_Windows_none.tar.gz benchmarks_Windows_none_amd
+          tar -zcvf benchmarks_Windows_hyperv.tar.gz benchmarks_Windows_hyperv_amd
           tar -zcvf benchmarks_Linux_hyperv.tar.gz benchmarks_Linux_hyperv_amd
           tar -zcvf benchmarks_Linux_kvm.tar.gz benchmarks_Linux_kvm_amd
-          tar -zcvf benchmarks_Windows_none.tar.gz benchmarks_Windows_none_intel
+          tar -zcvf benchmarks_Windows_hyperv.tar.gz benchmarks_Windows_hyperv_intel
           tar -zcvf benchmarks_Linux_hyperv.tar.gz benchmarks_Linux_hyperv_intel
           tar -zcvf benchmarks_Linux_kvm.tar.gz benchmarks_Linux_kvm_intel          
 
@@ -223,10 +223,10 @@ jobs:
             src/tests/rust_guests/bin/${{ env.CONFIG }}/simpleguest `
             src/tests/rust_guests/bin/${{ env.CONFIG }}/simpleguest.exe `
             src/tests/rust_guests/bin/${{ env.CONFIG }}/dummyguest `
-            benchmarks_Windows_none_amd.tar.gz `
+            benchmarks_Windows_hyperv_amd.tar.gz `
             benchmarks_Linux_hyperv_amd.tar.gz `
             benchmarks_Linux_kvm_amd.tar.gz `
-            benchmarks_Windows_none_intel.tar.gz `
+            benchmarks_Windows_hyperv_intel.tar.gz `
             benchmarks_Linux_hyperv_intel.tar.gz `
             benchmarks_Linux_kvm_intel.tar.gz `          
             hyperlight-guest-c-api-linux.tar.gz `
@@ -245,10 +245,10 @@ jobs:
             src/tests/rust_guests/bin/${{ env.CONFIG }}/simpleguest `
             src/tests/rust_guests/bin/${{ env.CONFIG }}/simpleguest.exe `
             src/tests/rust_guests/bin/${{ env.CONFIG }}/dummyguest `
-            benchmarks_Windows_none_amd.tar.gz `
+            benchmarks_Windows_hyperv_amd.tar.gz `
             benchmarks_Linux_hyperv_amd.tar.gz `
             benchmarks_Linux_kvm_amd.tar.gz `
-            benchmarks_Windows_none_intel.tar.gz `
+            benchmarks_Windows_hyperv_intel.tar.gz `
             benchmarks_Linux_hyperv_intel.tar.gz `
             benchmarks_Linux_kvm_intel.tar.gz `          
             hyperlight-guest-c-api-linux.tar.gz `

--- a/.github/workflows/CreateRelease.yml
+++ b/.github/workflows/CreateRelease.yml
@@ -155,41 +155,11 @@ jobs:
           just tar-headers
           just tar-static-lib
 
-      - name: Download benchmarks (Windows hyperv amd)
+      - name: Download all benchmarks
         uses: actions/download-artifact@v4
         with:
-          name: benchmarks_Windows_none_amd
-          path: benchmarks_Windows_none_amd
-
-      - name: Download benchmarks (Linux hyperv amd)
-        uses: actions/download-artifact@v4
-        with:
-          name: benchmarks_Linux_hyperv_amd
-          path: benchmarks_Linux_hyperv_amd
-
-      - name: Download benchmarks (Linux kvm amd)
-        uses: actions/download-artifact@v4
-        with:
-          name: benchmarks_Linux_kvm_amd
-          path: benchmarks_Linux_kvm_amd
-
-      - name: Download benchmarks (Windows hyperv intel)
-        uses: actions/download-artifact@v4
-        with:
-          name: benchmarks_Windows_none_intel
-          path: benchmarks_Windows_none_intel
-
-      - name: Download benchmarks (Linux hyperv intel)
-        uses: actions/download-artifact@v4
-        with:
-          name: benchmarks_Linux_hyperv_intel
-          path: benchmarks_Linux_hyperv_intel
-
-      - name: Download benchmarks (Linux kvm intel)
-        uses: actions/download-artifact@v4
-        with:
-          name: benchmarks_Linux_kvm_intel
-          path: benchmarks_Linux_kvm_intel
+          pattern: benchmarks_*
+          # note: artifacts retain their upload name, so we don't have to specify the path
 
       - name: Archive benchmarks
         run: |

--- a/.github/workflows/dep_rust.yml
+++ b/.github/workflows/dep_rust.yml
@@ -21,36 +21,66 @@ jobs:
       matrix:
         build:
           [
-            windows-2022-debug,
-            linux-kvm-debug,
-            linux-hyperv-debug,
-            windows-2022-release,
-            linux-kvm-release,
-            linux-hyperv-release,
+            windows-2022-debug-amd,
+            linux-kvm-debug-amd,
+            linux-hyperv-debug-amd,
+            windows-2022-release-amd,
+            linux-kvm-release-amd,
+            linux-hyperv-release-amd,
+            windows-2022-debug-intel,
+            linux-kvm-debug-intel,
+            linux-hyperv-debug-intel,
+            windows-2022-release-intel,
+            linux-kvm-release-intel,
+            linux-hyperv-release-intel,
           ]
         include:
-          - build: windows-2022-debug
+          - build: windows-2022-debug-amd
             os: [self-hosted, Windows, X64, "1ES.Pool=hld-win2022-amd"]
             hypervisor: none
             config: debug
-          - build: linux-kvm-debug
+          - build: linux-kvm-debug-amd
             os: [self-hosted, Linux, X64, "1ES.Pool=hld-kvm-amd"]
             hypervisor: kvm
             config: debug
-          - build: linux-hyperv-debug
+          - build: linux-hyperv-debug-amd
             os: [self-hosted, Linux, X64, "1ES.Pool=hld-mshv-amd"]
             hypervisor: hyperv
             config: debug
-          - build: windows-2022-release
+          - build: windows-2022-release-amd
             os: [self-hosted, Windows, X64, "1ES.Pool=hld-win2022-amd"]
             hypervisor: none
             config: release
-          - build: linux-kvm-release
+          - build: linux-kvm-release-amd
             os: [self-hosted, Linux, X64, "1ES.Pool=hld-kvm-amd"]
             hypervisor: kvm
             config: release
-          - build: linux-hyperv-release
+          - build: linux-hyperv-release-amd
             os: [self-hosted, Linux, X64, "1ES.Pool=hld-mshv-amd"]
+            hypervisor: hyperv
+            config: release
+          - build: windows-2022-debug-intel
+            os: [self-hosted, Windows, X64, "1ES.Pool=hld-win2022-intel"]
+            hypervisor: none
+            config: debug
+          - build: linux-kvm-debug-intel
+            os: [self-hosted, Linux, X64, "1ES.Pool=hld-kvm-intel"]
+            hypervisor: kvm
+            config: debug
+          - build: linux-hyperv-debug-intel
+            os: [self-hosted, Linux, X64, "1ES.Pool=hld-mshv-intel"]
+            hypervisor: hyperv
+            config: debug
+          - build: windows-2022-release-intel
+            os: [self-hosted, Windows, X64, "1ES.Pool=hld-win2022-intel"]
+            hypervisor: none
+            config: release
+          - build: linux-kvm-release-intel
+            os: [self-hosted, Linux, X64, "1ES.Pool=hld-kvm-intel"]
+            hypervisor: kvm
+            config: release
+          - build: linux-hyperv-release-intel
+            os: [self-hosted, Linux, X64, "1ES.Pool=hld-mshv-intel"]
             hypervisor: hyperv
             config: release
 

--- a/Justfile
+++ b/Justfile
@@ -167,10 +167,11 @@ run-rust-examples-linux target=default-target: (build-rust target) (run-rust-exa
 # Options for os: "Windows", or "Linux"
 # Options for Linux hypervisor: "kvm", "hyperv"
 # Options for Windows hypervisor: "none"
-bench-download os hypervisor tag="":
-    gh release download {{ tag }} -D ./target/ -p benchmarks_{{ os }}_{{ hypervisor }}.tar.gz
+# Options for arch: "amd", "intel"
+bench-download os hypervisor arch tag="":
+    gh release download {{ tag }} -D ./target/ -p benchmarks_{{ os }}_{{ hypervisor }}_{{ arch }}.tar.gz
     mkdir -p target/criterion {{ if os() == "windows" { "-Force" } else { "" } }}
-    tar -zxvf target/benchmarks_{{ os }}_{{ hypervisor }}.tar.gz -C target/criterion/ --strip-components=1
+    tar -zxvf target/benchmarks_{{ os }}_{{ hypervisor }}_{{ arch }}.tar.gz -C target/criterion/ --strip-components=1
 
 # Warning: compares to and then OVERWRITES the given baseline
 bench-ci baseline target=default-target:

--- a/Justfile
+++ b/Justfile
@@ -166,7 +166,7 @@ run-rust-examples-linux target=default-target: (build-rust target) (run-rust-exa
 # If tag is not given, defaults to latest release
 # Options for os: "Windows", or "Linux"
 # Options for Linux hypervisor: "kvm", "hyperv"
-# Options for Windows hypervisor: "none"
+# Options for Windows hypervisor: "hyperv"
 # Options for arch: "amd", "intel"
 bench-download os hypervisor arch tag="":
     gh release download {{ tag }} -D ./target/ -p benchmarks_{{ os }}_{{ hypervisor }}_{{ arch }}.tar.gz


### PR DESCRIPTION
Note: I only modified the dep_rust matrix which will run the tests to assess differences between amd and intel. In the future, we might want to consider revisiting our matrix setup.