### PR TITLE
Add a check for dependabot PR updating guest or common lib dependencies

### DIFF
--- a/.github/workflows/ValidatePullRequest.yml
+++ b/.github/workflows/ValidatePullRequest.yml
@@ -40,6 +40,21 @@ jobs:
             let all_file_count = ${{steps.changes.outputs.all_count}};
             return all_file_count === docs_file_count;
           result-encoding: string
+      # Check to see if this a dependabot PR and if it updates either the common or guest Cargo.toml files
+      # if it does we need to try and generate a new Cargo.lock file as the PR validation checks that these are up to date
+      - name: Update Cargo.lock for dependabot changes
+        if: ${{ github.actor == 'dependabot[bot]' && (github.event.pull_request.changed_files.* == 'src/hyperlight_common/Cargo.toml' || github.event.pull_request.changed_files.* == 'src/hyperlight_guest/Cargo.toml') }}
+        run: |
+          cargo update --manifest-path src/tests/rust_guests/simpleguest/Cargo.toml
+          cargo update --manifest-path src/tests/rust_guests/callbackguest/Cargo.toml
+          if [ -n "$(git status --porcelain src/tests/rust_guests/simpleguest/Cargo.lock src/tests/rust_guests/callbackguest/Cargo.lock)" ]; then
+            git config --global user.name "github-actions[bot]"
+            git config --global user.email "github-actions[bot]@users.noreply.github.com"
+            git add src/tests/rust_guests/simpleguest/Cargo.lock
+            git add src/tests/rust_guests/callbackguest/Cargo.lock
+            git commit -m "Update Cargo.lock files for dependabot changes"
+            git push
+          fi
 
   rust:
     needs:


### PR DESCRIPTION
We have a check in the PR workflow to ensure that Cargo.lock files are up to date as a part of any PR. This works fine for most scenarios but when dependabot updates depdendencies in either `hyperlight_common` or `hyperlight_guest` this may make the Cargo.lock file out of date for the `simpleguest` and `callbackguest` test guest binaries. 

See #148 for an example of this.

This PR updates the PR workflow to update those files if there are dependabot changes to the dependencies in either of those crates.