### PR TITLE
Adds support for Azure Linux 3

### DIFF
--- a/.github/workflows/Benchmarks.yml
+++ b/.github/workflows/Benchmarks.yml
@@ -17,11 +17,11 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        hypervisor: [hyperv, mshv, kvm] # hyperv is windows, mshv and kvm are linux
+        hypervisor: [hyperv, mshv, mshv3, kvm] # hyperv is windows, mshv and kvm are linux
         cpu: [amd, intel]
         config: [release] # don't want to benchmark debug-builds
 
-    runs-on: ${{ fromJson(format('["self-hosted", "{0}", "X64", "1ES.Pool=hld-{1}-{2}"]', matrix.hypervisor == 'hyperv' && 'Windows' || 'Linux', matrix.hypervisor == 'hyperv' && 'win2022' || matrix.hypervisor, matrix.cpu)) }} 
+    runs-on: ${{ fromJson(format('["self-hosted", "{0}", "X64", "1ES.Pool=hld-{1}-{2}"]', matrix.hypervisor == 'hyperv' && 'Windows' || 'Linux', matrix.hypervisor == 'hyperv' && 'win2022' || matrix.hypervisor == 'mshv3' && 'azlinux3-mshv' || matrix.hypervisor, matrix.cpu)) }} 
     
     steps:
       ### Setup ###
@@ -67,7 +67,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run Benchmarks
-        run: just bench-ci main release
+        run: just bench-ci main release ${{ matrix.hypervisor == 'mshv3' && 'mshv3' || ''}}
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/dep_rust.yml
+++ b/.github/workflows/dep_rust.yml
@@ -26,11 +26,15 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        hypervisor: [hyperv, mshv, kvm] # hyperv is windows, mshv and kvm are linux
+        hypervisor: [hyperv, mshv, mshv3, kvm] # hyperv is windows, mshv and kvm are linux
         cpu: [amd, intel]
         config: [debug, release]
 
-    runs-on: ${{ fromJson(format('["self-hosted", "{0}", "X64", "1ES.Pool=hld-{1}-{2}"]', matrix.hypervisor == 'hyperv' && 'Windows' || 'Linux', matrix.hypervisor == 'hyperv' && 'win2022' || matrix.hypervisor, matrix.cpu)) }} 
+    runs-on: ${{ fromJson(
+        format('["self-hosted", "{0}", "X64", "1ES.Pool=hld-{1}-{2}"]', 
+          matrix.hypervisor == 'hyperv' && 'Windows' || 'Linux', 
+          matrix.hypervisor == 'hyperv' && 'win2022' || matrix.hypervisor == 'mshv3' && 'azlinux3-mshv' || matrix.hypervisor, 
+          matrix.cpu)) }} 
     steps:
       - uses: actions/checkout@v4
 
@@ -75,10 +79,10 @@ jobs:
           CARGO_TERM_COLOR: always
         run: |
           # with default features
-          just test-rust ${{ matrix.config }}
+          just test-rust ${{ matrix.config }} ${{ matrix.hypervisor == 'mshv3' && 'mshv3' || ''}}
 
           # with only one driver enabled (driver mshv/kvm feature is ignored on windows) + seccomp + inprocess
-          just test-rust ${{ matrix.config }} inprocess,seccomp,${{ matrix.hypervisor == 'mshv' && 'mshv' || 'kvm' }} 
+          just test-rust ${{ matrix.config }} inprocess,seccomp,${{ matrix.hypervisor == 'mshv' && 'mshv2' || matrix.hypervisor == 'mshv3' && 'mshv3' || 'kvm' }} 
 
           # make sure certain cargo features compile
           cargo check -p hyperlight-host --features crashdump
@@ -100,7 +104,7 @@ jobs:
         env:
           CARGO_TERM_COLOR: always
           RUST_LOG: debug
-        run: just run-rust-examples-linux ${{ matrix.config }}
+        run: just run-rust-examples-linux ${{ matrix.config }} ${{ matrix.hypervisor == 'mshv3' && 'mshv3' || ''}}
 
       ### Benchmarks ###
       - name: Install github-cli (Linux mariner)
@@ -120,5 +124,5 @@ jobs:
 
       - name: Run benchmarks
         run: |
