### PR TITLE
Updates to otel 0.27.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1654,7 +1654,7 @@ checksum = "89abe853221fa6f14ad4066affb9abda241a03d65622887d5794e1422d0bd75a"
 dependencies = [
  "libc",
  "mshv-bindings 0.3.2",
- "thiserror 2.0.10",
+ "thiserror 2.0.11",
  "vmm-sys-util",
 ]
 
@@ -1730,16 +1730,16 @@ checksum = "b410bbe7e14ab526a0e86877eb47c6996a2bd7746f027ba551028c925390e4e9"
 
 [[package]]
 name = "opentelemetry"
-version = "0.27.0"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f3cebff57f7dbd1255b44d8bddc2cebeb0ea677dbaa2e25a3070a91b318f660"
+checksum = "ab70038c28ed37b97d8ed414b6429d343a8bbf44c9f79ec854f3a643029ba6d7"
 dependencies = [
  "futures-core",
  "futures-sink",
  "js-sys",
- "once_cell",
  "pin-project-lite",
  "thiserror 1.0.69",
+ "tracing",
 ]
 
 [[package]]
@@ -1781,16 +1781,15 @@ checksum = "bc1b6902ff63b32ef6c489e8048c5e253e2e4a803ea3ea7e783914536eb15c52"
 
 [[package]]
 name = "opentelemetry_sdk"
-version = "0.27.0"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27b742c1cae4693792cc564e58d75a2a0ba29421a34a85b50da92efa89ecb2bc"
+checksum = "231e9d6ceef9b0b2546ddf52335785ce41252bc7474ee8ba05bfad277be13ab8"
 dependencies = [
  "async-trait",
  "futures-channel",
  "futures-executor",
  "futures-util",
  "glob",
- "once_cell",
  "opentelemetry",
  "percent-encoding",
  "rand",

--- a/src/hyperlight_host/Cargo.toml
+++ b/src/hyperlight_host/Cargo.toml
@@ -94,10 +94,10 @@ tracing-forest = { version = "0.1.6", features = ["uuid", "chrono", "smallvec", 
 tracing = "0.1.41"
 tracing-subscriber = {version = "0.3.19", features = ["std", "env-filter"]}
 tracing-opentelemetry = "0.28.0"
-opentelemetry = "0.27.0"
+opentelemetry = "0.27.1"
 opentelemetry-otlp = { version = "0.27.0", features = ["default"] }
 opentelemetry-semantic-conventions = "0.27.0"
-opentelemetry_sdk = { version = "0.27.0", features = ["rt-tokio"] }
+opentelemetry_sdk = { version = "0.27.1", features = ["rt-tokio"] }
 tokio = { version = "1.43.0", features = ["full"] }
 criterion = "0.5.1"
 tracing-chrome = "0.7.2"

--- a/src/hyperlight_host/examples/otlp_tracing/main.rs
+++ b/src/hyperlight_host/examples/otlp_tracing/main.rs
@@ -38,7 +38,6 @@ use opentelemetry_otlp::{SpanExporter, WithExportConfig};
 use opentelemetry_sdk::runtime::Tokio;
 use opentelemetry_sdk::{trace, Resource};
 use opentelemetry_semantic_conventions::attribute::{SERVICE_NAME, SERVICE_VERSION};
-use opentelemetry_semantic_conventions::SCHEMA_URL;
 use tracing_subscriber::EnvFilter;
 use uuid::Uuid;
 
@@ -64,15 +63,10 @@ fn init_tracing_subscriber(addr: &str) -> Result<(), Box<dyn Error + Send + Sync
         .build()?;
 
     let provider = trace::TracerProvider::builder()
-        .with_config(
-            trace::Config::default().with_resource(Resource::from_schema_url(
-                vec![
-                    KeyValue::new(SERVICE_NAME, "hyperlight_otel_example"),
-                    KeyValue::new(SERVICE_VERSION, env!("CARGO_PKG_VERSION")),
-                ],
-                SCHEMA_URL,
-            )),
-        )
+        .with_resource(Resource::new(vec![
+            KeyValue::new(SERVICE_NAME, "hyperlight_otel_example"),
+            KeyValue::new(SERVICE_VERSION, env!("CARGO_PKG_VERSION")),
+        ]))
         .with_batch_exporter(exporter, Tokio)
         .build();
 


### PR DESCRIPTION
updates open-telemetry crates to 0.27.1 and fixes breaking change

see #174 and #176 for more details