### PR TITLE
Add required targets to `rust-toolchain.toml`

### DIFF
--- a/.github/workflows/Benchmarks.yml
+++ b/.github/workflows/Benchmarks.yml
@@ -57,9 +57,7 @@ jobs:
 
       - uses: actions/checkout@v4
 
-      - uses: hyperlight-dev/ci-setup-workflow@v1.0.0
-        with:
-          rust-toolchain: "1.81.0"
+      - uses: hyperlight-dev/ci-setup-workflow@use-rust-toolchain-toml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/CargoPublish.yml
+++ b/.github/workflows/CargoPublish.yml
@@ -32,9 +32,7 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
 
-      - uses: hyperlight-dev/ci-setup-workflow@v1.0.0
-        with:
-          rust-toolchain: "1.81.0"
+      - uses: hyperlight-dev/ci-setup-workflow@use-rust-toolchain-toml
 
       - name: Check crate versions
         shell: bash

--- a/.github/workflows/CreateRelease.yml
+++ b/.github/workflows/CreateRelease.yml
@@ -21,9 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: hyperlight-dev/ci-setup-workflow@v1.0.0
-        with:
-          rust-toolchain: "1.81.0"
+      - uses: hyperlight-dev/ci-setup-workflow@use-rust-toolchain-toml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -41,9 +39,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: hyperlight-dev/ci-setup-workflow@v1.0.0
-        with:
-          rust-toolchain: "1.81.0"
+      - uses: hyperlight-dev/ci-setup-workflow@use-rust-toolchain-toml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -109,9 +105,7 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
 
-      - uses: hyperlight-dev/ci-setup-workflow@v1.0.0
-        with:
-          rust-toolchain: "1.81.0"
+      - uses: hyperlight-dev/ci-setup-workflow@use-rust-toolchain-toml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/ValidatePullRequest.yml
+++ b/.github/workflows/ValidatePullRequest.yml
@@ -54,9 +54,7 @@ jobs:
           systeminfo
 
       # Run this so we can use just targets in this workflow
-      - uses: hyperlight-dev/ci-setup-workflow@v1.0.0
-        with:
-          rust-toolchain: "1.81.0"
+      - uses: hyperlight-dev/ci-setup-workflow@use-rust-toolchain-toml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -114,9 +112,7 @@ jobs:
           echo "cat /etc/os-release"
           cat /etc/os-release
 
-      - uses: hyperlight-dev/ci-setup-workflow@v1.0.0
-        with:
-          rust-toolchain: "1.81.0"
+      - uses: hyperlight-dev/ci-setup-workflow@use-rust-toolchain-toml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/dep_build_guest_binaries.yml
+++ b/.github/workflows/dep_build_guest_binaries.yml
@@ -31,9 +31,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: hyperlight-dev/ci-setup-workflow@v1.0.0
-        with:
-          rust-toolchain: "1.81.0"
+      - uses: hyperlight-dev/ci-setup-workflow@use-rust-toolchain-toml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/dep_fuzzing.yml
+++ b/.github/workflows/dep_fuzzing.yml
@@ -19,14 +19,12 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - uses: hyperlight-dev/ci-setup-workflow@v1.0.0
-        with:
-          rust-toolchain: "1.81.0"
+      - uses: hyperlight-dev/ci-setup-workflow@use-rust-toolchain-toml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up nightly rust
-        uses: dtolnay/rust-toolchain@nightly
+        run: rustup toolchain install nightly
 
       - name: Build rust binaries
         run: |

--- a/.github/workflows/dep_rust.yml
+++ b/.github/workflows/dep_rust.yml
@@ -88,11 +88,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: hyperlight-dev/ci-setup-workflow@v1.0.0
-        with:
-          rust-toolchain: "nightly"
+      - uses: hyperlight-dev/ci-setup-workflow@use-rust-toolchain-toml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up nightly rust
+        run: rustup toolchain install nightly --profile minimal --allow-downgrade --component rustfmt # used by rust-fmt
 
       - name: fmt
         run: just fmt-check

--- a/README.md
+++ b/README.md
@@ -171,15 +171,7 @@ You can run Hyperlight on:
 After having an environment with a hypervisor setup, running the example has the following pre-requisites:
 
 1. On Linux or WSL, you'll most likely need build essential. For Ubuntu, run `sudo apt install build-essential`. For Azure Linux, run `sudo dnf install build-essential`.
-2. [Rust](https://www.rust-lang.org/tools/install). Install toolchain v1.78.0 or later. 
-
-    Also, install the `x86_64-pc-windows-msvc` and `x86_64-unknown-none` targets, these are needed to build the test guest binaries. (Note: install both targets on either Linux or Windows: Hyperlight can load ELF or PE files on either OS, and the tests/examples are built for both):
-
-    ```sh
-    rustup target add x86_64-unknown-none
-    rustup target add x86_64-pc-windows-msvc
-    ```
-
+2. [Rust](https://www.rust-lang.org/tools/install). If you are using rustup you can move on to the next step, otherwise make sure to install the toolchain as specified in `rust-toolchain.toml`.
 3. [just](https://github.com/casey/just). `cargo install just` .
 4. [clang and LLVM](https://clang.llvm.org/get_started.html).
     - On Ubuntu, run:

--- a/hack/rust-dependabot-patch.Dockerfile
+++ b/hack/rust-dependabot-patch.Dockerfile
@@ -1,2 +1,0 @@
-FROM dependabot/dependabot-script
-RUN rustup toolchain install 1.81.0 && rustup default 1.81.0

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,3 +2,5 @@
 channel = "1.81.0"
 # if you update this, don't forget to change the pinned version
 # of nightly we use in the fuzzing workflow.
+
+targets = [ "x86_64-unknown-none", "x86_64-pc-windows-msvc" ]


### PR DESCRIPTION
This PR add the required targets to `rust-toolchain.toml` and simplifies the instructions in README.md.
I also removes `rust-dependabot-patch.Dockerfile` which was made unnecessary by #5