### PR TITLE
Update dependabot to check on test guest directories

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,6 @@ updates:
     schedule:
       interval: "daily"
   - package-ecosystem: "cargo"
-    directory: "/"
+    directories: ["/", "src/tests/rust_guests/simpleguest","src/tests/rust_guests/callbackguest"]
     schedule:
       interval: "daily"


### PR DESCRIPTION
Updates dependabot in order to try and have it update `Cargo.lock` in test binaries when dependencies in `hyperlight_common` or `hyperlight_guest` have changed. 

These dependabot PRs currenlty fail  because we have a check in the PR workflow to ensure that `Cargo.lock` files are up to date as a part of any PR which works fine for most scenarios but when dependabot updates depdendencies in either `hyperlight_common` or `hyperlight_guest` this may make the `Cargo.lock` file out of date for the `simpleguest` and `callbackguest` test guest binaries.

See #148 , #162 and #161 for examples of this sort of PR

This PR was opened in response to PR feedback on #154, if this doens not work then we will re-openthat PR instead.