### PR TITLE
Add support for Hyperlight KVM guest debugging using gdb 

### DIFF
--- a/.github/workflows/dep_rust.yml
+++ b/.github/workflows/dep_rust.yml
@@ -95,6 +95,7 @@ jobs:
           # make sure certain cargo features compile
           cargo check -p hyperlight-host --features crashdump
           cargo check -p hyperlight-host --features print_debug
+          cargo check -p hyperlight-host --features gdb
 
           # without any driver (shouldn't compile)
           just test-rust-feature-compilation-fail ${{ matrix.config }}

--- a/.github/workflows/dep_rust.yml
+++ b/.github/workflows/dep_rust.yml
@@ -115,6 +115,13 @@ jobs:
           RUST_LOG: debug
         run: just run-rust-examples-linux ${{ matrix.config }} ${{ matrix.hypervisor == 'mshv3' && 'mshv3' || ''}}
 
+      - name: Run Rust Gdb tests - linux
+        if: runner.os == 'Linux' && matrix.hypervisor == 'kvm'
+        env:
+          CARGO_TERM_COLOR: always
+          RUST_LOG: debug
+        run: just test-rust-gdb-debugging ${{ matrix.config }}
+
       ### Benchmarks ###
       - name: Install github-cli (Linux mariner)
         if: runner.os == 'Linux' && matrix.hypervisor == 'mshv'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -806,6 +806,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "gdbstub"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31c683a9f13de31432e6097131d5f385898c7f0635c0f392b9d0fa165063c8ac"
