### PR TITLE
Fix cargo feature 'dump_on_crash'

### DIFF
--- a/.github/workflows/dep_rust.yml
+++ b/.github/workflows/dep_rust.yml
@@ -74,6 +74,10 @@ jobs:
           # with only one driver enabled (driver mshv/kvm feature is ignored on windows) + seccomp + inprocess
           just test-rust ${{ matrix.config }} inprocess,seccomp,${{ matrix.hypervisor == 'mshv' && 'mshv' || 'kvm' }} 
 
+          # make sure certain cargo features compile
+          cargo check -p hyperlight-host --features crashdump
+          cargo check -p hyperlight-host --features print_debug
+
           # without any driver (shouldn't compile)
           just test-rust-feature-compilation-fail ${{ matrix.config }}
 

--- a/docs/debugging-hyperlight.md
+++ b/docs/debugging-hyperlight.md
@@ -39,6 +39,6 @@ cargo test --package hyperlight-host --test integration_test --features print_de
 
 ## Dumping the memory configuration, virtual processor register state and memory contents on a crash or unexpected VM Exit
 
-To dump the details of the memory configuration, the virtual processors register state and the contents of the VM memory set the feature `dump_on_crash` and run a debug build. This will result in a dump file being created in the temporary directory. The name and location of the dump file will be printed to the console and logged as an error message.
+To dump the details of the memory configuration, the virtual processors register state and the contents of the VM memory set the feature `crashdump` and run a debug build. This will result in a dump file being created in the temporary directory. The name and location of the dump file will be printed to the console and logged as an error message.
 
 There are no tools at this time to analyze the dump file, but it can be useful for debugging.

--- a/src/hyperlight_host/Cargo.toml
+++ b/src/hyperlight_host/Cargo.toml
@@ -118,9 +118,7 @@ function_call_metrics = []
 executable_heap = []
 # This feature enables printing of debug information to stdout in debug builds
 print_debug = []
-# This feature enables dunping of the VMs details to a file when an unexpected or error exit occurs in a VM in debug mode
-# the name of the file is output to stdout and logged.
-dump_on_crash = ["dep:tempfile"]
+crashdump = ["dep:tempfile"] # Dumps the VM state to a file on unexpected errors or crashes. The path of the file will be printed on stdout and logged. This feature can only be used in debug builds.
 kvm = ["dep:kvm-bindings", "dep:kvm-ioctls"]
 mshv = ["dep:mshv-bindings", "dep:mshv-ioctls"]
 inprocess = []

--- a/src/hyperlight_host/build.rs
+++ b/src/hyperlight_host/build.rs
@@ -96,6 +96,8 @@ fn main() -> Result<()> {
         inprocess: { all(feature = "inprocess", debug_assertions) },
         // crashdump feature is aliased with debug_assertions to make it only available in debug-builds.
         crashdump: { all(feature = "crashdump", debug_assertions) },
+        // print_debug feature is aliased with debug_assertions to make it only available in debug-builds.
+        print_debug: { all(feature = "print_debug", debug_assertions) },
     }
 
     write_built_file()?;

--- a/src/hyperlight_host/build.rs
+++ b/src/hyperlight_host/build.rs
@@ -94,6 +94,8 @@ fn main() -> Result<()> {
         // inprocess feature is aliased with debug_assertions to make it only available in debug-builds.
         // You should never use #[cfg(feature = "inprocess")] in the codebase. Use #[cfg(inprocess)] instead.
         inprocess: { all(feature = "inprocess", debug_assertions) },
+        // crashdump feature is aliased with debug_assertions to make it only available in debug-builds.
+        crashdump: { all(feature = "crashdump", debug_assertions) },
     }
 
     write_built_file()?;

--- a/src/hyperlight_host/src/hypervisor/crashdump.rs
+++ b/src/hyperlight_host/src/hypervisor/crashdump.rs
@@ -6,8 +6,8 @@ use super::Hypervisor;
 use crate::{new_error, Result};
 
 /// Dump registers + memory regions + raw memory to a tempfile
