### PR TITLE
Fix typos discovered by codespell

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -351,9 +351,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.9"
+version = "1.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8293772165d9345bdaaa39b45b2109591e63fe5e6fbc23c6ff930a048aa310b"
+checksum = "13208fcbb66eaeffe09b99fffbe1af420f00a7b35aa99ad683dfc1aa76145229"
 dependencies = [
  "jobserver",
  "libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -866,9 +866,9 @@ dependencies = [
 
 [[package]]
 name = "goblin"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53ab3f32d1d77146981dea5d6b1e8fe31eedcb7013e5e00d6ccd1259a4b4d923"
+checksum = "daa0a64d21a7eb230583b4c5f4e23b7e4e57974f96620f42a7e75e08ae66d745"
 dependencies = [
  "log",
  "plain",

--- a/Justfile
+++ b/Justfile
@@ -74,7 +74,7 @@ clean-rust:
 
 # TESTING
 # Some tests cannot run with other tests, they are marked as ignored so that cargo test works
-# there may be tests that we really want to ignore so we cant just use --ignored and we have to
+# there may be tests that we really want to ignore so we can't just use --ignored and we have to
 # Specify the test name of the ignored tests that we want to run
 test-rust target=default-target features="": (test-rust-int "rust" target features) (test-rust-int "c" target features) (test-seccomp target)
     # unit tests

--- a/proposals/NNNN-hip-template/README.md
+++ b/proposals/NNNN-hip-template/README.md
@@ -27,7 +27,7 @@
 This section is incredibly important for producing high-quality, user-focused
 documentation such as release notes or a development roadmap. It should be
 possible to collect this information before implementation begins, in order to
-avoid requiring implementors to split their attention between writing release
+avoid requiring implementers to split their attention between writing release
 notes and implementing the feature itself. HIP editors should help to ensure 
 that the tone and content of the `Summary` section is useful for a wide audience.
 

--- a/src/hyperlight_host/src/error.rs
+++ b/src/hyperlight_host/src/error.rs
@@ -55,7 +55,7 @@ pub enum HyperlightError {
     BoundsCheckFailed(u64, usize),
 
     /// Checked Add Overflow
-    #[error("Couldnt add offset to base address. Offset: {0}, Base Address: {1}")]
+    #[error("Couldn't add offset to base address. Offset: {0}, Base Address: {1}")]
     CheckedAddOverflow(u64, u64),
 
     /// Cross beam channel receive error

--- a/src/hyperlight_host/src/func/guest_dispatch.rs
+++ b/src/hyperlight_host/src/func/guest_dispatch.rs
@@ -384,7 +384,7 @@ mod tests {
 
     fn terminate_vcpu_after_1000ms() -> Result<()> {
         // This test relies upon a Hypervisor being present so for now
-        // we will skip it if there isnt one.
+        // we will skip it if there isn't one.
         if !is_hypervisor_present() {
             println!("Skipping terminate_vcpu_after_1000ms because no hypervisor is present");
             return Ok(());
@@ -433,7 +433,7 @@ mod tests {
     #[test]
     fn test_terminate_vcpu_calling_host_spinning_cpu() {
         // This test relies upon a Hypervisor being present so for now
-        // we will skip it if there isnt one.
+        // we will skip it if there isn't one.
         if !is_hypervisor_present() {
             println!("Skipping test_call_guest_function_by_name because no hypervisor is present");
             return;

--- a/src/hyperlight_host/src/hypervisor/windows_hypervisor_platform.rs
+++ b/src/hyperlight_host/src/hypervisor/windows_hypervisor_platform.rs
@@ -99,7 +99,7 @@ impl VMPartition {
         let whvmapgparange2_func = unsafe {
             match try_load_whv_map_gpa_range2() {
                 Ok(func) => func,
-                Err(e) => return Err(new_error!("Cant find API: {}", e)),
+                Err(e) => return Err(new_error!("Can't find API: {}", e)),
             }
         };
 

--- a/src/hyperlight_host/src/mem/pe/pe_info.rs
+++ b/src/hyperlight_host/src/mem/pe/pe_info.rs
@@ -360,7 +360,7 @@ mod tests {
                 load_address: 5368709120,
                 num_relocations: (900..1200).collect(),
                 // range of possible # of relocations
-                // (hardware dependant)
+                // (hardware dependent)
             }
         } else {
             PEFileTest {

--- a/src/hyperlight_host/src/sandbox/run_options.rs
+++ b/src/hyperlight_host/src/sandbox/run_options.rs
@@ -17,7 +17,7 @@ limitations under the License.
 use tracing::{instrument, Span};
 
 /// Configuration options for setting up a new `UninitializedSandbox` and
-/// subsequent inititialized sandboxes, including `MultiUseSandbox`.
+/// subsequent initialized sandboxes, including `MultiUseSandbox`.
 ///
 /// A `SandboxRunOptions` instance must be created with either in-process
 /// or in-hypervisor execution mode, and then can optionally be augmented


### PR DESCRIPTION
% `codespell --ignore-words-list=crate,fo,habitant,wit --skip="./NOTICE.txt,./src/hyperlight_guest/third_party/*" --write-changes`
https://github.com/codespell-project/codespell