### PR TITLE
docs/README.md: fix links to 'further reading' and 'for developers' articles

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -24,20 +24,20 @@ This project is composed internally of several internal components, depicted in 
 
 ## Further reading
 
-* [Glossary](./glossary)
-* [How code gets executed in a VM](./hyperlight-execution-details)
-* [How to build a Hyperlight guest binary](./how-to-build-a-hyperlight-guest-binary)
-* [Security considerations](./security)
-* [Technical requirements document](./technical-requirements-document)
+* [Glossary](./glossary.md)
+* [How code gets executed in a VM](./hyperlight-execution-details.md)
+* [How to build a Hyperlight guest binary](./how-to-build-a-hyperlight-guest-binary.md)
+* [Security considerations](./security.md)
+* [Technical requirements document](./technical-requirements-document.md)
 
 ## For developers
 
-* [Security guidance for developers](./security-guidance-for-developers)
-* [Paging Development Notes](./paging-development-notes)
-* [How to use Flatbuffers in Hyperlight](./how-to-use-flatbuffers)
-* [How to make a Hyperlight release](./how-to-make-releases)
-* [Getting Hyperlight Metrics, Logs, and Traces](./hyperlight-metrics-logs-and-traces)
-* [Benchmarking Hyperlight](./benchmarking-hyperlight)
-* [Hyperlight Surrogate Development Notes](./hyperlight-surrogate-development-notes)
-* [Debugging Hyperlight](./debugging-hyperlight)
+* [Security guidance for developers](./security-guidance-for-developers.md)
+* [Paging Development Notes](./paging-development-notes.md)
+* [How to use Flatbuffers in Hyperlight](./how-to-use-flatbuffers.md)
+* [How to make a Hyperlight release](./how-to-make-releases.md)
+* [Getting Hyperlight Metrics, Logs, and Traces](./hyperlight-metrics-logs-and-traces.md)
+* [Benchmarking Hyperlight](./benchmarking-hyperlight.md)
+* [Hyperlight Surrogate Development Notes](./hyperlight-surrogate-development-notes.md)
+* [Debugging Hyperlight](./debugging-hyperlight.md)
 * [Signal Handling in Hyperlight](./signal-handlers-development-notes.md)


### PR DESCRIPTION
most links were missing the ".md" suffix

Signed-off-by: Yoni L. <yonil@microsoft.com>
