### PR TITLE
Avoid eagerly doing unnecessary string formatting

### DIFF
--- a/.github/workflows/dep_rust.yml
+++ b/.github/workflows/dep_rust.yml
@@ -56,6 +56,7 @@ jobs:
             os: [self-hosted, Linux, X64, "1ES.Pool=hld-mshv-amd"]
             hypervisor: mshv
             config: release
+            arch: amd
           - build: windows-2022-debug-intel
             os: [self-hosted, Windows, X64, "1ES.Pool=hld-win2022-intel"]
             hypervisor: hyperv

--- a/src/hyperlight_host/src/mem/elf.rs
+++ b/src/hyperlight_host/src/mem/elf.rs
@@ -78,7 +78,10 @@ impl ElfInfo {
                 .copy_from_slice(&self.payload[payload_offset..payload_offset + payload_len]);
             target[start_va + payload_len..start_va + phdr.p_memsz as usize].fill(0);
         }
-        let get_addend = |name, r: &Reloc| r.r_addend.ok_or(new_error!("{} missing addend", name));
+        let get_addend = |name, r: &Reloc| {
+            r.r_addend
+                .ok_or_else(|| new_error!("{} missing addend", name))
+        };
         for r in self.relocs.iter() {
             #[cfg(target_arch = "aarch64")]
             match r.r_type {


### PR DESCRIPTION
Switch from `.ok_or` to `.ok_or_else` do only perform the string formatting in the failing case. 
Benchmarks show that time to create an uninitialized sandbox goes from 400µs to about 330µs (-17%) on my local machine

Also adds an `amd` tag that was forgotten in PR #74 