### PR TITLE
update to latest versions of windows crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3156,12 +3156,12 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
-version = "0.58.0"
+version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
+checksum = "7f919aee0a93304be7f62e8e5027811bbba96bcb1de84d6618be56e43f8a32a1"
 dependencies = [
- "windows-core 0.58.0",
- "windows-targets 0.52.6",
+ "windows-core 0.59.0",
+ "windows-targets 0.53.0",
 ]
 
 [[package]]
@@ -3175,22 +3175,22 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
-version = "0.58.0"
+version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
+checksum = "810ce18ed2112484b0d4e15d022e5f598113e220c53e373fb31e67e21670c1ce"
 dependencies = [
  "windows-implement",
  "windows-interface",
  "windows-result",
  "windows-strings",
- "windows-targets 0.52.6",
+ "windows-targets 0.53.0",
 ]
 
 [[package]]
 name = "windows-implement"
-version = "0.58.0"
+version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
+checksum = "83577b051e2f49a058c308f17f273b570a6a758386fc291b5f6a934dd84e48c1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3199,9 +3199,9 @@ dependencies = [
 
 [[package]]
 name = "windows-interface"
-version = "0.58.0"
+version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
+checksum = "cb26fd936d991781ea39e87c3a27285081e3c0da5ca0fcbc02d368cc6f52ff01"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3210,21 +3210,20 @@ dependencies = [
 
 [[package]]
 name = "windows-result"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+checksum = "d08106ce80268c4067c0571ca55a9b4e9516518eaa1a1fe9b37ca403ae1d1a34"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-targets 0.53.0",
 ]
 
 [[package]]
 name = "windows-strings"
-version = "0.1.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+checksum = "b888f919960b42ea4e11c2f408fadb55f78a9f236d5eef084103c8ce52893491"
 dependencies = [
- "windows-result",
- "windows-targets 0.52.6",
+ "windows-targets 0.53.0",
 ]
 
 [[package]]

--- a/src/hyperlight_host/Cargo.toml
+++ b/src/hyperlight_host/Cargo.toml
@@ -50,7 +50,7 @@ serde_yaml = "0.9"
 anyhow = "1.0"
 
 [target.'cfg(windows)'.dependencies]
-windows = { version = "0.58", features = [
+windows = { version = "0.59", features = [
     "Win32_Foundation",
     "Win32_System_LibraryLoader",
     "Win32_System_Threading",
@@ -64,7 +64,7 @@ windows = { version = "0.58", features = [
     "Win32_System_JobObjects",
 ] }
 windows-sys = { version = "0.59", features = ["Win32"] }
-windows-result = "0.2"
+windows-result = "0.3"
 rust-embed = { version = "8.3.0", features = ["debug-embed", "include-exclude", "interpolate-folder-path"] }
 sha256 = "1.4.0"
 windows-version = "0.1"
@@ -101,7 +101,7 @@ criterion = "0.5.1"
 tracing-chrome = "0.7.2"
 
 [target.'cfg(windows)'.dev-dependencies]
-windows = { version = "0.58", features = [
+windows = { version = "0.59", features = [
     "Win32_System_Diagnostics_ToolHelp",
 ] }
 

--- a/src/hyperlight_host/src/hypervisor/surrogate_process_manager.rs
+++ b/src/hyperlight_host/src/hypervisor/surrogate_process_manager.rs
@@ -361,7 +361,7 @@ fn create_surrogate_process(
     if let Err(e) = unsafe {
         CreateProcessA(
             PCSTR::null(),
-            p_cmd_line.into(),
+            Some(p_cmd_line.into()),
             Some(&process_attributes),
             Some(&thread_attributes),
             false,
@@ -442,7 +442,9 @@ mod tests {
                     let process_handle: HANDLE = surrogate_process.process_handle.into();
                     let job_handle: HANDLE = job_handle.into();
                     unsafe {
-                        assert!(IsProcessInJob(process_handle, job_handle, &mut result).is_ok());
+                        assert!(
+                            IsProcessInJob(process_handle, Some(job_handle), &mut result).is_ok()
+                        );
                         assert!(result.as_bool());
                     }
 

--- a/src/hyperlight_host/src/sandbox/uninitialized.rs
+++ b/src/hyperlight_host/src/sandbox/uninitialized.rs
@@ -1114,6 +1114,12 @@ mod tests {
             None,
             None,
         );
+        println!("{:?}", sbox);
+        #[cfg(target_os = "windows")]
+        assert!(
+            matches!(sbox, Err(e) if e.to_string().contains("GuestBinary not found: 'some/path/that/does/not/exist': The system cannot find the path specified. (os error 3)"))
+        );
+        #[cfg(target_os = "linux")]
         assert!(
             matches!(sbox, Err(e) if e.to_string().contains("GuestBinary not found: 'some/path/that/does/not/exist': No such file or directory (os error 2)"))
         );


### PR DESCRIPTION
#144 Bump Windows from 0.58 to 0.59
#133 Bump windows-result from 0.2 to 0.3

There are a couple of API signature changes in the windows crate which are addressed in this PR.