### PR TITLE
Check that windows version is supported

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1140,6 +1140,7 @@ dependencies = [
  "windows",
  "windows-result",
  "windows-sys 0.59.0",
+ "windows-version",
 ]
 
 [[package]]
@@ -3287,6 +3288,15 @@ dependencies = [
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-version"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6998aa457c9ba8ff2fb9f13e9d2a930dabcea28f1d0ab94d687d8b3654844515"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ exclude = [
 [workspace.package]
 version = "0.1.0"
 edition = "2021"
-rust-version = "1.79.0"
+rust-version = "1.80.0"
 license = "Apache-2.0"
 homepage = "https://github.com/hyperlight-dev/hyperlight"
 repository = "https://github.com/hyperlight-dev/hyperlight"

--- a/README.md
+++ b/README.md
@@ -174,8 +174,8 @@ the [./src/tests/rust_guests](./src/tests/rust_guests) directory for Rust guests
 You can run Hyperlight on:
 
 - [Linux with KVM][kvm].
-- [Windows with Windows Hypervisor Platform (WHP)][whp].
-- Windows Subsystem for Linux 2 ([WSL2][wsl2]) with KVM.
+- [Windows with Windows Hypervisor Platform (WHP).][whp] -  Note that you need Windows 11 / Windows Server 2022 or later to use hyperlight, if you are running on earlier versions of Windows then you should consider using our devcontainer on [GitHub codepsaces]((https://codespaces.new/hyperlight-dev/hyperlight)) or WSL2.
+- Windows Subsystem for Linux 2 (see instructions [here](https://learn.microsoft.com/en-us/windows/wsl/install) for Windows client and [here](https://learn.microsoft.com/en-us/windows/wsl/install-on-server) for Windows Server) with KVM.
 - Azure Linux with mshv (note that you need mshv to be installed to use Hyperlight)
 
 After having an environment with a hypervisor setup, running the example has the following pre-requisites:

--- a/src/hyperlight_host/Cargo.toml
+++ b/src/hyperlight_host/Cargo.toml
@@ -67,6 +67,7 @@ windows-sys = { version = "0.59", features = ["Win32"] }
 windows-result = "0.2"
 rust-embed = { version = "8.3.0", features = ["debug-embed", "include-exclude", "interpolate-folder-path"] }
 sha256 = "1.4.0"
+windows-version = "0.1"
 
 [target.'cfg(unix)'.dependencies]
 seccompiler = { version = "0.4.0", optional = true }

--- a/src/hyperlight_host/src/hypervisor/hyperv_linux.rs
+++ b/src/hyperlight_host/src/hypervisor/hyperv_linux.rs
@@ -84,9 +84,6 @@ impl HypervLinuxDriver {
         rsp_ptr: GuestPtr,
         pml4_ptr: GuestPtr,
     ) -> Result<Self> {
-        if !is_hypervisor_present() {
-            log_then_return!("Hyper-V is not present on this system");
-        }
         let mshv = Mshv::new()?;
         let pr = Default::default();
         let vm_fd = mshv.create_vm_with_config(&pr)?;

--- a/src/hyperlight_host/src/hypervisor/hyperv_windows.rs
+++ b/src/hyperlight_host/src/hypervisor/hyperv_windows.rs
@@ -35,16 +35,15 @@ use super::surrogate_process_manager::*;
 use super::windows_hypervisor_platform::{VMPartition, VMProcessor};
 use super::wrappers::WHvFPURegisters;
 use super::{
-    windows_hypervisor_platform as whp, HyperlightExit, Hypervisor, VirtualCPU, CR0_AM, CR0_ET,
-    CR0_MP, CR0_NE, CR0_PE, CR0_PG, CR0_WP, CR4_OSFXSR, CR4_OSXMMEXCPT, CR4_PAE, EFER_LMA,
-    EFER_LME, EFER_NX, EFER_SCE,
+    HyperlightExit, Hypervisor, VirtualCPU, CR0_AM, CR0_ET, CR0_MP, CR0_NE, CR0_PE, CR0_PG, CR0_WP,
+    CR4_OSFXSR, CR4_OSXMMEXCPT, CR4_PAE, EFER_LMA, EFER_LME, EFER_NX, EFER_SCE,
 };
 use crate::hypervisor::fpu::FP_CONTROL_WORD_DEFAULT;
 use crate::hypervisor::hypervisor_handler::HypervisorHandler;
 use crate::hypervisor::wrappers::WHvGeneralRegisters;
 use crate::mem::memory_region::{MemoryRegion, MemoryRegionFlags};
 use crate::mem::ptr::{GuestPtr, RawPtr};
-use crate::HyperlightError::{NoHypervisorFound, WindowsAPIError};
+use crate::HyperlightError::WindowsAPIError;
 use crate::{debug, log_then_return, new_error, Result};
 
 /// A Hypervisor driver for HyperV-on-Windows.
@@ -75,10 +74,6 @@ impl HypervWindowsDriver {
         entrypoint: u64,
         rsp: u64,
     ) -> Result<Self> {
-        if !whp::is_hypervisor_present() {
-            log_then_return!(NoHypervisorFound());
-        }
-
         // create and setup hypervisor partition
         let mut partition = VMPartition::new(1)?;
 

--- a/src/hyperlight_host/src/hypervisor/kvm.rs
+++ b/src/hyperlight_host/src/hypervisor/kvm.rs
@@ -76,9 +76,6 @@ impl KVMDriver {
         entrypoint: u64,
         rsp: u64,
     ) -> Result<Self> {
-        if !is_hypervisor_present() {
-            log_then_return!("KVM is not present");
-        };
         let kvm = Kvm::new()?;
 
         let vm_fd = kvm.create_vm_with_type(0)?;


### PR DESCRIPTION
Adds checks to ensure that when running on Windows the version of Windows is supported.

On Windows hyperlight requires the API `WHvMapGpaRange2` which only exists on Windows 11 and Windows Server 2022 (or later).

There are multiple commits in this PR each with their own description.

Fixes #76