### PR TITLE
Ignore markdown and txt files in CI

### DIFF
--- a/.github/workflows/ValidatePullRequest.yml
+++ b/.github/workflows/ValidatePullRequest.yml
@@ -5,6 +5,9 @@ name: Validate Pull Request
 on:
   pull_request:
     branches: [main, "release/**"]
+    paths-ignore:
+      - '**.md'
+      - '**.txt'
   merge_group:
 
 permissions:


### PR DESCRIPTION
This PR will ignore paths for markdown as well as txt files. The intent of this is to make it quicker to accept docs changes.