### PR TITLE
Only use general purpose registers in c guest

### DIFF
--- a/c.just
+++ b/c.just
@@ -9,7 +9,7 @@ c-flags-release-pe := '/O2 /Gy'
 
 # Elf options
 # We don't support stack protectors at the moment, but Arch Linux clang auto-enables them for -linux platforms, so explicitly disable them.
-c-compile-options-elf := '-nobuiltininc -H --target=x86_64-unknown-linux-none -fno-stack-protector -fstack-clash-protection -mstack-probe-size=4096'
+c-compile-options-elf := '-mgeneral-regs-only -nobuiltininc -H --target=x86_64-unknown-none-elf -fPIC -fno-stack-protector -fstack-clash-protection -mstack-probe-size=4096'
 c-include-flags-elf := replace(c-include-flags-pe, '/I ', '-I ')
 c-linker-options-elf := '--entry "entrypoint" --nostdlib -pie'
 c-flags-debug-elf := '-O0'

--- a/src/hyperlight_host/tests/sandbox_host_tests.rs
+++ b/src/hyperlight_host/tests/sandbox_host_tests.rs
@@ -63,7 +63,6 @@ fn pass_byte_array() {
 }
 
 #[test]
-#[ignore = "Fails with mismatched float only when c .exe guest?!"]
 #[cfg_attr(target_os = "windows", serial)] // using LoadLibrary requires serial tests
 fn float_roundtrip() {
     let doubles = [


### PR DESCRIPTION
There is a mismatch in the ffi ABI between c and rust. Rust library doesn't use SSE, so won't use XMM registers for passing floats as arguments, but clang will. This is a temporary fix until I figure out how to properly set this