-#[cfg(feature = "dump_on_crash")]
-pub(crate) fn dump_on_crash_to_tempfile(hv: &dyn Hypervisor) -> Result<()> {
+#[cfg(crashdump)]
+pub(crate) fn crashdump_to_tempfile(hv: &dyn Hypervisor) -> Result<()> {
     let mut temp_file = NamedTempFile::with_prefix("mem")?;
     let hv_details = format!("{:#x?}", hv);
 
@@ -35,7 +35,7 @@ pub(crate) fn dump_on_crash_to_tempfile(hv: &dyn Hypervisor) -> Result<()> {
     let persist_path = temp_file.path().with_extension("dmp");
     temp_file
         .persist(&persist_path)
-        .map_err(|e| new_error!("Failed to persist dump_on_crash file: {:?}", e))?;
+        .map_err(|e| new_error!("Failed to persist crashdump file: {:?}", e))?;
 
     println!("Memory dumped to file: {:?}", persist_path);
     log::error!("Memory dumped to file: {:?}", persist_path);

--- a/src/hyperlight_host/src/hypervisor/dump_on_crash.rs
+++ b/src/hyperlight_host/src/hypervisor/dump_on_crash.rs
@@ -1,0 +1,44 @@
+use std::io::Write;
+
+use tempfile::NamedTempFile;
+
+use super::Hypervisor;
+use crate::{new_error, Result};
+
+/// Dump registers + memory regions + raw memory to a tempfile
+#[cfg(feature = "dump_on_crash")]
+pub(crate) fn dump_on_crash_to_tempfile(hv: &dyn Hypervisor) -> Result<()> {
+    let mut temp_file = NamedTempFile::with_prefix("mem")?;
+    let hv_details = format!("{:#x?}", hv);
+
+    // write hypervisor details such as registers, info about mapped memory regions, etc.
+    temp_file.write_all(hv_details.as_bytes())?;
+    temp_file.write_all(b"================ MEMORY DUMP =================\n")?;
+
+    // write the raw memory dump for each memory region
+    for region in hv.get_memory_regions() {
+        if region.host_region.start == 0 || region.host_region.is_empty() {
+            continue;
+        }
+        // SAFETY: we got this memory region from the hypervisor so should never be invalid
+        let region_slice = unsafe {
+            std::slice::from_raw_parts(
+                region.host_region.start as *const u8,
+                region.host_region.len(),
+            )
+        };
+        temp_file.write_all(region_slice)?;
+    }
+    temp_file.flush()?;
+
+    // persist the tempfile to disk
+    let persist_path = temp_file.path().with_extension("dmp");
+    temp_file
+        .persist(&persist_path)
+        .map_err(|e| new_error!("Failed to persist dump_on_crash file: {:?}", e))?;
+
+    println!("Memory dumped to file: {:?}", persist_path);
+    log::error!("Memory dumped to file: {:?}", persist_path);
+
+    Ok(())
+}

--- a/src/hyperlight_host/src/hypervisor/hyperv_linux.rs
+++ b/src/hyperlight_host/src/hypervisor/hyperv_linux.rs
@@ -311,8 +311,6 @@ impl Hypervisor for HypervLinuxDriver {
                         "mshv MMIO unmapped GPA -Details: Address: {} \n {:#?}",
                         addr, &self
                     );
-                    #[cfg(all(debug_assertions, feature = "dump_on_crash"))]
-                    self.dump_on_crash(self.mem_regions.clone());
                     HyperlightExit::Mmio(addr)
                 }
                 INVALID_GPA_ACCESS_MESSAGE => {
@@ -323,8 +321,6 @@ impl Hypervisor for HypervLinuxDriver {
                         "mshv MMIO invalid GPA access -Details: Address: {} \n {:#?}",
                         gpa, &self
                     );
-                    #[cfg(all(debug_assertions, feature = "dump_on_crash"))]
-                    self.dump_on_crash(self.mem_regions.clone());
                     match self.get_memory_access_violation(
                         gpa as usize,
                         &self.mem_regions,
@@ -336,8 +332,6 @@ impl Hypervisor for HypervLinuxDriver {
                 }
                 other => {
                     debug!("mshv Other Exit: Exit: {:#?} \n {:#?}", other, &self);
-                    #[cfg(all(debug_assertions, feature = "dump_on_crash"))]
-                    self.dump_on_crash(self.mem_regions.clone());
                     log_then_return!("unknown Hyper-V run message type {:?}", other);
                 }
             },
@@ -347,8 +341,6 @@ impl Hypervisor for HypervLinuxDriver {
                 libc::EAGAIN => HyperlightExit::Retry(),
                 _ => {
                     debug!("mshv Error - Details: Error: {} \n {:#?}", e, &self);
-                    #[cfg(all(debug_assertions, feature = "dump_on_crash"))]
-                    self.dump_on_crash(self.mem_regions.clone());
                     log_then_return!("Error running VCPU {:?}", e);
                 }
             },
@@ -359,6 +351,11 @@ impl Hypervisor for HypervLinuxDriver {
     #[instrument(skip_all, parent = Span::current(), level = "Trace")]
     fn as_mut_hypervisor(&mut self) -> &mut dyn Hypervisor {
         self as &mut dyn Hypervisor
+    }
+
+    #[cfg(feature = "dump_on_crash")]
+    fn get_memory_regions(&self) -> &[MemoryRegion] {
+        &self.mem_regions
     }
 }
 

--- a/src/hyperlight_host/src/hypervisor/hyperv_linux.rs
+++ b/src/hyperlight_host/src/hypervisor/hyperv_linux.rs
@@ -353,7 +353,7 @@ impl Hypervisor for HypervLinuxDriver {
         self as &mut dyn Hypervisor
     }
 
-    #[cfg(feature = "dump_on_crash")]
+    #[cfg(crashdump)]
     fn get_memory_regions(&self) -> &[MemoryRegion] {
         &self.mem_regions
     }

--- a/src/hyperlight_host/src/hypervisor/hyperv_windows.rs
+++ b/src/hyperlight_host/src/hypervisor/hyperv_windows.rs
@@ -536,7 +536,7 @@ impl Hypervisor for HypervWindowsDriver {
         self as &mut dyn Hypervisor
     }
 
-    #[cfg(feature = "dump_on_crash")]
+    #[cfg(crashdump)]
     fn get_memory_regions(&self) -> &[MemoryRegion] {
         &self.mem_regions
     }

--- a/src/hyperlight_host/src/hypervisor/inprocess.rs
+++ b/src/hyperlight_host/src/hypervisor/inprocess.rs
@@ -18,6 +18,8 @@ use std::fmt::Debug;
 use std::os::raw::c_void;
 
 use super::{HyperlightExit, Hypervisor};
+#[cfg(feature = "dump_on_crash")]
+use crate::mem::memory_region::MemoryRegion;
 use crate::sandbox::leaked_outb::LeakedOutBWrapper;
 use crate::Result;
 
@@ -122,5 +124,10 @@ impl<'a> Hypervisor for InprocessDriver<'a> {
     #[cfg(target_os = "windows")]
     fn get_partition_handle(&self) -> windows::Win32::System::Hypervisor::WHV_PARTITION_HANDLE {
         unimplemented!("get_partition_handle should not be needed since we are in in-process mode")
+    }
+
+    #[cfg(feature = "dump_on_crash")]
+    fn get_memory_regions(&self) -> &[MemoryRegion] {
+        unimplemented!("get_memory_regions is not supported since we are in in-process mode")
     }
 }

--- a/src/hyperlight_host/src/hypervisor/inprocess.rs
+++ b/src/hyperlight_host/src/hypervisor/inprocess.rs
@@ -18,7 +18,7 @@ use std::fmt::Debug;
 use std::os::raw::c_void;
 
 use super::{HyperlightExit, Hypervisor};
-#[cfg(feature = "dump_on_crash")]
+#[cfg(crashdump)]
 use crate::mem::memory_region::MemoryRegion;
 use crate::sandbox::leaked_outb::LeakedOutBWrapper;
 use crate::Result;
@@ -126,7 +126,7 @@ impl<'a> Hypervisor for InprocessDriver<'a> {
         unimplemented!("get_partition_handle should not be needed since we are in in-process mode")
     }
 
-    #[cfg(feature = "dump_on_crash")]
+    #[cfg(crashdump)]
     fn get_memory_regions(&self) -> &[MemoryRegion] {
         unimplemented!("get_memory_regions is not supported since we are in in-process mode")
     }

--- a/src/hyperlight_host/src/hypervisor/kvm.rs
+++ b/src/hyperlight_host/src/hypervisor/kvm.rs
@@ -326,7 +326,7 @@ impl Hypervisor for KVMDriver {
         self as &mut dyn Hypervisor
     }
 
-    #[cfg(feature = "dump_on_crash")]
+    #[cfg(crashdump)]
     fn get_memory_regions(&self) -> &[MemoryRegion] {
         &self.mem_regions
     }

--- a/src/hyperlight_host/src/lib.rs
+++ b/src/hyperlight_host/src/lib.rs
@@ -143,19 +143,14 @@ macro_rules! log_then_return {
     };
 }
 
+// same as log::debug!, but will additionally print to stdout if the print_debug feature is enabled
 #[macro_export]
 macro_rules! debug {
-
     ($($arg:tt)+) =>
     {
-        // If the print_debug feature is enabled, print the debug message to the console
-        #[cfg(all(feature = "print_debug", debug_assertions))]
-        {
-            (println!($($arg)+))
-        }
-
-        // Then log/trace the debug message
-        (log::debug!($($arg)+))
+        #[cfg(print_debug)]
+        println!($($arg)+);
+        log::debug!($($arg)+);
     }
 }
 

--- a/src/hyperlight_host/src/mem/pe/pe_info.rs
+++ b/src/hyperlight_host/src/mem/pe/pe_info.rs
@@ -23,7 +23,7 @@ use goblin::pe::PE;
 use tracing::{instrument, Span};
 
 use crate::mem::pe::base_relocations;
-use crate::{debug, log_then_return, Result};
+use crate::{log_then_return, Result};
 
 const IMAGE_REL_BASED_DIR64: u8 = 10;
 const IMAGE_REL_BASED_ABSOLUTE: u8 = 0;
@@ -106,9 +106,11 @@ impl PEInfo {
             let name = section.name().unwrap_or("Unknown");
             let virtual_size = section.virtual_size;
             let raw_size = section.size_of_raw_data;
-            debug!(
+            crate::debug!(
                 "Section: {}, Virtual Size: {}, On-Disk Size: {}",
-                name, virtual_size, raw_size
+                name,
+                virtual_size,
+                raw_size
             );
 
             if virtual_size > raw_size {
@@ -122,16 +124,16 @@ impl PEInfo {
 
                     data_section_raw_pointer = section.pointer_to_raw_data;
                     data_section_additional_bytes = virtual_size - raw_size;
-                    debug!(
+                    crate::debug!(
                         "Resizing the data section - Additional bytes required: {}",
                         data_section_additional_bytes
                     );
-                    debug!(
+                    crate::debug!(
                         "Resizing the data section - Existing PE File Size: {} New PE File Size: {}",
                         pe_bytes.len(),
                         pe_bytes.len() + data_section_additional_bytes as usize,
                     );
-                    debug!(
+                    crate::debug!(
                         "Resizing the data section - Data Section Raw Pointer: {}",
                         data_section_raw_pointer
                     );
@@ -140,19 +142,19 @@ impl PEInfo {
                     end_of_data_index =
                         (section.pointer_to_raw_data + section.size_of_raw_data) as usize;
 
-                    debug!("End of data index: {}", end_of_data_index);
+                    crate::debug!("End of data index: {}", end_of_data_index);
 
                     // the remainder of the data is the rest of the file after the .data section if any
 
                     let next_section = pe.sections.get(i + 1);
 
                     if let Some(next_section) = next_section {
-                        debug!(
+                        crate::debug!(
                             "Start of section after data index: {}",
                             next_section.pointer_to_raw_data
                         );
                     } else {
-                        debug!("No more sections after the .data section");
+                        crate::debug!("No more sections after the .data section");
                     }
                 } else {
                     log_then_return!(

--- a/src/hyperlight_host/src/sandbox/uninitialized.rs
+++ b/src/hyperlight_host/src/sandbox/uninitialized.rs
@@ -35,7 +35,7 @@ use crate::sandbox::SandboxConfiguration;
 use crate::sandbox_state::sandbox::EvolvableSandbox;
 use crate::sandbox_state::transition::Noop;
 use crate::{
-    debug, log_build_details, log_then_return, new_error, MultiUseSandbox, Result, SingleUseSandbox,
+    log_build_details, log_then_return, new_error, MultiUseSandbox, Result, SingleUseSandbox,
 };
 
 /// A preliminary `Sandbox`, not yet ready to execute guest code.
@@ -258,7 +258,7 @@ impl UninitializedSandbox {
             }
         }
 
-        debug!("Sandbox created:  {:#?}", sandbox);
+        crate::debug!("Sandbox created:  {:#?}", sandbox);
 
         Ok(sandbox)
     }


### PR DESCRIPTION
Fixes #70. Renames the feature to just "crashdump". Moves it into VirtualCPU::run, so each driver doesn't need to call it. Behavior should be the same: dumps registers,memory_regions and raw memory to file for certain hyperlightexits: mmio, accessviolation, unknown, and errors.

Also changes uses of `crate::debug!` macro to explicilty use the `crate` module prefix to distinguish from the `log` crate.