-          just bench-ci main ${{ matrix.config }}
+          just bench-ci main ${{ matrix.config }} ${{ matrix.hypervisor == 'mshv3' && 'mshv3' || ''}}
         if: ${{ matrix.config == 'release' }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1102,8 +1102,10 @@ dependencies = [
  "lazy_static",
  "libc",
  "log",
- "mshv-bindings",
- "mshv-ioctls",
+ "mshv-bindings 0.2.1",
+ "mshv-bindings 0.3.2",
+ "mshv-ioctls 0.2.1",
+ "mshv-ioctls 0.3.2",
  "once_cell",
  "opentelemetry",
  "opentelemetry-otlp",
@@ -1617,7 +1619,19 @@ dependencies = [
  "libc",
  "num_enum",
  "vmm-sys-util",
- "zerocopy",
+ "zerocopy 0.7.35",
+]
+
+[[package]]
+name = "mshv-bindings"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0cb5031f3243a7459b7c13d960d25420980874eebda816db24ce6077e21d43"
+dependencies = [
+ "libc",
+ "num_enum",
+ "vmm-sys-util",
+ "zerocopy 0.8.14",
 ]
 
 [[package]]
@@ -1627,8 +1641,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d57586da719aacc905042eea71ff2efb52d16c7228a94af155c9ea45fe09c1c7"
 dependencies = [
  "libc",
- "mshv-bindings",
+ "mshv-bindings 0.2.1",
  "thiserror 1.0.69",
+ "vmm-sys-util",
+]
+
+[[package]]
+name = "mshv-ioctls"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89abe853221fa6f14ad4066affb9abda241a03d65622887d5794e1422d0bd75a"
+dependencies = [
+ "libc",
+ "mshv-bindings 0.3.2",
+ "thiserror 2.0.10",
  "vmm-sys-util",
 ]
 
@@ -1910,7 +1936,7 @@ version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
 dependencies = [
- "zerocopy",
+ "zerocopy 0.7.35",
 ]
 
 [[package]]
@@ -3499,7 +3525,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
  "byteorder",
- "zerocopy-derive",
+ "zerocopy-derive 0.7.35",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a367f292d93d4eab890745e75a778da40909cab4d6ff8173693812f79c4a2468"
+dependencies = [
+ "zerocopy-derive 0.8.14",
 ]
 
 [[package]]
@@ -3507,6 +3542,17 @@ name = "zerocopy-derive"
 version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3931cb58c62c13adec22e38686b559c86a30565e16ad6e8510a337cedc611e1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,8 +33,6 @@ repository = "https://github.com/hyperlight-dev/hyperlight"
 readme = "README.md"
 
 [workspace.dependencies]
-mshv-bindings = { version = "=0.2.1" }
-mshv-ioctls = { version = "=0.2.1" }
 
 hyperlight-common = { path = "src/hyperlight_common", version = "0.1.0", default-features = false }
 hyperlight-host = { path = "src/hyperlight_host", version = "0.1.0", default-features = false }

--- a/src/hyperlight_host/Cargo.toml
+++ b/src/hyperlight_host/Cargo.toml
@@ -71,10 +71,12 @@ windows-version = "0.1"
 
 [target.'cfg(unix)'.dependencies]
 seccompiler = { version = "0.4.0", optional = true }
-mshv-bindings = { workspace = true, optional = true }
-mshv-ioctls = { workspace = true, optional = true }
 kvm-bindings = { version = "0.10.0", features = ["fam-wrappers"], optional = true }
 kvm-ioctls = { version = "0.19.1", optional = true }
+mshv-bindings2 = { package="mshv-bindings", version = "=0.2.1", optional = true }
+mshv-ioctls2 = { package="mshv-ioctls",  version = "=0.2.1", optional = true}
+mshv-bindings3 = { package="mshv-bindings", version = "0.3.2", optional = true }
+mshv-ioctls3 = { package="mshv-ioctls",  version = "0.3.2", optional = true}
 
 [dev-dependencies]
 uuid = { version = "1.12.1", features = ["v4"] }
@@ -114,7 +116,7 @@ cfg_aliases = "0.2.1"
 built = { version = "0.7.0", features = ["chrono", "git2"] }
 
 [features]
-default = ["kvm", "mshv", "seccomp"]
+default = ["kvm", "mshv2", "seccomp"]
 seccomp = ["dep:seccompiler"]
 function_call_metrics = []
 executable_heap = []
@@ -122,7 +124,8 @@ executable_heap = []
 print_debug = []
 crashdump = ["dep:tempfile"] # Dumps the VM state to a file on unexpected errors or crashes. The path of the file will be printed on stdout and logged. This feature can only be used in debug builds.
 kvm = ["dep:kvm-bindings", "dep:kvm-ioctls"]
-mshv = ["dep:mshv-bindings", "dep:mshv-ioctls"]
+mshv2 = ["dep:mshv-bindings2", "dep:mshv-ioctls2"]
+mshv3 = ["dep:mshv-bindings3", "dep:mshv-ioctls3"]
 inprocess = []
 
 [[bench]]

--- a/src/hyperlight_host/build.rs
+++ b/src/hyperlight_host/build.rs
@@ -85,12 +85,12 @@ fn main() -> Result<()> {
     }
 
     // Makes #[cfg(kvm)] == #[cfg(all(feature = "kvm", target_os = "linux"))]
-    // and #[cfg(mshv)] == #[cfg(all(feature = "mshv", target_os = "linux"))].
+    // and #[cfg(mshv)] == #[cfg(all(any(feature = "mshv2", feature = "mshv3"), target_os = "linux"))].
     // Essentially the kvm and mshv features are ignored on windows as long as you use #[cfg(kvm)] and not #[cfg(feature = "kvm")].
     // You should never use #[cfg(feature = "kvm")] or #[cfg(feature = "mshv")] in the codebase.
     cfg_aliases::cfg_aliases! {
         kvm: { all(feature = "kvm", target_os = "linux") },
-        mshv: { all(feature = "mshv", target_os = "linux") },
+        mshv: { all(any(feature = "mshv2", feature = "mshv3"), target_os = "linux") },
         // inprocess feature is aliased with debug_assertions to make it only available in debug-builds.
         // You should never use #[cfg(feature = "inprocess")] in the codebase. Use #[cfg(inprocess)] instead.
         inprocess: { all(feature = "inprocess", debug_assertions) },
@@ -98,6 +98,11 @@ fn main() -> Result<()> {
         crashdump: { all(feature = "crashdump", debug_assertions) },
         // print_debug feature is aliased with debug_assertions to make it only available in debug-builds.
         print_debug: { all(feature = "print_debug", debug_assertions) },
+        // the following features are mutually exclusive but rather than enforcing that here we are enabling mshv3 to override mshv2 when both are enabled
+        // because mshv2 is in the default feature set we want to allow users to enable mshv3 without having to set --no-default-features and the re-enable
+        // the other features they want.
+        mshv2: { all(feature = "mshv2", not(feature="mshv3"), target_os = "linux") },
+        mshv3: { all(feature = "mshv3", target_os = "linux") },
     }
 
     write_built_file()?;

--- a/src/hyperlight_host/src/error.rs
+++ b/src/hyperlight_host/src/error.rs
@@ -14,6 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+#[cfg(mshv2)]
+extern crate mshv_ioctls2 as mshv_ioctls;
+
+#[cfg(mshv3)]
+extern crate mshv_ioctls3 as mshv_ioctls;
+
 use std::array::TryFromSliceError;
 use std::cell::{BorrowError, BorrowMutError};
 use std::convert::Infallible;

--- a/src/hyperlight_host/src/mem/memory_region.rs
+++ b/src/hyperlight_host/src/mem/memory_region.rs
@@ -14,6 +14,16 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+#[cfg(mshv2)]
+extern crate mshv_bindings2 as mshv_bindings;
+#[cfg(mshv2)]
+extern crate mshv_ioctls2 as mshv_ioctls;
+
+#[cfg(mshv3)]
+extern crate mshv_bindings3 as mshv_bindings;
+#[cfg(mshv3)]
+extern crate mshv_ioctls3 as mshv_ioctls;
+
 use std::ops::Range;
 
 use bitflags::bitflags;
@@ -21,9 +31,14 @@ use bitflags::bitflags;
 use hyperlight_common::mem::PAGE_SHIFT;
 use hyperlight_common::mem::PAGE_SIZE_USIZE;
 #[cfg(mshv)]
+use mshv_bindings::{hv_x64_memory_intercept_message, mshv_user_mem_region};
+#[cfg(mshv2)]
 use mshv_bindings::{
-    hv_x64_memory_intercept_message, mshv_user_mem_region, HV_MAP_GPA_EXECUTABLE,
-    HV_MAP_GPA_PERMISSIONS_NONE, HV_MAP_GPA_READABLE, HV_MAP_GPA_WRITABLE,
+    HV_MAP_GPA_EXECUTABLE, HV_MAP_GPA_PERMISSIONS_NONE, HV_MAP_GPA_READABLE, HV_MAP_GPA_WRITABLE,
+};
+#[cfg(mshv3)]
+use mshv_bindings::{
+    MSHV_SET_MEM_BIT_EXECUTABLE, MSHV_SET_MEM_BIT_UNMAP, MSHV_SET_MEM_BIT_WRITABLE,
 };
 #[cfg(target_os = "windows")]
 use windows::Win32::System::Hypervisor::{self, WHV_MEMORY_ACCESS_TYPE};
@@ -227,22 +242,45 @@ impl From<MemoryRegion> for mshv_user_mem_region {
         let guest_pfn = region.guest_region.start as u64 >> PAGE_SHIFT;
         let userspace_addr = region.host_region.start as u64;
 
-        let flags = region.flags.iter().fold(0, |acc, flag| {
-            let flag_value = match flag {
-                MemoryRegionFlags::NONE => HV_MAP_GPA_PERMISSIONS_NONE,
-                MemoryRegionFlags::READ => HV_MAP_GPA_READABLE,
-                MemoryRegionFlags::WRITE => HV_MAP_GPA_WRITABLE,
-                MemoryRegionFlags::EXECUTE => HV_MAP_GPA_EXECUTABLE,
-                _ => 0, // ignore any unknown flags
-            };
-            acc | flag_value
-        });
+        #[cfg(mshv2)]
+        {
+            let flags = region.flags.iter().fold(0, |acc, flag| {
+                let flag_value = match flag {
+                    MemoryRegionFlags::NONE => HV_MAP_GPA_PERMISSIONS_NONE,
+                    MemoryRegionFlags::READ => HV_MAP_GPA_READABLE,
+                    MemoryRegionFlags::WRITE => HV_MAP_GPA_WRITABLE,
+                    MemoryRegionFlags::EXECUTE => HV_MAP_GPA_EXECUTABLE,
+                    _ => 0, // ignore any unknown flags
+                };
+                acc | flag_value
+            });
+            mshv_user_mem_region {
+                guest_pfn,
+                size,
+                userspace_addr,
+                flags,
+            }
+        }
+        #[cfg(mshv3)]
+        {
+            let flags: u8 = region.flags.iter().fold(0, |acc, flag| {
+                let flag_value = match flag {
+                    MemoryRegionFlags::NONE => 1 << MSHV_SET_MEM_BIT_UNMAP,
+                    MemoryRegionFlags::READ => 0,
+                    MemoryRegionFlags::WRITE => 1 << MSHV_SET_MEM_BIT_WRITABLE,
+                    MemoryRegionFlags::EXECUTE => 1 << MSHV_SET_MEM_BIT_EXECUTABLE,
+                    _ => 0, // ignore any unknown flags
+                };
+                acc | flag_value
+            });
 
-        mshv_user_mem_region {
-            guest_pfn,
-            size,
-            userspace_addr,
-            flags,
+            mshv_user_mem_region {
+                guest_pfn,
+                size,
+                userspace_addr,
+                flags,
+                ..Default::default()
+            }
         }
     }
 }


### PR DESCRIPTION
This PR adds support for Azure Linux 3.

Because there are breaking changes between version 2 and verrion 3 of the `mshv-bindings` and `mshv-ioctls` and version 2 is required for Azure Linux version 2 and version 3 is required for Azure Linux version 3, this change also includes feature flags to allow the user to specify which version of mshv to target. 

This defaults to mshv2 (Azure Linux 2), to target Azure Linux 3 enable the `mshv3` feature, there is no need to disable the mshv2 feature in this case.

CI is also updated so tests, examples and benchmarks are all run on Azure Linux 3 runners with the `mshv3` feature enabled.

Fixes https://github.com/hyperlight-dev/hyperlight/issues/167
