### PR TITLE
Fix otlp tracing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1107,6 +1107,7 @@ dependencies = [
  "once_cell",
  "opentelemetry",
  "opentelemetry-otlp",
+ "opentelemetry-semantic-conventions",
  "opentelemetry_sdk",
  "page_size",
  "paste",
@@ -1709,9 +1710,9 @@ checksum = "b410bbe7e14ab526a0e86877eb47c6996a2bd7746f027ba551028c925390e4e9"
 
 [[package]]
 name = "opentelemetry"
-version = "0.26.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "570074cc999d1a58184080966e5bd3bf3a9a4af650c3b05047c2621e7405cd17"
+checksum = "0f3cebff57f7dbd1255b44d8bddc2cebeb0ea677dbaa2e25a3070a91b318f660"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1723,9 +1724,9 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-otlp"
-version = "0.26.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29e1f9c8b032d4f635c730c0efcf731d5e2530ea13fa8bef7939ddc8420696bd"
+checksum = "91cf61a1868dacc576bf2b2a1c3e9ab150af7272909e80085c3173384fe11f76"
 dependencies = [
  "async-trait",
  "futures-core",
@@ -1737,13 +1738,14 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "tonic",
+ "tracing",
 ]
 
 [[package]]
 name = "opentelemetry-proto"
-version = "0.26.1"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9d3968ce3aefdcca5c27e3c4ea4391b37547726a70893aab52d3de95d5f8b34"
+checksum = "a6e05acbfada5ec79023c85368af14abd0b307c015e9064d249b2a950ef459a6"
 dependencies = [
  "opentelemetry",
  "opentelemetry_sdk",
@@ -1752,10 +1754,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "opentelemetry_sdk"
-version = "0.26.0"
+name = "opentelemetry-semantic-conventions"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2c627d9f4c9cdc1f21a29ee4bfbd6028fcb8bcf2a857b43f3abdf72c9c862f3"
+checksum = "bc1b6902ff63b32ef6c489e8048c5e253e2e4a803ea3ea7e783914536eb15c52"
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b742c1cae4693792cc564e58d75a2a0ba29421a34a85b50da92efa89ecb2bc"
 dependencies = [
  "async-trait",
  "futures-channel",
@@ -1770,6 +1778,7 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "tokio-stream",
+ "tracing",
 ]
 
 [[package]]
@@ -2882,9 +2891,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-opentelemetry"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc58af5d3f6c5811462cabb3289aec0093f7338e367e5a33d28c0433b3c7360b"
+checksum = "97a971f6058498b5c0f1affa23e7ea202057a7301dbff68e968b2d578bcbd053"
 dependencies = [
  "js-sys",
  "once_cell",

--- a/docs/hyperlight-metrics-logs-and-traces.md
+++ b/docs/hyperlight-metrics-logs-and-traces.md
@@ -82,13 +82,13 @@ In the [examples/otlp_tracing](../src/hyperlight_host/examples/otlp_tracing) dir
 #### Linux
 
 ```bash
-RUST_LOG='none,hyperlight-host=info,tracing=info' cargo run --example otlp_tracing
+RUST_LOG='none,hyperlight_host=info,tracing=info' cargo run --example otlp_tracing
 ```
 
 #### Windows
 
 ```powershell
-$env:RUST_LOG='none,hyperlight-host=info,tracing=info';cargo run --example otlp_tracing
+$env:RUST_LOG='none,hyperlight_host=info,tracing=info';cargo run --example otlp_tracing
 ```
 
 The sample will run and generate trace data until any key is pressed.
@@ -96,7 +96,7 @@ The sample will run and generate trace data until any key is pressed.
 To view the trace data, leave the example running and use the jaegertracing/all-in-one container image with the following command:
 
 ```console
- docker run -d --name jaeger -e COLLECTOR_OTLP_ENABLED=true -p 4317:4317 -p 16686:16686 jaegertracing/all-in-one:1.51
+ docker run -d --name jaeger -e COLLECTOR_OTLP_ENABLED=true -p 4317:4317 -p 16686:16686 jaegertracing/all-in-one:1.60
 ```
 
 NOTE: when running this on windows that this is a linux container, so you will need to ensure that docker is configured to run linux containers using WSL2. Alternatively, you can download the Jaeger binaries from [here](https://www.jaegertracing.io/download/). Extract the archive and run the `jaeger-all-in-one` executable as follows:

--- a/src/hyperlight_host/Cargo.toml
+++ b/src/hyperlight_host/Cargo.toml
@@ -89,11 +89,12 @@ hyperlight-testing = { workspace = true }
 env_logger = "0.11.5"
 tracing-forest = { version = "0.1.6", features = ["uuid", "chrono", "smallvec", "serde", "env-filter"] }
 tracing = "0.1.37"
-tracing-subscriber = { version = "0.3.18", features = ["std", "env-filter"] }
-tracing-opentelemetry = "0.27.0"
-opentelemetry = "0.26.0"
-opentelemetry-otlp = { version = "0.26.0", features = ["default"] }
-opentelemetry_sdk = { version = "0.26.0", features = ["rt-tokio"] }
+tracing-subscriber = {version = "0.3.18", features = ["std", "env-filter"]}
+tracing-opentelemetry = "0.28.0"
+opentelemetry = "0.27.0"
+opentelemetry-otlp = { version = "0.27.0", features = ["default"] }
+opentelemetry-semantic-conventions = "0.27.0"
+opentelemetry_sdk = { version = "0.27.0", features = ["rt-tokio"] }
 tokio = { version = "1.34.0", features = ["full"] }
 criterion = "0.5.1"
 tracing-chrome = "0.7.2"

--- a/src/hyperlight_host/examples/otlp_tracing/main.rs
+++ b/src/hyperlight_host/examples/otlp_tracing/main.rs
@@ -18,28 +18,27 @@ use hyperlight_common::flatbuffer_wrappers::function_types::{ParameterValue, Ret
 use rand::Rng;
 use tracing::{span, Level};
 use tracing_opentelemetry::OpenTelemetryLayer;
-use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
+use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::util::SubscriberInitExt;
 extern crate hyperlight_host;
+use std::error::Error;
+use std::io::stdin;
+use std::sync::{Arc, Mutex};
+use std::thread::{self, spawn, JoinHandle};
+
 use hyperlight_host::sandbox::uninitialized::UninitializedSandbox;
 use hyperlight_host::sandbox_state::sandbox::EvolvableSandbox;
 use hyperlight_host::sandbox_state::transition::Noop;
 use hyperlight_host::{GuestBinary, MultiUseSandbox, Result as HyperlightResult};
 use hyperlight_testing::simple_guest_as_string;
-use opentelemetry::{
-    global::{self, shutdown_tracer_provider},
-    trace::TracerProvider,
-    KeyValue,
-};
+use opentelemetry::global::{self, shutdown_tracer_provider};
+use opentelemetry::trace::TracerProvider;
+use opentelemetry::KeyValue;
 use opentelemetry_otlp::{SpanExporter, WithExportConfig};
-use opentelemetry_sdk::{runtime::Tokio, trace, Resource};
-use opentelemetry_semantic_conventions::{
-    attribute::{SERVICE_NAME, SERVICE_VERSION},
-    SCHEMA_URL,
-};
-use std::error::Error;
-use std::io::stdin;
-use std::sync::{Arc, Mutex};
-use std::thread::{self, spawn, JoinHandle};
+use opentelemetry_sdk::runtime::Tokio;
+use opentelemetry_sdk::{trace, Resource};
+use opentelemetry_semantic_conventions::attribute::{SERVICE_NAME, SERVICE_VERSION};
+use opentelemetry_semantic_conventions::SCHEMA_URL;
 use tracing_subscriber::EnvFilter;
 use uuid::Uuid;
 


### PR DESCRIPTION
This PR fixes the otlp_tracing example compile issues with latest opentelemetry crate.

It required a slightly different approach to set up the tracer. The [examples ](https://github.com/tokio-rs/tracing-opentelemetry/blob/v0.1.x/examples/opentelemetry-otlp.rs) from tracing-opentelemetry crate were useful.

One other side of the problem was that `jaeger` didn't receive the traces from the example anymore and it turns out it is because of the log filtering. So, using a different `RUST_LOG` should suffice.

The new test added sets up a TcpListener that binds to the same address the tracer subscriber does so it is able to receive the traces so it can validate whether the example runs correctly