### PR TITLE
chore(deps) Bump strum

### DIFF
--- a/src/hyperlight_common/Cargo.toml
+++ b/src/hyperlight_common/Cargo.toml
@@ -19,8 +19,7 @@ flatbuffers = { version = "24.3.25", default-features = false }
 anyhow = { version = "1.0.72", default-features = false }
 log = "0.4.20"
 tracing = { version = "0.1.27", optional = true }
-strum = {version = "0.25",  default-features = false, features = ["derive"]}
-strum_macros = {version = "0.26", features =[]}
+strum = {version = "0.26",  default-features = false, features = ["derive"]}
 
 [features]
 default = ["tracing"]

--- a/src/hyperlight_common/src/flatbuffer_wrappers/guest_log_level.rs
+++ b/src/hyperlight_common/src/flatbuffer_wrappers/guest_log_level.rs
@@ -16,7 +16,7 @@ limitations under the License.
 
 use anyhow::{bail, Error, Result};
 use log::Level;
-use strum_macros::EnumIter;
+use strum::EnumIter;
 #[cfg(feature = "tracing")]
 use tracing::{instrument, Span};
 

--- a/src/hyperlight_host/Cargo.toml
+++ b/src/hyperlight_host/Cargo.toml
@@ -47,7 +47,7 @@ crossbeam = "0.8.0"
 crossbeam-channel = "0.5.8"
 thiserror = "2.0.0"
 prometheus = "0.13.3"
-strum = { version = "0.25", features = ["derive"] }
+strum = { version = "0.26", features = ["derive"] }
 tempfile = {version = "3.10", optional = true}
 serde_yaml = "0.9"
 anyhow = "1.0"

--- a/src/hyperlight_host/src/hypervisor/metrics.rs
+++ b/src/hyperlight_host/src/hypervisor/metrics.rs
@@ -21,7 +21,7 @@ use std::collections::HashMap;
 use std::sync::Once;
 
 use once_cell::sync::OnceCell;
-use strum::{EnumIter, EnumVariantNames, IntoStaticStr};
+use strum::{EnumIter, IntoStaticStr, VariantNames};
 use tracing::{instrument, Span};
 
 use crate::metrics::{
@@ -55,7 +55,7 @@ static HYPERVISOR_METRIC_DEFINITIONS: &[HyperlightMetricDefinition] =
 /// The enum is required to derive from EnumIter, EnumVariantNames, IntoStaticStr
 /// and strum(serialize_all = "snake_case") performs the name conversion from CamelCase to snake_case
 /// when the enum variant is serialized to a string
-#[derive(Debug, EnumIter, EnumVariantNames, IntoStaticStr)]
+#[derive(Debug, EnumIter, VariantNames, IntoStaticStr)]
 #[strum(serialize_all = "snake_case")]
 pub(super) enum HypervisorMetric {
     NumberOfCancelledGuestExecutions,

--- a/src/hyperlight_host/src/sandbox/metrics.rs
+++ b/src/hyperlight_host/src/sandbox/metrics.rs
@@ -21,7 +21,7 @@ use std::collections::HashMap;
 use std::sync::Once;
 
 use once_cell::sync::OnceCell;
-use strum::{EnumIter, EnumVariantNames, IntoStaticStr};
+use strum::{EnumIter, IntoStaticStr, VariantNames};
 use tracing::{instrument, Span};
 
 use crate::metrics::{
@@ -87,7 +87,7 @@ static SANDBOX_METRIC_DEFINITIONS: &[HyperlightMetricDefinition] = &[
 /// The enum is required to derive from EnumIter, EnumVariantNames, IntoStaticStr
 /// and strum(serialize_all = "snake_case") performs the name conversion from CamelCase to snake_case
 /// when the enum variant is serialized to a string
-#[derive(Debug, EnumIter, EnumVariantNames, IntoStaticStr)]
+#[derive(Debug, EnumIter, VariantNames, IntoStaticStr)]
 #[strum(serialize_all = "snake_case")]
 pub(crate) enum SandboxMetric {
     GuestErrorCount,

--- a/src/tests/rust_guests/callbackguest/Cargo.lock
+++ b/src/tests/rust_guests/callbackguest/Cargo.lock
@@ -64,9 +64,9 @@ dependencies = [
 
 [[package]]
 name = "heck"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hyperlight-common"
@@ -76,7 +76,6 @@ dependencies = [
  "flatbuffers",
  "log",
  "strum",
- "strum_macros",
 ]
 
 [[package]]
@@ -221,18 +220,18 @@ dependencies = [
 
 [[package]]
 name = "strum"
-version = "0.25.0"
+version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
 dependencies = [
  "strum_macros",
 ]
 
 [[package]]
 name = "strum_macros"
-version = "0.25.3"
+version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
 dependencies = [
  "heck",
  "proc-macro2",

--- a/src/tests/rust_guests/simpleguest/Cargo.lock
+++ b/src/tests/rust_guests/simpleguest/Cargo.lock
@@ -56,9 +56,9 @@ dependencies = [
 
 [[package]]
 name = "heck"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hyperlight-common"
@@ -68,7 +68,6 @@ dependencies = [
  "flatbuffers",
  "log",
  "strum",
- "strum_macros",
 ]
 
 [[package]]
@@ -222,18 +221,18 @@ dependencies = [
 
 [[package]]
 name = "strum"
-version = "0.25.0"
+version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
 dependencies = [
  "strum_macros",
 ]
 
 [[package]]
 name = "strum_macros"
-version = "0.25.3"
+version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
 dependencies = [
  "heck",
  "proc-macro2",


### PR DESCRIPTION
strum 0.26 added a deprecation warning, which was being flagged by clippy in CI, preventing the dependabot PR from succeeding.
This PR bumps strum and fixes the deprecation warning.