### PR TITLE
reduce number of threads in simple_test_parallel test function

### DIFF
--- a/src/hyperlight_host/tests/sandbox_host_tests.rs
+++ b/src/hyperlight_host/tests/sandbox_host_tests.rs
@@ -499,7 +499,7 @@ fn simple_test() {
 #[test]
 #[cfg(target_os = "linux")]
 fn simple_test_parallel() {
-    let handles: Vec<_> = (0..100)
+    let handles: Vec<_> = (0..50)
         .map(|_| {
             std::thread::spawn(|| {
                 simple_test_helper().unwrap();


### PR DESCRIPTION
The latest KVM runner image causes the test `simple_test-parallel` to fail. The failure is due to execution time of a function call taking longer than the default maximum execution time. 

This test currently creates 100 threads to test parallel execution, and, since 100 is an arbitrary number and the test is not a scalability test this PR resolves that issue by reducing the number of threads to 50.

Note that this issue does not appear to be related to #47 (or at least applying suggested mitigations for that issue does not fix this one).

#152 opened to capture the fact that we need some scalability benchmarks