### PR TITLE
Fix 'download benchmark' workflow

### DIFF
--- a/.github/workflows/Benchmarks.yml
+++ b/.github/workflows/Benchmarks.yml
@@ -17,14 +17,6 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        build: [
-          windows-2022-release-amd,
-          linux-kvm-release-amd,
-          linux-hyperv-release-amd,
-          windows-2022-release-intel,
-          linux-kvm-release-intel,
-          linux-hyperv-release-intel,
-        ]
         include:
           - build: windows-2022-release-amd
             os: [self-hosted, Windows, X64, "1ES.Pool=hld-win2022-amd"]
@@ -34,9 +26,9 @@ jobs:
             os: [self-hosted, Linux, X64, "1ES.Pool=hld-kvm-amd"]
             hypervisor: kvm
             arch: amd
-          - build: linux-hyperv-release-amd
+          - build: linux-mshv-release-amd
             os: [self-hosted, Linux, X64, "1ES.Pool=hld-mshv-amd"]
-            hypervisor: hyperv
+            hypervisor: mshv
             arch: amd
           - build: windows-2022-release-intel
             os: [self-hosted, Windows, X64, "1ES.Pool=hld-win2022-intel"]
@@ -46,9 +38,9 @@ jobs:
             os: [self-hosted, Linux, X64, "1ES.Pool=hld-kvm-intel"]
             hypervisor: kvm
             arch: intel
-          - build: linux-hyperv-release-intel
+          - build: linux-mshv-release-intel
             os: [self-hosted, Linux, X64, "1ES.Pool=hld-mshv-intel"]
-            hypervisor: hyperv
+            hypervisor: mshv
             arch: intel
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/dep_rust.yml
+++ b/.github/workflows/dep_rust.yml
@@ -26,70 +26,66 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        build:
-          [
-            windows-2022-debug-amd,
-            linux-kvm-debug-amd,
-            linux-hyperv-debug-amd,
-            windows-2022-release-amd,
-            linux-kvm-release-amd,
-            linux-hyperv-release-amd,
-            windows-2022-debug-intel,
-            linux-kvm-debug-intel,
-            linux-hyperv-debug-intel,
-            windows-2022-release-intel,
-            linux-kvm-release-intel,
-            linux-hyperv-release-intel,
-          ]
         include:
           - build: windows-2022-debug-amd
             os: [self-hosted, Windows, X64, "1ES.Pool=hld-win2022-amd"]
-            hypervisor: none
+            hypervisor: hyperv
             config: debug
+            arch: amd
           - build: linux-kvm-debug-amd
             os: [self-hosted, Linux, X64, "1ES.Pool=hld-kvm-amd"]
             hypervisor: kvm
             config: debug
-          - build: linux-hyperv-debug-amd
+            arch: amd
+          - build: linux-mshv-debug-amd
             os: [self-hosted, Linux, X64, "1ES.Pool=hld-mshv-amd"]
-            hypervisor: hyperv
+            hypervisor: mshv
             config: debug
+            arch: amd
           - build: windows-2022-release-amd
             os: [self-hosted, Windows, X64, "1ES.Pool=hld-win2022-amd"]
-            hypervisor: none
+            hypervisor: hyperv
             config: release
+            arch: amd
           - build: linux-kvm-release-amd
             os: [self-hosted, Linux, X64, "1ES.Pool=hld-kvm-amd"]
             hypervisor: kvm
             config: release
-          - build: linux-hyperv-release-amd
+            arch: amd
+          - build: linux-mshv-release-amd
             os: [self-hosted, Linux, X64, "1ES.Pool=hld-mshv-amd"]
-            hypervisor: hyperv
+            hypervisor: mshv
             config: release
           - build: windows-2022-debug-intel
             os: [self-hosted, Windows, X64, "1ES.Pool=hld-win2022-intel"]
-            hypervisor: none
+            hypervisor: hyperv
             config: debug
+            arch: intel
           - build: linux-kvm-debug-intel
             os: [self-hosted, Linux, X64, "1ES.Pool=hld-kvm-intel"]
             hypervisor: kvm
             config: debug
-          - build: linux-hyperv-debug-intel
+            arch: intel
+          - build: linux-mshv-debug-intel
             os: [self-hosted, Linux, X64, "1ES.Pool=hld-mshv-intel"]
-            hypervisor: hyperv
+            hypervisor: mshv
             config: debug
+            arch: intel
           - build: windows-2022-release-intel
             os: [self-hosted, Windows, X64, "1ES.Pool=hld-win2022-intel"]
-            hypervisor: none
+            hypervisor: hyperv
             config: release
+            arch: intel
           - build: linux-kvm-release-intel
             os: [self-hosted, Linux, X64, "1ES.Pool=hld-kvm-intel"]
             hypervisor: kvm
             config: release
-          - build: linux-hyperv-release-intel
+            arch: intel
+          - build: linux-mshv-release-intel
             os: [self-hosted, Linux, X64, "1ES.Pool=hld-mshv-intel"]
-            hypervisor: hyperv
+            hypervisor: mshv
             config: release
+            arch: intel
 
     runs-on: ${{ matrix.os }}
     steps:
@@ -133,7 +129,7 @@ jobs:
           just test-rust ${{ matrix.config }}
 
           # with only one driver enabled (driver mshv/kvm feature is ignored on windows) + seccomp + inprocess
-          just test-rust ${{ matrix.config }} inprocess,seccomp,${{ matrix.hypervisor == 'hyperv' && 'mshv' || 'kvm' }} 
+          just test-rust ${{ matrix.config }} inprocess,seccomp,${{ matrix.hypervisor == 'mshv' && 'mshv' || 'kvm' }} 
 
           # without any driver (shouldn't compile)
           just test-rust-feature-compilation-fail ${{ matrix.config }}
@@ -155,7 +151,7 @@ jobs:
 
       ### Benchmarks ###
       - name: Install github-cli (Linux mariner)
-        if: runner.os == 'Linux' && matrix.hypervisor == 'hyperv'
+        if: runner.os == 'Linux' && matrix.hypervisor == 'mshv'
         run: sudo dnf install gh -y
 
       - name: Install github-cli (Linux ubuntu)
@@ -163,7 +159,7 @@ jobs:
         run: sudo apt install gh -y
 
       - name: Download benchmarks from "latest"
-        run: just bench-download ${{ runner.os }} ${{ matrix.hypervisor }} dev-latest # compare to prerelease
+        run: just bench-download ${{ runner.os }} ${{ matrix.hypervisor }} ${{ matrix.arch}} dev-latest # compare to prerelease
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         continue-on-error: true


### PR DESCRIPTION
Currently, PRs are not able to compare performance to main branch, because downloading benchmarks from latest prerelease fails because the name of the artifact is incorrect. See https://github.com/hyperlight-dev/hyperlight/actions/runs/11925609379/job/33237994407#step:16:13 for an example error. 

Here is an example of it now working https://github.com/hyperlight-dev/hyperlight/actions/runs/11928115786/job/33244575940?pr=74#step:16:12. Note that some will still fail, since we haven't published benchmarks with the new naming conventions yet (It will be done as part of prerelease when this PR is merged). 

This pr also renames the matrix.hypervisor such that hyperv is used for windows, and mshv for linux

