### PR TITLE
update kvm-ioctls and kvm-bindings to latest versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1423,18 +1423,18 @@ dependencies = [
 
 [[package]]
 name = "kvm-bindings"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa4933174d0cc4b77b958578cd45784071cc5ae212c2d78fbd755aaaa6dfa71a"
+checksum = "501bc0717c6a9fc409f29047ebeb6040a4d304344698abb268c4c6a440e6a09a"
 dependencies = [
  "vmm-sys-util",
 ]
 
 [[package]]
 name = "kvm-ioctls"
-version = "0.19.1"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e013ae7fcd2c6a8f384104d16afe7ea02969301ea2bb2a56e44b011ebc907cab"
+checksum = "3f9120f23310f01dd7b4fbb4ae1fd4eae3e09a7aa5b77038b08a6b37099d8ef4"
 dependencies = [
  "bitflags 2.8.0",
  "kvm-bindings",

--- a/src/hyperlight_host/Cargo.toml
+++ b/src/hyperlight_host/Cargo.toml
@@ -72,8 +72,8 @@ windows-version = "0.1"
 
 [target.'cfg(unix)'.dependencies]
 seccompiler = { version = "0.4.0", optional = true }
-kvm-bindings = { version = "0.10.0", features = ["fam-wrappers"], optional = true }
-kvm-ioctls = { version = "0.19.1", optional = true }
+kvm-bindings = { version = "0.11", features = ["fam-wrappers"], optional = true }
+kvm-ioctls = { version = "0.20", optional = true }
 mshv-bindings2 = { package="mshv-bindings", version = "=0.2.1", optional = true }
 mshv-ioctls2 = { package="mshv-ioctls",  version = "=0.2.1", optional = true}
 mshv-bindings3 = { package="mshv-bindings", version = "0.3.2", optional = true }


### PR DESCRIPTION
Updates `kvm-ioctls` and `kvm-bindings` to the latest versions.

See #211 and #177 