### PR TITLE
update dependabot labels

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,10 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    labels: []
   - package-ecosystem: "cargo"
     directories: ["/", "src/tests/rust_guests/simpleguest","src/tests/rust_guests/callbackguest"]
     schedule:
       interval: "daily"
+    labels:
+      - "area/dependencies"

--- a/.github/workflows/PRLabelChecker.yml
+++ b/.github/workflows/PRLabelChecker.yml
@@ -14,6 +14,11 @@ jobs:
       - uses: actions/checkout@v4
       - name: Check for specific labels
         run: |
+          # ignore dependabot PRs
+          if [[ ${{ github.actor }} == "dependabot[bot]" ]]; then
+            echo "Ignoring dependabot PRs."
+            exit 0
+          fi
           # Fetch repository labels from the GitHub API
           REPO_LABELS=$(gh api repos/${{ github.repository }}/labels --jq '.[].name')
 


### PR DESCRIPTION
Updates dependabot to use the `"area/dependencies"` label instead of the `"dependencies"` label for Cargo crate version updates.

Removes labels from github-actions updates, when we update release.yml for the new labels we will need to ensure that changes with no labels are excluded or add a ignore label here and then exclude that.

Updates PR Label checker job to ignore dependabot PRs