### PR TITLE
Fix docs only CI job processing

### DIFF
--- a/.github/workflows/ValidatePullRequest.yml
+++ b/.github/workflows/ValidatePullRequest.yml
@@ -5,9 +5,6 @@ name: Validate Pull Request
 on:
   pull_request:
     branches: [main, "release/**"]
-    paths-ignore:
-      - '**.md'
-      - '**.txt'
   merge_group:
 
 permissions:
@@ -15,20 +12,52 @@ permissions:
   contents: read
 
 jobs:
+  docs-pr:
+    runs-on: ubuntu-latest
+    outputs:
+      docs-only: ${{ steps.docs-only.outputs.result }}
+    steps:
+      - uses: dorny/paths-filter@v3
+        id: changes
+        with:
+          filters: |
+            docs:
+              - '**/*.md'
+              - '**/*.txt'
+            all:
+              - '**/*'
+      - uses: actions/github-script@v7
+        id: docs-only
+        with:
+          script: |
+            let docs_file_count = ${{steps.changes.outputs.docs_count}};
+            let all_file_count = ${{steps.changes.outputs.all_count}};
+            return all_file_count === docs_file_count;
+          result-encoding: string
 
   rust:
+    needs:
+      - docs-pr
     uses: ./.github/workflows/dep_rust.yml
     secrets: inherit
+    with: 
+      docs_only: ${{needs.docs-pr.outputs.docs-only}}
   fuzzing:
+    needs:
+      - docs-pr
     uses: ./.github/workflows/dep_fuzzing.yml
     with:
       max_total_time: 300 # 5 minutes in seconds
+      docs_only: ${{needs.docs-pr.outputs.docs-only}}
     secrets: inherit
 
   #####
   # start build-on-windows
   #####
   build-on-windows:
+    needs:
+      - docs-pr
+    if: ${{needs.docs-pr.outputs.docs-only != 'true'}}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: true
@@ -72,6 +101,9 @@ jobs:
   # start build-on-linux
   #####
   build-on-linux:
+    needs:
+      - docs-pr
+    if: ${{needs.docs-pr.outputs.docs-only != 'true'}}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: true

--- a/.github/workflows/dep_fuzzing.yml
+++ b/.github/workflows/dep_fuzzing.yml
@@ -7,6 +7,11 @@ on:
         description: Maximum total time for the fuzz run in seconds
         required: true
         type: number
+      docs_only:
+        description: Skip fuzzing if docs only
+        required: false
+        type: string
+        default: "false"
 
 permissions:
   id-token: write
@@ -14,6 +19,7 @@ permissions:
 
 jobs:
   fuzz:
+    if: ${{ inputs.docs_only == 'false' }}
     runs-on: [ self-hosted, Linux, X64, "1ES.Pool=hld-kvm-amd" ]
     steps:
       - name: Checkout code

--- a/.github/workflows/dep_rust.yml
+++ b/.github/workflows/dep_rust.yml
@@ -5,6 +5,12 @@ name: Rust Tests and Lints
 # See README.md in this directory for more information about workflow_call
 on:
   workflow_call:
+    inputs:
+      docs_only:
+        description: Skip building if docs only
+        required: false
+        type: string
+        default: "false"
 
 env:
   CARGO_TERM_COLOR: always
@@ -16,6 +22,7 @@ permissions:
 
 jobs:
   build:
+    if: ${{ inputs.docs_only == 'false' }}
     strategy:
       fail-fast: true
       matrix:

--- a/src/tests/rust_guests/callbackguest/Cargo.lock
+++ b/src/tests/rust_guests/callbackguest/Cargo.lock
@@ -69,6 +69,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
 name = "hyperlight-common"
 version = "0.1.0"
 dependencies = [
@@ -76,7 +82,7 @@ dependencies = [
  "flatbuffers",
  "log",
  "strum",
- "strum_macros",
+ "strum_macros 0.26.4",
 ]
 
 [[package]]
@@ -225,7 +231,7 @@ version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
 dependencies = [
- "strum_macros",
+ "strum_macros 0.25.3",
 ]
 
 [[package]]
@@ -234,7 +240,20 @@ version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
 dependencies = [
- "heck",
+ "heck 0.4.1",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "rustversion",

--- a/src/tests/rust_guests/simpleguest/Cargo.lock
+++ b/src/tests/rust_guests/simpleguest/Cargo.lock
@@ -61,6 +61,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
 name = "hyperlight-common"
 version = "0.1.0"
 dependencies = [
@@ -68,7 +74,7 @@ dependencies = [
  "flatbuffers",
  "log",
  "strum",
- "strum_macros",
+ "strum_macros 0.26.4",
 ]
 
 [[package]]
@@ -226,7 +232,7 @@ version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
 dependencies = [
- "strum_macros",
+ "strum_macros 0.25.3",
 ]
 
 [[package]]
@@ -235,7 +241,20 @@ version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
 dependencies = [
- "heck",
+ "heck 0.4.1",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "rustversion",


### PR DESCRIPTION
In #44, I attempted to ignore docs only CI job processing, but branch protection required jobs were still required to run. The only way to satisfy the branch protection required jobs is to have them run, but return with success. This PR does that by using conditional execution for the job rather than filtering on the PR content in the `pull_request` event handler.