+dependencies = [
+ "bitflags 2.8.0",
+ "cfg-if",
+ "log",
+ "managed",
+ "num-traits",
+ "paste",
+]
+
+[[package]]
+name = "gdbstub_arch"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "328a9e9425db13770d0d11de6332a608854266e44c53d12776be7b4aa427e3de"
+dependencies = [
+ "gdbstub",
+ "num-traits",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1106,6 +1130,8 @@ dependencies = [
  "env_logger",
  "envy",
  "flatbuffers",
+ "gdbstub",
+ "gdbstub_arch",
  "goblin",
  "hyperlight-common",
  "hyperlight-testing",
@@ -1573,6 +1599,12 @@ checksum = "19b955cdeb2a02b9117f121ce63aa52d08ade45de53e48fe6a38b39c10f6f709"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "managed"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ca88d725a0a943b096803bd34e73a4437208b6077654cc4ecb2947a5f91618d"
 
 [[package]]
 name = "matchers"

--- a/Justfile
+++ b/Justfile
@@ -110,6 +110,11 @@ test-rust-feature-compilation-fail target=default-target:
     @# the following should fail on linux because one of kvm, mshv, or mshv3 feature must be specified, which is why the exit code is inverted with an !.
     {{ if os() == "linux" { "! cargo check -p hyperlight-host --no-default-features 2> /dev/null"} else { "" } }}
 
+# Test rust gdb debugging
+test-rust-gdb-debugging target=default-target: (build-rust target)
+    {{ set-trace-env-vars }} cargo test --profile={{ if target == "debug" { "dev" } else { target } }} --example guest-debugging --features gdb
+    {{ set-trace-env-vars }} cargo test --profile={{ if target == "debug" { "dev" } else { target } }} --features gdb -- test_gdb
+
 test target=default-target: (test-rust target)
 
 # RUST LINTING

--- a/docs/README.md
+++ b/docs/README.md
@@ -34,6 +34,7 @@ This project is composed internally of several internal components, depicted in 
 
 * [Security guidance for developers](./security-guidance-for-developers.md)
 * [Paging Development Notes](./paging-development-notes.md)
+* [How to debug a Hyperlight guest](./how-to-debug-a-hyperlight-guest.md)
 * [How to use Flatbuffers in Hyperlight](./how-to-use-flatbuffers.md)
 * [How to make a Hyperlight release](./how-to-make-releases.md)
 * [Getting Hyperlight Metrics, Logs, and Traces](./hyperlight-metrics-logs-and-traces.md)

--- a/docs/how-to-debug-a-hyperlight-guest.md
+++ b/docs/how-to-debug-a-hyperlight-guest.md
@@ -1,0 +1,193 @@
+# How to debug a Hyperlight **KVM** guest using gdb
+
+Hyperlight supports gdb debugging of a **KVM** guest running inside a Hyperlight sandbox.
+When Hyperlight is compiled with the `gdb` feature enabled, a Hyperlight KVM sandbox can be configured
+to start listening for a gdb connection.
+
+## Supported features
+
+The Hyperlight `gdb` feature enables **KVM** guest debugging:
+   - an entry point breakpoint is automatically set for the guest to stop
+   - add and remove HW breakpoints (maximum 4 set breakpoints at a time)
+   - add and remove SW breakpoints
+   - read and write registers
+   - read and write addresses
+   - step/continue
+   - get code offset from target
+
+## Expected behavior
+
+Below is a list describing some cases of expected behavior from a gdb debug 
+session of a guest binary running inside a KVM Hyperlight sandbox.
+
+- when the `gdb` feature is enabled and a SandboxConfiguration is provided a
+  debug port, the created sandbox will wait for a gdb client to connect on the
+  configured port
+- when the gdb client attaches, the guest vCPU is expected to be stopped at the
+  entry point
+- if a gdb client disconnects unexpectedly, the debug session will be closed and
+  the guest will continue executing disregarding any prior breakpoints
+- if multiple sandbox instances are created, each instance will have its own
+  gdb thread listening on the configured port
+- if two sandbox instances are created with the same debug port, the second
+  instance logs an error and the gdb thread will not be created, but the sandbox
+  will continue to run without gdb debugging
+
+## Example
+
+### Sandbox configuration
+
+The `guest-debugging` example in Hyperlight demonstrates how to configure a Hyperlight
+sandbox to listen for a gdb client on a specific port.
+
+### CLI Gdb configuration
+
+One can use a gdb config file to provide the symbols and desired configuration.
+
+The below contents of the `.gdbinit` file can be used to provide a basic configuration
+to gdb startup.
+
+```gdb
+# Path to symbols
+file path/to/symbols.elf
+# The port on which Hyperlight listens for a connection
+target remote :8080
+set disassembly-flavor intel
+set disassemble-next-line on
+enable pretty-printer
+layout src
+```
+One can find more information about the `.gdbinit` file at [gdbinit(5)](https://www.man7.org/linux/man-pages/man5/gdbinit.5.html).
+
+### End to end example
+
+Using the example mentioned at [Sandbox configuration](#sandbox-configuration) 
+one can run the below commands to debug the guest binary:
+
+```bash
+# Terminal 1
+$ cargo run --example guest-debugging --features gdb
+```
+
+```bash
+# Terminal 2
+$ cat .gdbinit
+file src/tests/rust_guests/bin/debug/simpleguest
+target remote :8080
+set disassembly-flavor intel
+set disassemble-next-line on
+enable pretty-printer
+layout src
+
+$ gdb
+```
+
+### Using VSCode to debug a Hyperlight guest
+
+To replicate the above behavior using VSCode follow the below steps:
+- install the `gdb` package on the host machine
+- install the `C/C++` extension in VSCode to add debugging capabilities
+- create a `.vscode/launch.json` file in the project directory with the below content:
+    ```json
+    {
+        "version": "0.2.0",
+        "configurations": [
+            {
+                "name": "GDB",
+                "type": "cppdbg",
+                "request": "launch",
+                "program": "${workspaceFolder}/src/tests/rust_guests/bin/debug/simpleguest",
+                "args": [],
+                "stopAtEntry": true,
+                "hardwareBreakpoints": {"require": false, "limit": 4},
+                "cwd": "${workspaceFolder}",
+                "environment": [],
+                "externalConsole": false,
+                "MIMode": "gdb",
+                "miDebuggerPath": "/usr/bin/gdb",
+                "miDebuggerServerAddress": "localhost:8080",
+                "setupCommands": [
+                    {
+                        "description": "Enable pretty-printing for gdb",
+                        "text": "-enable-pretty-printing",
+                        "ignoreFailures": true
+                    },
+                    {
+                        "description": "Set Disassembly Flavor to Intel",
+                        "text": "-gdb-set disassembly-flavor intel",
+                        "ignoreFailures": true
+                    }
+                ]
+            }
+        ]
+    }
+    ```
+- in `Run and Debug` tab, select the `GDB` configuration and click on the `Run`
+  button to start the debugging session.
+  The gdb client will connect to the Hyperlight sandbox and the guest vCPU will
+  stop at the entry point.
+
+
+## How it works
+
+The gdb feature is designed to work like a Request - Response protocol between
+a thread that accepts commands from a gdb client and the hypervisor handler over
+a communication channel.
+
+All the functionality is implemented on the hypervisor side so it has access to
+the shared memory and the vCPU.
+
+The gdb thread uses the `gdbstub` crate to handle the communication with the gdb client.
+When the gdb client requests one of the supported features mentioned above, a request
+is sent over the communication channel to the hypervisor handler for the sandbox
+to resolve.
+
+Below is a sequence diagram that shows the interaction between the entities
+involved in the gdb debugging of a Hyperlight guest running inside a KVM sandbox.
+
+```
+                               ┌───────────────────────────────────────────────────────────────────────────────────────────────┐
+                               │                                       Hyperlight Sandbox                                      │
+     USER                      │                                                                                               │
+┌────────────┐                 │  ┌──────────────┐                      ┌───────────────────────────┐              ┌────────┐  │
+│ gdb client │                 │  │  gdb thread  │                      │ hypervisor handler thread │              │  vCPU  │  │
+└────────────┘                 │  └──────────────┘                      └───────────────────────────┘              └────────┘  │
+      |                        │          |               create_gdb_thread           |                                 |      │
+      |                        │          |◄─────────────────────────────────────────┌─┐         vcpu stopped          ┌─┐     │
+      |    attach              │         ┌─┐                                         │ │◄──────────────────────────────┴─┘     │
+     ┌─┐───────────────────────┼────────►│ │                                         │ │     entrypoint breakpoint      |      │
+     │ │   attach response     │         │ │                                         │ │                                |      │
+     │ │◄──────────────────────┼─────────│ │                                         │ │                                |      │
+     │ │                       │         │ │                                         │ │                                |      │
+     │ │  add_breakpoint       │         │ │                                         │ │                                |      │
+     │ │───────────────────────┼────────►│ │          add_breakpoint                 │ │                                |      │
+     │ │                       │         │ │────────────────────────────────────────►│ │  add_breakpoint                |      │
+     │ │                       │         │ │                                         │ │────┐                           |      │
+     │ │                       │         │ │                                         │ │    │                           |      │
+     │ │                       │         │ │                                         │ │◄───┘                           |      │
+     │ │                       │         │ │          add_breakpoint response        │ │                                |      │
+     │ │  add_breakpoint response        │ │◄────────────────────────────────────────│ │                                |      │
+     │ │◄──────────────────────┬─────────│ │                                         │ │                                |      │
+     │ │   continue            │         │ │                                         │ │                                |      │
+     │ │───────────────────────┼────────►│ │            continue                     │ │                                |      │
+     │ │                       │         │ │────────────────────────────────────────►│ │         resume vcpu            |      │
+     │ │                       │         │ │                                         │ │──────────────────────────────►┌─┐     │
+     │ │                       │         │ │                                         │ │                               │ │     │
+     │ │                       │         │ │                                         │ │                               │ │     │
+     │ │                       │         │ │                                         │ │                               │ │     │
+     │ │                       │         │ │                                         │ │                               │ │     │
+     │ │                       │         │ │                                         │ │         vcpu stopped          │ │     │
+     │ │                       │         │ │        notify vcpu stop reason          │ │◄──────────────────────────────┴─┘     │
+     │ │   notify vcpu stop reason       │ │◄────────────────────────────────────────│ │                                |      │
+     │ │◄──────────────────────┬─────────│ │                                         │ │                                |      │
+     │ │    continue until end │         │ │                                         │ │                                |      │
+     │ │───────────────────────┼────────►│ │            continue                     │ │         resume vcpu            |      │
+     │ │                       │         │ │────────────────────────────────────────►│ │──────────────────────────────►┌─┐     │
+     │ │                       │         │ │                                         │ │                               │ │     │
+     │ │                       │         │ │        comm channel disconnected        │ │         vcpu halted           │ │     │
+     │ │   target finished exec│         │ │◄────────────────────────────────────────┤ │◄──────────────────────────────┴─┘     │
+     │ │◄──────────────────────┼─────────┴─┘          target finished exec           └─┘                                |      │
+     │ │                       │          |                                           |                                 |      │
+     └─┘                       │          |                                           |                                 |      │
+      |                        └───────────────────────────────────────────────────────────────────────────────────────────────┘
+```

--- a/src/hyperlight_host/Cargo.toml
+++ b/src/hyperlight_host/Cargo.toml
@@ -71,6 +71,8 @@ sha256 = "1.4.0"
 windows-version = "0.1"
 
 [target.'cfg(unix)'.dependencies]
+gdbstub = { version = "0.7.3", optional = true }
+gdbstub_arch = { version = "0.3.1", optional = true }
 seccompiler = { version = "0.4.0", optional = true }
 kvm-bindings = { version = "0.11", features = ["fam-wrappers"], optional = true }
 kvm-ioctls = { version = "0.20", optional = true }
@@ -128,8 +130,8 @@ kvm = ["dep:kvm-bindings", "dep:kvm-ioctls"]
 mshv2 = ["dep:mshv-bindings2", "dep:mshv-ioctls2"]
 mshv3 = ["dep:mshv-bindings3", "dep:mshv-ioctls3"]
 inprocess = []
-# This enables compilation of gdb stub for easy debug in the guest
-gdb = []
+# This enables easy debug in the guest
+gdb = ["dep:gdbstub", "dep:gdbstub_arch"]
 
 [[bench]]
 name = "benchmarks"

--- a/src/hyperlight_host/Cargo.toml
+++ b/src/hyperlight_host/Cargo.toml
@@ -128,6 +128,8 @@ kvm = ["dep:kvm-bindings", "dep:kvm-ioctls"]
 mshv2 = ["dep:mshv-bindings2", "dep:mshv-ioctls2"]
 mshv3 = ["dep:mshv-bindings3", "dep:mshv-ioctls3"]
 inprocess = []
+# This enables compilation of gdb stub for easy debug in the guest
+gdb = []
 
 [[bench]]
 name = "benchmarks"

--- a/src/hyperlight_host/build.rs
+++ b/src/hyperlight_host/build.rs
@@ -89,6 +89,7 @@ fn main() -> Result<()> {
     // Essentially the kvm and mshv features are ignored on windows as long as you use #[cfg(kvm)] and not #[cfg(feature = "kvm")].
     // You should never use #[cfg(feature = "kvm")] or #[cfg(feature = "mshv")] in the codebase.
     cfg_aliases::cfg_aliases! {
+        gdb: { all(feature = "gdb", debug_assertions, feature = "kvm", target_os = "linux") },
         kvm: { all(feature = "kvm", target_os = "linux") },
         mshv: { all(any(feature = "mshv2", feature = "mshv3"), target_os = "linux") },
         // inprocess feature is aliased with debug_assertions to make it only available in debug-builds.

--- a/src/hyperlight_host/examples/guest-debugging/main.rs
+++ b/src/hyperlight_host/examples/guest-debugging/main.rs
@@ -1,0 +1,82 @@
+/*
+Copyright 2024 The Hyperlight Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use std::sync::{Arc, Mutex};
+use std::thread;
+
+use hyperlight_common::flatbuffer_wrappers::function_types::{ParameterValue, ReturnType};
+use hyperlight_host::func::HostFunction0;
+#[cfg(gdb)]
+use hyperlight_host::sandbox::config::DebugInfo;
+use hyperlight_host::sandbox::SandboxConfiguration;
+use hyperlight_host::sandbox_state::sandbox::EvolvableSandbox;
+use hyperlight_host::sandbox_state::transition::Noop;
+use hyperlight_host::{MultiUseSandbox, UninitializedSandbox};
+
+/// Build a sandbox configuration that enables GDB debugging when the `gdb` feature is enabled.
+fn get_sandbox_cfg() -> Option<SandboxConfiguration> {
+    #[cfg(gdb)]
+    {
+        let mut cfg = SandboxConfiguration::default();
+        let debug_info = DebugInfo { port: 8080 };
+        cfg.set_guest_debug_info(debug_info);
+
+        Some(cfg)
+    }
+
+    #[cfg(not(gdb))]
+    None
+}
+
+fn main() -> hyperlight_host::Result<()> {
+    let cfg = get_sandbox_cfg();
+
+    // Create an uninitialized sandbox with a guest binary
+    let mut uninitialized_sandbox = UninitializedSandbox::new(
+        hyperlight_host::GuestBinary::FilePath(
+            hyperlight_testing::simple_guest_as_string().unwrap(),
+        ),
+        cfg,  // sandbox configuration
+        None, // default run options
+        None, // default host print function
+    )?;
+
+    // Register a host functions
+    fn sleep_5_secs() -> hyperlight_host::Result<()> {
+        thread::sleep(std::time::Duration::from_secs(5));
+        Ok(())
+    }
+
+    let host_function = Arc::new(Mutex::new(sleep_5_secs));
+
+    host_function.register(&mut uninitialized_sandbox, "Sleep5Secs")?;
+    // Note: This function is unused, it's just here for demonstration purposes
+
+    // Initialize sandbox to be able to call host functions
+    let mut multi_use_sandbox: MultiUseSandbox = uninitialized_sandbox.evolve(Noop::default())?;
+
+    // Call guest function
+    let message = "Hello, World! I am executing inside of a VM :)\n".to_string();
+    let result = multi_use_sandbox.call_guest_function_by_name(
+        "PrintOutput", // function must be defined in the guest binary
+        ReturnType::Int,
+        Some(vec![ParameterValue::String(message.clone())]),
+    );
+
+    assert!(result.is_ok());
+
+    Ok(())
+}

--- a/src/hyperlight_host/src/error.rs
+++ b/src/hyperlight_host/src/error.rs
@@ -275,6 +275,11 @@ pub enum HyperlightError {
     #[error("SystemTimeError {0:?}")]
     SystemTimeError(#[from] SystemTimeError),
 
+    /// Error occurred when translating guest address
+    #[error("An error occurred when translating guest address: {0:?}")]
+    #[cfg(gdb)]
+    TranslateGuestAddress(u64),
+
     /// Error occurred converting a slice to an array
     #[error("TryFromSliceError {0:?}")]
     TryFromSliceError(#[from] TryFromSliceError),

--- a/src/hyperlight_host/src/hypervisor/gdb/event_loop.rs
+++ b/src/hyperlight_host/src/hypervisor/gdb/event_loop.rs
@@ -101,6 +101,9 @@ pub fn event_loop_thread(
         Ok(disconnect_reason) => match disconnect_reason {
             DisconnectReason::Disconnect => { 
                 log::info!("Gdb client disconnected");
+                if let Err(e) = target.disable_debug() {
+                    log::error!("Cannot disable debugging: {:?}", e);
+                }
             }
             DisconnectReason::TargetExited(_) => {
                 log::info!("Guest finalized execution and disconnected");

--- a/src/hyperlight_host/src/hypervisor/gdb/event_loop.rs
+++ b/src/hyperlight_host/src/hypervisor/gdb/event_loop.rs
@@ -1,0 +1,117 @@
+/*
+Copyright 2024 The Hyperlight Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use gdbstub::conn::ConnectionExt;
+use gdbstub::stub::run_blocking::{self, WaitForStopReasonError};
+use gdbstub::stub::{BaseStopReason, DisconnectReason, GdbStub, SingleThreadStopReason};
+
+use super::x86_64_target::HyperlightSandboxTarget;
+use super::{DebugResponse, VcpuStopReason};
+
+pub struct GdbBlockingEventLoop;
+
+impl run_blocking::BlockingEventLoop for GdbBlockingEventLoop {
+    type Connection = Box<dyn ConnectionExt<Error = std::io::Error>>;
+    type StopReason = SingleThreadStopReason<u64>;
+    type Target = HyperlightSandboxTarget;
+
+    fn wait_for_stop_reason(
+        target: &mut Self::Target,
+        conn: &mut Self::Connection,
+    ) -> Result<
+        run_blocking::Event<Self::StopReason>,
+        run_blocking::WaitForStopReasonError<
+            <Self::Target as gdbstub::target::Target>::Error,
+            <Self::Connection as gdbstub::conn::Connection>::Error,
+        >,
+    > {
+        loop {
+            match target.try_recv() {
+                Ok(DebugResponse::VcpuStopped(stop_reason)) => {
+                    log::debug!("VcpuStopped with reason {:?}", stop_reason);
+
+                    // Resume execution if unknown reason for stop
+                    let stop_response = match stop_reason {
+                        VcpuStopReason::DoneStep => BaseStopReason::DoneStep,
+                        VcpuStopReason::SwBp => BaseStopReason::SwBreak(()),
+                        VcpuStopReason::HwBp => BaseStopReason::HwBreak(()),
+                        VcpuStopReason::Unknown => {
+                            target
+                                .resume_vcpu()
+                                .map_err(WaitForStopReasonError::Target)?;
+
+                            continue;
+                        }
+                    };
+
+                    return Ok(run_blocking::Event::TargetStopped(stop_response));
+                }
+                Ok(msg) => {
+                    log::error!("Unexpected message received {:?}", msg);
+                }
+                Err(crossbeam_channel::TryRecvError::Empty) => (),
+                Err(crossbeam_channel::TryRecvError::Disconnected) => {
+                    return Ok(run_blocking::Event::TargetStopped(BaseStopReason::Exited(
+                        0,
+                    )));
+                }
+            }
+
+            // Check if there is any data to read from the connection
+            // If there is, return the data as an incoming data event
+            // Otherwise, continue waiting for a stop reason from the target
+            if conn.peek().map(|b| b.is_some()).unwrap_or(false) {
+                let byte = conn
+                    .read()
+                    .map_err(run_blocking::WaitForStopReasonError::Connection)?;
+
+                return Ok(run_blocking::Event::IncomingData(byte));
+            }
+        }
+    }
+
+    /// Handle an interrupt from the GDB client.
+    /// This function is called when the GDB client sends an interrupt signal.
+    /// Passing `None` defers sending a stop reason to later (e.g. when the target stops).
+    fn on_interrupt(
+        _target: &mut Self::Target,
+    ) -> Result<Option<Self::StopReason>, <Self::Target as gdbstub::target::Target>::Error> {
+        Ok(None)
+    }
+}
+
+pub fn event_loop_thread(
+    debugger: GdbStub<HyperlightSandboxTarget, Box<dyn ConnectionExt<Error = std::io::Error>>>,
+    target: &mut HyperlightSandboxTarget,
+) {
+    match debugger.run_blocking::<GdbBlockingEventLoop>(target) {
+        Ok(disconnect_reason) => match disconnect_reason {
+            DisconnectReason::Disconnect => { 
+                log::info!("Gdb client disconnected");
+            }
+            DisconnectReason::TargetExited(_) => {
+                log::info!("Guest finalized execution and disconnected");
+            }
+            DisconnectReason::TargetTerminated(sig) => {
+                log::info!("Gdb target terminated with signal {}", sig)
+            }
+            DisconnectReason::Kill => log::info!("Gdb sent a kill command"),
+        },
+        Err(e) => {
+            log::error!("fatal error encountered: {e:?}");
+        }
+    }
+}

--- a/src/hyperlight_host/src/hypervisor/gdb/event_loop.rs
+++ b/src/hyperlight_host/src/hypervisor/gdb/event_loop.rs
@@ -99,7 +99,7 @@ pub fn event_loop_thread(
 ) {
     match debugger.run_blocking::<GdbBlockingEventLoop>(target) {
         Ok(disconnect_reason) => match disconnect_reason {
-            DisconnectReason::Disconnect => { 
+            DisconnectReason::Disconnect => {
                 log::info!("Gdb client disconnected");
                 if let Err(e) = target.disable_debug() {
                     log::error!("Cannot disable debugging: {:?}", e);

--- a/src/hyperlight_host/src/hypervisor/gdb/mod.rs
+++ b/src/hyperlight_host/src/hypervisor/gdb/mod.rs
@@ -101,8 +101,10 @@ pub enum VcpuStopReason {
 pub enum DebugMsg {
     AddHwBreakpoint(u64),
     Continue,
+    DisableDebug,
     ReadRegisters,
     RemoveHwBreakpoint(u64),
+    Step,
     WriteRegisters(X86_64Regs),
 }
 
@@ -111,8 +113,10 @@ pub enum DebugMsg {
 pub enum DebugResponse {
     AddHwBreakpoint(bool),
     Continue,
+    DisableDebug,
     ReadRegisters(X86_64Regs),
     RemoveHwBreakpoint(bool),
+    Step,
     VcpuStopped(VcpuStopReason),
     WriteRegisters,
 }

--- a/src/hyperlight_host/src/hypervisor/gdb/mod.rs
+++ b/src/hyperlight_host/src/hypervisor/gdb/mod.rs
@@ -1,0 +1,62 @@
+/*
+Copyright 2024 The Hyperlight Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use std::io::{self, ErrorKind};
+use std::net::TcpListener;
+use std::thread;
+use thiserror::Error;
+#[derive(Debug, Error)]
+pub enum GdbTargetError {
+    #[error("Error encountered while binding to address and port")]
+    CannotBind,
+    #[error("Error encountered while listening for connections")]
+    ListenerError,
+    #[error("Unexpected error encountered")]
+    UnexpectedError,
+}
+
+impl From<io::Error> for GdbTargetError {
+    fn from(err: io::Error) -> Self {
+        match err.kind() {
+            ErrorKind::AddrInUse => Self::CannotBind,
+            ErrorKind::AddrNotAvailable => Self::CannotBind,
+            ErrorKind::ConnectionReset
+            | ErrorKind::ConnectionAborted
+            | ErrorKind::ConnectionRefused => Self::ListenerError,
+            _ => Self::UnexpectedError,
+        }
+    }
+}
+/// Creates a thread that handles gdb protocol
+pub fn create_gdb_thread(
+    port: u16,
+) -> Result<(), GdbTargetError> {
+    let socket = format!("localhost:{}", port);
+
+    log::info!("Listening on {:?}", socket);
+    let listener = TcpListener::bind(socket)?;
+
+    log::info!("Starting GDB thread");
+    let _handle = thread::Builder::new()
+        .name("GDB handler".to_string())
+        .spawn(move || -> Result<(), GdbTargetError> {
+            log::info!("Waiting for GDB connection ... ");
+            let (_, _) = listener.accept()?;
+            Ok(())
+        });
+
+    Ok(())
+}

--- a/src/hyperlight_host/src/hypervisor/gdb/mod.rs
+++ b/src/hyperlight_host/src/hypervisor/gdb/mod.rs
@@ -64,6 +64,29 @@ impl From<GdbTargetError> for TargetError<GdbTargetError> {
     }
 }
 
+/// Struct that contains the x86_64 core registers
+#[derive(Debug, Default)]
+pub struct X86_64Regs {
+    pub rax: u64,
+    pub rbx: u64,
+    pub rcx: u64,
+    pub rdx: u64,
+    pub rsi: u64,
+    pub rdi: u64,
+    pub rbp: u64,
+    pub rsp: u64,
+    pub r8: u64,
+    pub r9: u64,
+    pub r10: u64,
+    pub r11: u64,
+    pub r12: u64,
+    pub r13: u64,
+    pub r14: u64,
+    pub r15: u64,
+    pub rip: u64,
+    pub rflags: u64,
+}
+
 /// Defines the possible reasons for which a vCPU can be stopped when debugging
 #[derive(Debug)]
 pub enum VcpuStopReason {
@@ -74,18 +97,20 @@ pub enum VcpuStopReason {
 }
 
 /// Enumerates the possible actions that a debugger can ask from a Hypervisor
-#[allow(dead_code)]
 #[derive(Debug)]
 pub enum DebugMsg {
     Continue,
+    ReadRegisters,
+    WriteRegisters(X86_64Regs),
 }
 
 /// Enumerates the possible responses that a hypervisor can provide to a debugger
-#[allow(dead_code)]
 #[derive(Debug)]
 pub enum DebugResponse {
     Continue,
+    ReadRegisters(X86_64Regs),
     VcpuStopped(VcpuStopReason),
+    WriteRegisters,
 }
 
 /// Debug communication channel that is used for sending a request type and

--- a/src/hyperlight_host/src/hypervisor/gdb/mod.rs
+++ b/src/hyperlight_host/src/hypervisor/gdb/mod.rs
@@ -14,9 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+#![allow(dead_code)]
 use std::io::{self, ErrorKind};
 use std::net::TcpListener;
 use std::thread;
+
+use crossbeam_channel::{Receiver, Sender, TryRecvError};
 use thiserror::Error;
 #[derive(Debug, Error)]
 pub enum GdbTargetError {
@@ -24,6 +27,10 @@ pub enum GdbTargetError {
     CannotBind,
     #[error("Error encountered while listening for connections")]
     ListenerError,
+    #[error("Error encountered when waiting to receive message")]
+    CannotReceiveMsg,
+    #[error("Error encountered when sending message")]
+    CannotSendMsg,
     #[error("Unexpected error encountered")]
     UnexpectedError,
 }
@@ -40,6 +47,48 @@ impl From<io::Error> for GdbTargetError {
         }
     }
 }
+/// Type that takes care of communication between Hypervisor and Gdb
+pub struct DebugCommChannel<T, U> {
+    /// Transmit channel
+    tx: Sender<T>,
+    /// Receive channel
+    rx: Receiver<U>,
+}
+
+impl<T, U> DebugCommChannel<T, U> {
+    pub fn unbounded() -> (DebugCommChannel<T, U>, DebugCommChannel<U, T>) {
+        let (hyp_tx, gdb_rx): (Sender<U>, Receiver<U>) = crossbeam_channel::unbounded();
+        let (gdb_tx, hyp_rx): (Sender<T>, Receiver<T>) = crossbeam_channel::unbounded();
+
+        let gdb_conn = DebugCommChannel {
+            tx: gdb_tx,
+            rx: gdb_rx,
+        };
+
+        let hyp_conn = DebugCommChannel {
+            tx: hyp_tx,
+            rx: hyp_rx,
+        };
+
+        (gdb_conn, hyp_conn)
+    }
+
+    /// Sends message over the transmit channel and expects a response
+    pub fn send(&self, msg: T) -> Result<(), GdbTargetError> {
+        self.tx.send(msg).map_err(|_| GdbTargetError::CannotSendMsg)
+    }
+
+    /// Waits for a message over the receive channel
+    pub fn recv(&self) -> Result<U, GdbTargetError> {
+        self.rx.recv().map_err(|_| GdbTargetError::CannotReceiveMsg)
+    }
+
+    /// Checks whether there's a message waiting on the receive channel
+    pub fn try_recv(&self) -> Result<U, TryRecvError> {
+        self.rx.try_recv()
+    }
+}
+
 /// Creates a thread that handles gdb protocol
 pub fn create_gdb_thread(
     port: u16,

--- a/src/hyperlight_host/src/hypervisor/gdb/mod.rs
+++ b/src/hyperlight_host/src/hypervisor/gdb/mod.rs
@@ -100,12 +100,14 @@ pub enum VcpuStopReason {
 #[derive(Debug)]
 pub enum DebugMsg {
     AddHwBreakpoint(u64),
+    AddSwBreakpoint(u64),
     Continue,
     DisableDebug,
     GetCodeSectionOffset,
     ReadAddr(u64, usize),
     ReadRegisters,
     RemoveHwBreakpoint(u64),
+    RemoveSwBreakpoint(u64),
     Step,
     WriteAddr(u64, Vec<u8>),
     WriteRegisters(X86_64Regs),
@@ -115,12 +117,14 @@ pub enum DebugMsg {
 #[derive(Debug)]
 pub enum DebugResponse {
     AddHwBreakpoint(bool),
+    AddSwBreakpoint(bool),
     Continue,
     DisableDebug,
     GetCodeSectionOffset(u64),
     ReadAddr(Vec<u8>),
     ReadRegisters(X86_64Regs),
     RemoveHwBreakpoint(bool),
+    RemoveSwBreakpoint(bool),
     Step,
     VcpuStopped(VcpuStopReason),
     WriteAddr,

--- a/src/hyperlight_host/src/hypervisor/gdb/mod.rs
+++ b/src/hyperlight_host/src/hypervisor/gdb/mod.rs
@@ -102,9 +102,12 @@ pub enum DebugMsg {
     AddHwBreakpoint(u64),
     Continue,
     DisableDebug,
+    GetCodeSectionOffset,
+    ReadAddr(u64, usize),
     ReadRegisters,
     RemoveHwBreakpoint(u64),
     Step,
+    WriteAddr(u64, Vec<u8>),
     WriteRegisters(X86_64Regs),
 }
 
@@ -114,10 +117,13 @@ pub enum DebugResponse {
     AddHwBreakpoint(bool),
     Continue,
     DisableDebug,
+    GetCodeSectionOffset(u64),
+    ReadAddr(Vec<u8>),
     ReadRegisters(X86_64Regs),
     RemoveHwBreakpoint(bool),
     Step,
     VcpuStopped(VcpuStopReason),
+    WriteAddr,
     WriteRegisters,
 }
 

--- a/src/hyperlight_host/src/hypervisor/gdb/mod.rs
+++ b/src/hyperlight_host/src/hypervisor/gdb/mod.rs
@@ -99,16 +99,20 @@ pub enum VcpuStopReason {
 /// Enumerates the possible actions that a debugger can ask from a Hypervisor
 #[derive(Debug)]
 pub enum DebugMsg {
+    AddHwBreakpoint(u64),
     Continue,
     ReadRegisters,
+    RemoveHwBreakpoint(u64),
     WriteRegisters(X86_64Regs),
 }
 
 /// Enumerates the possible responses that a hypervisor can provide to a debugger
 #[derive(Debug)]
 pub enum DebugResponse {
+    AddHwBreakpoint(bool),
     Continue,
     ReadRegisters(X86_64Regs),
+    RemoveHwBreakpoint(bool),
     VcpuStopped(VcpuStopReason),
     WriteRegisters,
 }

--- a/src/hyperlight_host/src/hypervisor/gdb/mod.rs
+++ b/src/hyperlight_host/src/hypervisor/gdb/mod.rs
@@ -120,6 +120,7 @@ pub enum DebugResponse {
     AddSwBreakpoint(bool),
     Continue,
     DisableDebug,
+    ErrorOccurred,
     GetCodeSectionOffset(u64),
     ReadAddr(Vec<u8>),
     ReadRegisters(X86_64Regs),

--- a/src/hyperlight_host/src/hypervisor/gdb/mod.rs
+++ b/src/hyperlight_host/src/hypervisor/gdb/mod.rs
@@ -208,3 +208,29 @@ pub fn create_gdb_thread(
 
     Ok(gdb_conn)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_gdb_debug_comm_channel() {
+        let (gdb_conn, hyp_conn) = DebugCommChannel::<DebugMsg, DebugResponse>::unbounded();
+
+        let msg = DebugMsg::ReadRegisters;
+        let res = gdb_conn.send(msg);
+        assert!(res.is_ok());
+
+        let res = hyp_conn.recv();
+        assert!(res.is_ok());
+
+        let res = gdb_conn.try_recv();
+        assert!(res.is_err());
+
+        let res = hyp_conn.send(DebugResponse::ReadRegisters(X86_64Regs::default()));
+        assert!(res.is_ok());
+
+        let res = gdb_conn.recv();
+        assert!(res.is_ok());
+    }
+}

--- a/src/hyperlight_host/src/hypervisor/gdb/x86_64_target.rs
+++ b/src/hyperlight_host/src/hypervisor/gdb/x86_64_target.rs
@@ -1,0 +1,124 @@
+/*
+Copyright 2024 The Hyperlight Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use crossbeam_channel::TryRecvError;
+use gdbstub::arch::Arch;
+use gdbstub::target::ext::base::singlethread::SingleThreadBase;
+use gdbstub::target::ext::base::BaseOps;
+use gdbstub::target::{Target, TargetResult};
+use gdbstub_arch::x86::X86_64_SSE as GdbTargetArch;
+
+use super::{DebugMsg, DebugResponse, DebugCommChannel, GdbTargetError};
+
+/// Gdbstub target used by the gdbstub crate to provide GDB protocol implementation
+pub struct HyperlightSandboxTarget {
+    /// Hypervisor communication channels
+    hyp_conn: DebugCommChannel<DebugMsg, DebugResponse>,
+}
+
+impl HyperlightSandboxTarget {
+    pub fn new(hyp_conn: DebugCommChannel<DebugMsg, DebugResponse>) -> Self {
+        HyperlightSandboxTarget { hyp_conn }
+    }
+
+    /// Sends a command over the communication channel and waits for response
+    fn send_command(&self, cmd: DebugMsg) -> Result<DebugResponse, GdbTargetError> {
+        self.send(cmd)?;
+
+        // Wait for response
+        self.recv()
+    }
+
+    /// Sends a command over the communication channel
+    fn send(&self, ev: DebugMsg) -> Result<(), GdbTargetError> {
+        self.hyp_conn.send(ev)
+    }
+
+    /// Waits for a response over the communication channel
+    pub fn recv(&self) -> Result<DebugResponse, GdbTargetError> {
+        self.hyp_conn.recv()
+    }
+
+    /// Non-Blocking check for a response over the communication channel
+    pub fn try_recv(&self) -> Result<DebugResponse, TryRecvError> {
+        self.hyp_conn.try_recv()
+    }
+
+    /// Sends an event to the Hypervisor that tells it to resume vCPU execution
+    /// Note: The method waits for a confirmation message
+    pub fn resume_vcpu(&mut self) -> Result<(), GdbTargetError> {
+        log::info!("Resume vCPU execution");
+
+        match self.send_command(DebugMsg::Continue)? {
+            DebugResponse::Continue => Ok(()),
+            msg => {
+                log::error!("Unexpected message received: {:?}", msg);
+                Err(GdbTargetError::UnexpectedMessage)
+            }
+        }
+    }
+
+}
+
+impl Target for HyperlightSandboxTarget {
+    type Arch = GdbTargetArch;
+    type Error = GdbTargetError;
+
+    #[inline(always)]
+    fn base_ops(&mut self) -> BaseOps<Self::Arch, Self::Error> {
+        BaseOps::SingleThread(self)
+    }
+}
+
+impl SingleThreadBase for HyperlightSandboxTarget {
+    fn read_addrs(
+        &mut self,
+        gva: <Self::Arch as Arch>::Usize,
+        data: &mut [u8],
+    ) -> TargetResult<usize, Self> {
+        log::debug!("Read addr: {:X} len: {:X}", gva, data.len());
+
+        unimplemented!()
+    }
+
+    fn write_addrs(
+        &mut self,
+        gva: <Self::Arch as Arch>::Usize,
+        data: &[u8],
+    ) -> TargetResult<(), Self> {
+        log::debug!("Write addr: {:X} len: {:X}", gva, data.len());
+
+        unimplemented!()
+    }
+
+    fn read_registers(
+        &mut self,
+        _regs: &mut <Self::Arch as Arch>::Registers,
+    ) -> TargetResult<(), Self> {
+        log::debug!("Read regs");
+
+        unimplemented!()
+    }
+
+    fn write_registers(
+        &mut self,
+        _regs: &<Self::Arch as Arch>::Registers,
+    ) -> TargetResult<(), Self> {
+        log::debug!("Write regs");
+
+        unimplemented!()
+    }
+}

--- a/src/hyperlight_host/src/hypervisor/gdb/x86_64_target.rs
+++ b/src/hyperlight_host/src/hypervisor/gdb/x86_64_target.rs
@@ -87,6 +87,10 @@ impl HyperlightSandboxTarget {
 
         match self.send_command(DebugMsg::DisableDebug)? {
             DebugResponse::DisableDebug => Ok(()),
+            DebugResponse::ErrorOccurred => {
+                log::error!("Error occurred");
+                Err(GdbTargetError::UnexpectedError)
+            }
             msg => {
                 log::error!("Unexpected message received: {:?}", msg);
                 Err(GdbTargetError::UnexpectedMessage)
@@ -129,6 +133,10 @@ impl SingleThreadBase for HyperlightSandboxTarget {
 
                 Ok(v.len())
             }
+            DebugResponse::ErrorOccurred => {
+                log::error!("Error occurred");
+                Err(TargetError::NonFatal)
+            }
             msg => {
                 log::error!("Unexpected message received: {:?}", msg);
                 Err(TargetError::Fatal(GdbTargetError::UnexpectedMessage))
@@ -146,6 +154,10 @@ impl SingleThreadBase for HyperlightSandboxTarget {
 
         match self.send_command(DebugMsg::WriteAddr(gva, v))? {
             DebugResponse::WriteAddr => Ok(()),
+            DebugResponse::ErrorOccurred => {
+                log::error!("Error occurred");
+                Err(TargetError::NonFatal)
+            }
             msg => {
                 log::error!("Unexpected message received: {:?}", msg);
                 Err(TargetError::Fatal(GdbTargetError::UnexpectedMessage))
@@ -181,6 +193,10 @@ impl SingleThreadBase for HyperlightSandboxTarget {
                 regs.eflags = read_regs.rflags as u32;
 
                 Ok(())
+            }
+            DebugResponse::ErrorOccurred => {
+                log::error!("Error occurred");
+                Err(TargetError::NonFatal)
             }
 
             msg => {
@@ -219,6 +235,10 @@ impl SingleThreadBase for HyperlightSandboxTarget {
 
         match self.send_command(DebugMsg::WriteRegisters(regs))? {
             DebugResponse::WriteRegisters => Ok(()),
+            DebugResponse::ErrorOccurred => {
+                log::error!("Error occurred");
+                Err(TargetError::NonFatal)
+            }
             msg => {
                 log::error!("Unexpected message received: {:?}", msg);
                 Err(TargetError::Fatal(GdbTargetError::UnexpectedMessage))
@@ -240,6 +260,10 @@ impl SectionOffsets for HyperlightSandboxTarget {
                 text_seg: text,
                 data_seg: None,
             }),
+            DebugResponse::ErrorOccurred => {
+                log::error!("Error occurred");
+                Err(GdbTargetError::UnexpectedError)
+            }
             msg => {
                 log::error!("Unexpected message received: {:?}", msg);
                 Err(GdbTargetError::UnexpectedMessage)
@@ -267,6 +291,10 @@ impl HwBreakpoint for HyperlightSandboxTarget {
 
         match self.send_command(DebugMsg::AddHwBreakpoint(addr))? {
             DebugResponse::AddHwBreakpoint(rsp) => Ok(rsp),
+            DebugResponse::ErrorOccurred => {
+                log::error!("Error occurred");
+                Err(TargetError::NonFatal)
+            }
             msg => {
                 log::error!("Unexpected message received: {:?}", msg);
                 Err(TargetError::Fatal(GdbTargetError::UnexpectedMessage))
@@ -283,6 +311,10 @@ impl HwBreakpoint for HyperlightSandboxTarget {
 
         match self.send_command(DebugMsg::RemoveHwBreakpoint(addr))? {
             DebugResponse::RemoveHwBreakpoint(rsp) => Ok(rsp),
+            DebugResponse::ErrorOccurred => {
+                log::error!("Error occurred");
+                Err(TargetError::NonFatal)
+            }
             msg => {
                 log::error!("Unexpected message received: {:?}", msg);
                 Err(TargetError::Fatal(GdbTargetError::UnexpectedMessage))
@@ -301,6 +333,10 @@ impl SwBreakpoint for HyperlightSandboxTarget {
 
         match self.send_command(DebugMsg::AddSwBreakpoint(addr))? {
             DebugResponse::AddSwBreakpoint(rsp) => Ok(rsp),
+            DebugResponse::ErrorOccurred => {
+                log::error!("Error occurred");
+                Err(TargetError::NonFatal)
+            }
             msg => {
                 log::error!("Unexpected message received: {:?}", msg);
                 Err(TargetError::Fatal(GdbTargetError::UnexpectedMessage))
@@ -317,6 +353,10 @@ impl SwBreakpoint for HyperlightSandboxTarget {
 
         match self.send_command(DebugMsg::RemoveSwBreakpoint(addr))? {
             DebugResponse::RemoveSwBreakpoint(rsp) => Ok(rsp),
+            DebugResponse::ErrorOccurred => {
+                log::error!("Error occurred");
+                Err(TargetError::NonFatal)
+            }
             msg => {
                 log::error!("Unexpected message received: {:?}", msg);
                 Err(TargetError::Fatal(GdbTargetError::UnexpectedMessage))
@@ -342,6 +382,10 @@ impl SingleThreadSingleStep for HyperlightSandboxTarget {
         log::debug!("Step");
         match self.send_command(DebugMsg::Step)? {
             DebugResponse::Step => Ok(()),
+            DebugResponse::ErrorOccurred => {
+                log::error!("Error occurred");
+                Err(GdbTargetError::UnexpectedError)
+            }
             msg => {
                 log::error!("Unexpected message received: {:?}", msg);
                 Err(GdbTargetError::UnexpectedMessage)

--- a/src/hyperlight_host/src/hypervisor/gdb/x86_64_target.rs
+++ b/src/hyperlight_host/src/hypervisor/gdb/x86_64_target.rs
@@ -90,10 +90,10 @@ impl HyperlightSandboxTarget {
     }
 
     /// Sends an event to the Hypervisor that tells it to disable debugging
-    /// and continue executing until end
+    /// and continue executing
     /// Note: The method waits for a confirmation message
     pub fn disable_debug(&mut self) -> Result<(), GdbTargetError> {
-        log::info!("Disable debugging and continue until end");
+        log::info!("Disable debugging and resume execution");
 
         match self.send_command(DebugMsg::DisableDebug)? {
             DebugResponse::DisableDebug => Ok(()),

--- a/src/hyperlight_host/src/hypervisor/handlers.rs
+++ b/src/hyperlight_host/src/hypervisor/handlers.rs
@@ -102,3 +102,25 @@ impl MemAccessHandlerCaller for MemAccessHandler {
         func()
     }
 }
+
+/// The trait representing custom logic to handle the case when
+/// a Hypervisor's virtual CPU (vCPU) informs Hyperlight a debug memory access
+/// has been requested.
+#[cfg(gdb)]
+pub trait DbgMemAccessHandlerCaller: Send {
+    /// Function that gets called when a read is requested.
+    fn read(&mut self, addr: usize, data: &mut [u8]) -> Result<()>;
+
+    /// Function that gets called when a write is requested.
+    fn write(&mut self, addr: usize, data: &[u8]) -> Result<()>;
+
+    /// Function that gets called for a request to get guest code offset.
+    fn get_code_offset(&mut self) -> Result<usize>;
+}
+
+/// A convenient type representing an implementer of `DbgMemAccessHandlerCaller`
+///
+/// Note: This needs to be wrapped in a Mutex to be able to grab a mutable
+/// reference to the underlying data
+#[cfg(gdb)]
+pub type DbgMemAccessHandlerWrapper = Arc<Mutex<dyn DbgMemAccessHandlerCaller>>;

--- a/src/hyperlight_host/src/hypervisor/hyperv_linux.rs
+++ b/src/hyperlight_host/src/hypervisor/hyperv_linux.rs
@@ -44,6 +44,8 @@ use mshv_ioctls::{Mshv, VcpuFd, VmFd};
 use tracing::{instrument, Span};
 
 use super::fpu::{FP_CONTROL_WORD_DEFAULT, FP_TAG_WORD_DEFAULT, MXCSR_DEFAULT};
+#[cfg(gdb)]
+use super::handlers::DbgMemAccessHandlerWrapper;
 use super::handlers::{MemAccessHandlerWrapper, OutBHandlerWrapper};
 use super::{
     Hypervisor, VirtualCPU, CR0_AM, CR0_ET, CR0_MP, CR0_NE, CR0_PE, CR0_PG, CR0_WP, CR4_OSFXSR,
@@ -203,6 +205,7 @@ impl Hypervisor for HypervLinuxDriver {
         outb_hdl: OutBHandlerWrapper,
         mem_access_hdl: MemAccessHandlerWrapper,
         hv_handler: Option<HypervisorHandler>,
+        #[cfg(gdb)] dbg_mem_access_fn: DbgMemAccessHandlerWrapper,
     ) -> Result<()> {
         let regs = StandardRegisters {
             rip: self.entrypoint,
@@ -224,6 +227,8 @@ impl Hypervisor for HypervLinuxDriver {
             hv_handler,
             outb_hdl,
             mem_access_hdl,
+            #[cfg(gdb)]
+            dbg_mem_access_fn,
         )?;
 
         // reset RSP to what it was before initialise
@@ -242,6 +247,7 @@ impl Hypervisor for HypervLinuxDriver {
         outb_handle_fn: OutBHandlerWrapper,
         mem_access_fn: MemAccessHandlerWrapper,
         hv_handler: Option<HypervisorHandler>,
+        #[cfg(gdb)] dbg_mem_access_fn: DbgMemAccessHandlerWrapper,
     ) -> Result<()> {
         // Reset general purpose registers except RSP, then set RIP
         let rsp_before = self.vcpu_fd.get_regs()?.rsp;
@@ -268,6 +274,8 @@ impl Hypervisor for HypervLinuxDriver {
             hv_handler,
             outb_handle_fn,
             mem_access_fn,
+            #[cfg(gdb)]
+            dbg_mem_access_fn,
         )?;
 
         // reset RSP to what it was before function call

--- a/src/hyperlight_host/src/hypervisor/hyperv_windows.rs
+++ b/src/hyperlight_host/src/hypervisor/hyperv_windows.rs
@@ -28,6 +28,8 @@ use windows::Win32::System::Hypervisor::{
 };
 
 use super::fpu::{FP_TAG_WORD_DEFAULT, MXCSR_DEFAULT};
+#[cfg(gdb)]
+use super::handlers::DbgMemAccessHandlerWrapper;
 use super::handlers::{MemAccessHandlerWrapper, OutBHandlerWrapper};
 use super::surrogate_process::SurrogateProcess;
 use super::surrogate_process_manager::*;
@@ -305,6 +307,7 @@ impl Hypervisor for HypervWindowsDriver {
         outb_hdl: OutBHandlerWrapper,
         mem_access_hdl: MemAccessHandlerWrapper,
         hv_handler: Option<HypervisorHandler>,
+        #[cfg(gdb)] dbg_mem_access_hdl: DbgMemAccessHandlerWrapper,
     ) -> Result<()> {
         let regs = WHvGeneralRegisters {
             rip: self.entrypoint,
@@ -326,6 +329,8 @@ impl Hypervisor for HypervWindowsDriver {
             hv_handler,
             outb_hdl,
             mem_access_hdl,
+            #[cfg(gdb)]
+            dbg_mem_access_hdl,
         )?;
 
         // reset RSP to what it was before initialise
@@ -344,6 +349,7 @@ impl Hypervisor for HypervWindowsDriver {
         outb_hdl: OutBHandlerWrapper,
         mem_access_hdl: MemAccessHandlerWrapper,
         hv_handler: Option<HypervisorHandler>,
+        #[cfg(gdb)] dbg_mem_access_hdl: DbgMemAccessHandlerWrapper,
     ) -> Result<()> {
         // Reset general purpose registers except RSP, then set RIP
         let rsp_before = self.processor.get_regs()?.rsp;
@@ -368,6 +374,8 @@ impl Hypervisor for HypervWindowsDriver {
             hv_handler,
             outb_hdl,
             mem_access_hdl,
+            #[cfg(gdb)]
+            dbg_mem_access_hdl,
         )?;
 
         // reset RSP to what it was before function call

--- a/src/hyperlight_host/src/hypervisor/hypervisor_handler.rs
+++ b/src/hyperlight_host/src/hypervisor/hypervisor_handler.rs
@@ -37,6 +37,8 @@ use windows::Win32::System::Hypervisor::{WHvCancelRunVirtualProcessor, WHV_PARTI
 
 #[cfg(feature = "function_call_metrics")]
 use crate::histogram_vec_observe;
+#[cfg(gdb)]
+use crate::hypervisor::handlers::DbgMemAccessHandlerWrapper;
 use crate::hypervisor::handlers::{MemAccessHandlerWrapper, OutBHandlerWrapper};
 #[cfg(target_os = "windows")]
 use crate::hypervisor::wrappers::HandleWrapper;
@@ -187,6 +189,8 @@ pub(crate) struct HvHandlerConfig {
     pub(crate) outb_handler: OutBHandlerWrapper,
     pub(crate) mem_access_handler: MemAccessHandlerWrapper,
     pub(crate) max_wait_for_cancellation: Duration,
+    #[cfg(gdb)]
+    pub(crate) dbg_mem_access_handler: DbgMemAccessHandlerWrapper,
 }
 
 impl HypervisorHandler {
@@ -351,6 +355,8 @@ impl HypervisorHandler {
                                     configuration.outb_handler.clone(),
                                     configuration.mem_access_handler.clone(),
                                     Some(hv_handler_clone.clone()),
+                                    #[cfg(gdb)]
+                                    configuration.dbg_mem_access_handler.clone(),
                                 );
                                 drop(mem_lock_guard);
                                 drop(evar_lock_guard);
@@ -436,6 +442,8 @@ impl HypervisorHandler {
                                             configuration.outb_handler.clone(),
                                             configuration.mem_access_handler.clone(),
                                             Some(hv_handler_clone.clone()),
+                                            #[cfg(gdb)]
+                                            configuration.dbg_mem_access_handler.clone(),
                                         );
                                         histogram_vec_observe!(
                                             &GuestFunctionCallDurationMicroseconds,
@@ -451,6 +459,8 @@ impl HypervisorHandler {
                                         configuration.outb_handler.clone(),
                                         configuration.mem_access_handler.clone(),
                                         Some(hv_handler_clone.clone()),
+                                        #[cfg(gdb)]
+                                        configuration.dbg_mem_access_handler.clone(),
                                     )
                                 };
                                 drop(mem_lock_guard);

--- a/src/hyperlight_host/src/hypervisor/hypervisor_handler.rs
+++ b/src/hyperlight_host/src/hypervisor/hypervisor_handler.rs
@@ -836,7 +836,7 @@ fn set_up_hypervisor_partition(
     mgr: &mut SandboxMemoryManager<GuestSharedMemory>,
     #[allow(unused_variables)] // parameter only used for in-process mode
     outb_handler: OutBHandlerWrapper,
-    #[cfg(gdb)] _debug_info: &Option<DebugInfo>,
+    #[cfg(gdb)] debug_info: &Option<DebugInfo>,
 ) -> Result<Box<dyn Hypervisor>> {
     let mem_size = u64::try_from(mgr.shared_mem.mem_size())?;
     let mut regions = mgr.layout.get_memory_regions(&mgr.shared_mem)?;
@@ -915,6 +915,8 @@ fn set_up_hypervisor_partition(
                     pml4_ptr.absolute()?,
                     entrypoint_ptr.absolute()?,
                     rsp_ptr.absolute()?,
+                    #[cfg(gdb)]
+                    debug_info,
                 )?;
                 Ok(Box::new(hv))
             }

--- a/src/hyperlight_host/src/hypervisor/inprocess.rs
+++ b/src/hyperlight_host/src/hypervisor/inprocess.rs
@@ -17,6 +17,8 @@ limitations under the License.
 use std::fmt::Debug;
 use std::os::raw::c_void;
 
+#[cfg(gdb)]
+use super::handlers::DbgMemAccessHandlerWrapper;
 use super::{HyperlightExit, Hypervisor};
 #[cfg(crashdump)]
 use crate::mem::memory_region::MemoryRegion;
@@ -73,6 +75,7 @@ impl<'a> Hypervisor for InprocessDriver<'a> {
         _outb_handle_fn: super::handlers::OutBHandlerWrapper,
         _mem_access_fn: super::handlers::MemAccessHandlerWrapper,
         _hv_handler: Option<super::hypervisor_handler::HypervisorHandler>,
+        #[cfg(gdb)] _dbg_mem_access_fn: DbgMemAccessHandlerWrapper,
     ) -> crate::Result<()> {
         let entrypoint_fn: extern "win64" fn(u64, u64, u64, u64) =
             unsafe { std::mem::transmute(self.args.entrypoint_raw as *const c_void) };
@@ -93,6 +96,7 @@ impl<'a> Hypervisor for InprocessDriver<'a> {
         _outb_handle_fn: super::handlers::OutBHandlerWrapper,
         _mem_access_fn: super::handlers::MemAccessHandlerWrapper,
         _hv_handler: Option<super::hypervisor_handler::HypervisorHandler>,
+        #[cfg(gdb)] _dbg_mem_access_fn: DbgMemAccessHandlerWrapper,
     ) -> crate::Result<()> {
         let ptr: u64 = dispatch_func_addr.into();
         let dispatch_func: extern "win64" fn() =

--- a/src/hyperlight_host/src/hypervisor/mod.rs
+++ b/src/hyperlight_host/src/hypervisor/mod.rs
@@ -34,6 +34,10 @@ pub mod hyperv_linux;
 pub(crate) mod hyperv_windows;
 pub(crate) mod hypervisor_handler;
 
+/// GDB debugging support
+#[cfg(gdb)]
+mod gdb;
+
 /// Driver for running in process instead of using hypervisor
 #[cfg(inprocess)]
 pub mod inprocess;

--- a/src/hyperlight_host/src/hypervisor/mod.rs
+++ b/src/hyperlight_host/src/hypervisor/mod.rs
@@ -336,7 +336,11 @@ pub(crate) mod tests {
         // whether we can configure the shared memory region, load a binary
         // into it, and run the CPU to completion (e.g., a HLT interrupt)
 
-        hv_handler.start_hypervisor_handler(gshm)?;
+        hv_handler.start_hypervisor_handler(
+            gshm,
+            #[cfg(gdb)]
+            None,
+        )?;
 
         hv_handler.execute_hypervisor_handler_action(HypervisorHandlerAction::Initialise)
     }

--- a/src/hyperlight_host/src/hypervisor/mod.rs
+++ b/src/hyperlight_host/src/hypervisor/mod.rs
@@ -232,7 +232,9 @@ impl VirtualCPU {
             match hv.run() {
                 #[cfg(gdb)]
                 Ok(HyperlightExit::Debug(stop_reason)) => {
-                    hv.handle_debug(dbg_mem_access_fn.clone(), stop_reason)?;
+                    if let Err(e) = hv.handle_debug(dbg_mem_access_fn.clone(), stop_reason) {
+                        log_then_return!(e);
+                    }
                 }
 
                 Ok(HyperlightExit::Halt()) => {

--- a/src/hyperlight_host/src/mem/layout.rs
+++ b/src/hyperlight_host/src/mem/layout.rs
@@ -656,7 +656,7 @@ impl SandboxMemoryLayout {
 
     /// Get the guest address of the code section in the sandbox
     #[instrument(skip_all, parent = Span::current(), level= "Trace")]
-    pub(super) fn get_guest_code_address(&self) -> usize {
+    pub(crate) fn get_guest_code_address(&self) -> usize {
         Self::BASE_ADDRESS + self.guest_code_offset
     }
 

--- a/src/hyperlight_host/src/mem/shared_mem.rs
+++ b/src/hyperlight_host/src/mem/shared_mem.rs
@@ -840,7 +840,7 @@ impl HostSharedMemory {
         Ok(())
     }
 
-    /// /Copy the contents of the sandbox at the specified offset into
+    /// Copy the contents of the sandbox at the specified offset into
     /// the slice
     pub fn copy_from_slice(&self, slice: &[u8], offset: usize) -> Result<()> {
         bounds_check!(offset, slice.len(), self.mem_size());

--- a/src/hyperlight_host/src/sandbox/uninitialized.rs
+++ b/src/hyperlight_host/src/sandbox/uninitialized.rs
@@ -165,6 +165,7 @@ impl UninitializedSandbox {
         }
 
         let sandbox_cfg = cfg.unwrap_or_default();
+
         #[cfg(gdb)]
         let debug_info = sandbox_cfg.get_guest_debug_info();
         let mut mem_mgr_wrapper = {

--- a/src/hyperlight_host/src/sandbox/uninitialized.rs
+++ b/src/hyperlight_host/src/sandbox/uninitialized.rs
@@ -22,6 +22,8 @@ use std::time::Duration;
 
 use tracing::{instrument, Span};
 
+#[cfg(gdb)]
+use super::config::DebugInfo;
 use super::host_funcs::{default_writer_func, HostFuncsWrapper};
 use super::mem_mgr::MemMgrWrapper;
 use super::run_options::SandboxRunOptions;
@@ -52,6 +54,8 @@ pub struct UninitializedSandbox {
     pub(crate) max_initialization_time: Duration,
     pub(crate) max_execution_time: Duration,
     pub(crate) max_wait_for_cancellation: Duration,
+    #[cfg(gdb)]
+    pub(crate) debug_info: Option<DebugInfo>,
 }
 
 impl crate::sandbox_state::sandbox::UninitializedSandbox for UninitializedSandbox {
@@ -161,6 +165,8 @@ impl UninitializedSandbox {
         }
 
         let sandbox_cfg = cfg.unwrap_or_default();
+        #[cfg(gdb)]
+        let debug_info = sandbox_cfg.get_guest_debug_info();
         let mut mem_mgr_wrapper = {
             let mut mgr = UninitializedSandbox::load_guest_binary(
                 sandbox_cfg,
@@ -188,6 +194,8 @@ impl UninitializedSandbox {
             max_wait_for_cancellation: Duration::from_millis(
                 sandbox_cfg.get_max_wait_for_cancellation() as u64,
             ),
+            #[cfg(gdb)]
+            debug_info,
         };
 
         // TODO: These only here to accommodate some writer functions.

--- a/src/hyperlight_host/src/sandbox/uninitialized_evolve.rs
+++ b/src/hyperlight_host/src/sandbox/uninitialized_evolve.rs
@@ -26,6 +26,8 @@ use crate::hypervisor::hypervisor_handler::{
 use crate::mem::mgr::SandboxMemoryManager;
 use crate::mem::ptr::RawPtr;
 use crate::mem::shared_mem::GuestSharedMemory;
+#[cfg(gdb)]
+use crate::sandbox::config::DebugInfo;
 use crate::sandbox::host_funcs::HostFuncsWrapper;
 use crate::sandbox::mem_access::mem_access_handler_wrapper;
 use crate::sandbox::outb::outb_handler_wrapper;
@@ -66,6 +68,8 @@ where
             u_sbox.max_initialization_time,
             u_sbox.max_execution_time,
             u_sbox.max_wait_for_cancellation,
+            #[cfg(gdb)]
+            u_sbox.debug_info,
         )?;
 
         {
@@ -98,6 +102,7 @@ fn hv_init(
     max_init_time: Duration,
     max_exec_time: Duration,
     max_wait_for_cancellation: Duration,
+    #[cfg(gdb)] debug_info: Option<DebugInfo>,
 ) -> Result<HypervisorHandler> {
     let outb_hdl = outb_handler_wrapper(hshm.clone(), host_funcs);
     let mem_access_hdl = mem_access_handler_wrapper(hshm.clone());
@@ -126,7 +131,11 @@ fn hv_init(
 
     let mut hv_handler = HypervisorHandler::new(hv_handler_config);
 
-    hv_handler.start_hypervisor_handler(gshm)?;
+    hv_handler.start_hypervisor_handler(
+        gshm,
+        #[cfg(gdb)]
+        debug_info,
+    )?;
 
     hv_handler
         .execute_hypervisor_handler_action(HypervisorHandlerAction::Initialise)

--- a/src/hyperlight_host/src/sandbox/uninitialized_evolve.rs
+++ b/src/hyperlight_host/src/sandbox/uninitialized_evolve.rs
@@ -20,6 +20,8 @@ use std::sync::{Arc, Mutex};
 use rand::Rng;
 use tracing::{instrument, Span};
 
+#[cfg(gdb)]
+use super::mem_access::dbg_mem_access_handler_wrapper;
 use crate::hypervisor::hypervisor_handler::{
     HvHandlerConfig, HypervisorHandler, HypervisorHandlerAction,
 };
@@ -106,6 +108,9 @@ fn hv_init(
 ) -> Result<HypervisorHandler> {
     let outb_hdl = outb_handler_wrapper(hshm.clone(), host_funcs);
     let mem_access_hdl = mem_access_handler_wrapper(hshm.clone());
+    #[cfg(gdb)]
+    let dbg_mem_access_hdl = dbg_mem_access_handler_wrapper(hshm.clone());
+
     let seed = {
         let mut rng = rand::rng();
         rng.random::<u64>()
@@ -118,6 +123,8 @@ fn hv_init(
     let hv_handler_config = HvHandlerConfig {
         outb_handler: outb_hdl,
         mem_access_handler: mem_access_hdl,
+        #[cfg(gdb)]
+        dbg_mem_access_handler: dbg_mem_access_hdl,
         seed,
         page_size,
         peb_addr,


### PR DESCRIPTION
The current implementation supports:
- add/remove HW breakpoints (max 4)
- add/remove SW breakpoints
- read/write registers
- read/write addresses
- step/continue
- get code offset from target

The overall architecture is designed to work like a `Request - Response` protocol from the gdb thread to the hypervisor handler over a `DebugCommChannel`.
- All the functionality is implemented on the hypervisor side so it has access to the shared memory and VcpuFd
- The gdb thread uses `gdbstub` to handle the communication with the gdb client
- when the gdb client requests the supported features mentioned above, a request is sent forward to the hypervisor handler for the running sandbox to run