### PR TITLE
Run clippy on guests in CI

### DIFF
--- a/.github/workflows/dep_rust.yml
+++ b/.github/workflows/dep_rust.yml
@@ -60,7 +60,7 @@ jobs:
       - name: clippy
         run: |
           just clippy ${{ matrix.config }}
-          just clippy-guests
+          just clippy-guests ${{ matrix.config }}
 
       # Does not check for updated Cargo.lock files for test rust guests as this causes an issue with this checkwhen deoendabot updates dependencies in common crates
       - name: Ensure up-to-date Cargo.lock

--- a/.github/workflows/dep_rust.yml
+++ b/.github/workflows/dep_rust.yml
@@ -58,7 +58,9 @@ jobs:
         run: just fmt-check
 
       - name: clippy
-        run: just clippy ${{ matrix.config }}
+        run: |
+          just clippy ${{ matrix.config }}
+          just clippy-guests
 
       # Does not check for updated Cargo.lock files for test rust guests as this causes an issue with this checkwhen deoendabot updates dependencies in common crates
       - name: Ensure up-to-date Cargo.lock

--- a/Justfile
+++ b/Justfile
@@ -138,6 +138,10 @@ fmt-apply:
 clippy target=default-target:
     cargo clippy --all-targets --all-features --profile={{ if target == "debug" { "dev" } else { target } }} -- -D warnings
 
+clippy-guests target=default-target:
+    cd src/tests/rust_guests/simpleguest && cargo clippy --profile={{ if target == "debug" { "dev" } else { target } }} -- -D warnings
+    cd src/tests/rust_guests/callbackguest && cargo clippy --profile={{ if target == "debug" { "dev" } else { target } }} -- -D warnings
+
 clippy-apply-fix-unix:
     cargo clippy --fix --all 
 

--- a/src/hyperlight_guest/src/guest_function_call.rs
+++ b/src/hyperlight_guest/src/guest_function_call.rs
@@ -58,7 +58,7 @@ pub(crate) fn call_guest_function(function_call: FunctionCall) -> Result<Vec<u8>
 
         let p_function = unsafe {
             let function_pointer = registered_function_definition.function_pointer;
-            core::mem::transmute::<i64, GuestFunc>(function_pointer)
+            core::mem::transmute::<usize, GuestFunc>(function_pointer)
         };
 
         p_function(&function_call)

--- a/src/hyperlight_guest/src/guest_function_definition.rs
+++ b/src/hyperlight_guest/src/guest_function_definition.rs
@@ -33,7 +33,7 @@ pub struct GuestFunctionDefinition {
     /// The type of the return value from the host function call
     pub return_type: ReturnType,
     /// The function pointer to the guest function
-    pub function_pointer: i64,
+    pub function_pointer: usize,
 }
 
 impl GuestFunctionDefinition {
@@ -42,7 +42,7 @@ impl GuestFunctionDefinition {
         function_name: String,
         parameter_types: Vec<ParameterType>,
         return_type: ReturnType,
-        function_pointer: i64,
+        function_pointer: usize,
     ) -> Self {
         Self {
             function_name,

--- a/src/hyperlight_guest_capi/src/dispatch.rs
+++ b/src/hyperlight_guest_capi/src/dispatch.rs
@@ -39,7 +39,7 @@ pub fn guest_dispatch_function(function_call: FunctionCall) -> Result<Vec<u8>> {
         let ffi_func_call = FfiFunctionCall::from_function_call(function_call)?;
 
         let guest_func =
-            unsafe { mem::transmute::<i64, CGuestFunc>(registered_func.function_pointer) };
+            unsafe { mem::transmute::<usize, CGuestFunc>(registered_func.function_pointer) };
         let function_result = guest_func(&ffi_func_call);
 
         unsafe { Ok(FfiVec::into_vec(*function_result)) }
@@ -76,12 +76,8 @@ pub extern "C" fn hl_register_function_definition(
 
     let func_params = unsafe { slice::from_raw_parts(params_type, param_no).to_vec() };
 
-    let func_def = GuestFunctionDefinition::new(
-        func_name,
-        func_params,
-        return_type,
-        func_ptr as usize as i64,
-    );
+    let func_def =
+        GuestFunctionDefinition::new(func_name, func_params, return_type, func_ptr as usize);
 
     #[allow(static_mut_refs)]
     unsafe { &mut REGISTERED_C_GUEST_FUNCTIONS }.register(func_def);

--- a/src/tests/rust_guests/callbackguest/src/main.rs
+++ b/src/tests/rust_guests/callbackguest/src/main.rs
@@ -60,10 +60,10 @@ fn guest_function(function_call: &FunctionCall) -> Result<Vec<u8>> {
     if let ParameterValue::String(message) = &function_call.parameters.as_ref().unwrap()[0] {
         send_message_to_host_method("HostMethod", "Hello from GuestFunction, ", message)
     } else {
-        return Err(HyperlightGuestError::new(
+        Err(HyperlightGuestError::new(
             ErrorCode::GuestFunctionParameterTypeMismatch,
             "Invalid parameters passed to guest_function".to_string(),
-        ));
+        ))
     }
 }
 
@@ -71,10 +71,10 @@ fn guest_function1(function_call: &FunctionCall) -> Result<Vec<u8>> {
     if let ParameterValue::String(message) = &function_call.parameters.as_ref().unwrap()[0] {
         send_message_to_host_method("HostMethod1", "Hello from GuestFunction1, ", message)
     } else {
-        return Err(HyperlightGuestError::new(
+        Err(HyperlightGuestError::new(
             ErrorCode::GuestFunctionParameterTypeMismatch,
             "Invalid parameters passed to guest_function1".to_string(),
-        ));
+        ))
     }
 }
 
@@ -82,10 +82,10 @@ fn guest_function2(function_call: &FunctionCall) -> Result<Vec<u8>> {
     if let ParameterValue::String(message) = &function_call.parameters.as_ref().unwrap()[0] {
         send_message_to_host_method("HostMethod1", "Hello from GuestFunction2, ", message)
     } else {
-        return Err(HyperlightGuestError::new(
+        Err(HyperlightGuestError::new(
             ErrorCode::GuestFunctionParameterTypeMismatch,
             "Invalid parameters passed to guest_function2".to_string(),
-        ));
+        ))
     }
 }
 
@@ -93,14 +93,14 @@ fn guest_function3(function_call: &FunctionCall) -> Result<Vec<u8>> {
     if let ParameterValue::String(message) = &function_call.parameters.as_ref().unwrap()[0] {
         send_message_to_host_method("HostMethod1", "Hello from GuestFunction3, ", message)
     } else {
-        return Err(HyperlightGuestError::new(
+        Err(HyperlightGuestError::new(
             ErrorCode::GuestFunctionParameterTypeMismatch,
             "Invalid parameters passed to guest_function3".to_string(),
-        ));
+        ))
     }
 }
 
-fn guest_function4() -> Result<Vec<u8>> {
+fn guest_function4(_: &FunctionCall) -> Result<Vec<u8>> {
     call_host_function(
         "HostMethod4",
         Some(Vec::from(&[ParameterValue::String(
@@ -123,7 +123,7 @@ fn guest_log_message(function_call: &FunctionCall) -> Result<Vec<u8>> {
         &function_call.parameters.as_ref().unwrap()[2],
     ) {
         let mut log_level = *level;
-        if log_level < 0 || log_level > 6 {
+        if !(0..=6).contains(&log_level) {
             log_level = 0;
         }
 
@@ -138,10 +138,10 @@ fn guest_log_message(function_call: &FunctionCall) -> Result<Vec<u8>> {
 
         Ok(get_flatbuffer_result(message.len() as i32))
     } else {
-        return Err(HyperlightGuestError::new(
+        Err(HyperlightGuestError::new(
             ErrorCode::GuestFunctionParameterTypeMismatch,
             "Invalid parameters passed to guest_log_message".to_string(),
-        ));
+        ))
     }
 }
 
@@ -149,14 +149,14 @@ fn call_error_method(function_call: &FunctionCall) -> Result<Vec<u8>> {
     if let ParameterValue::String(message) = &function_call.parameters.as_ref().unwrap()[0] {
         send_message_to_host_method("ErrorMethod", "Error From Host: ", message)
     } else {
-        return Err(HyperlightGuestError::new(
+        Err(HyperlightGuestError::new(
             ErrorCode::GuestFunctionParameterTypeMismatch,
             "Invalid parameters passed to call_error_method".to_string(),
-        ));
+        ))
     }
 }
 
-fn call_host_spin() -> Result<Vec<u8>> {
+fn call_host_spin(_: &FunctionCall) -> Result<Vec<u8>> {
     call_host_function("Spin", None, ReturnType::Void)?;
     Ok(get_flatbuffer_result(()))
 }
@@ -167,7 +167,7 @@ pub extern "C" fn hyperlight_main() {
         "PrintOutput".to_string(),
         Vec::from(&[ParameterType::String]),
         ReturnType::Int,
-        print_output_as_guest_function as i64,
+        print_output_as_guest_function as usize,
     );
     register_function(print_output_def);
 
@@ -175,7 +175,7 @@ pub extern "C" fn hyperlight_main() {
         "GuestMethod".to_string(),
         Vec::from(&[ParameterType::String]),
         ReturnType::Int,
-        guest_function as i64,
+        guest_function as usize,
     );
     register_function(guest_function_def);
 
@@ -183,7 +183,7 @@ pub extern "C" fn hyperlight_main() {
         "GuestMethod1".to_string(),
         Vec::from(&[ParameterType::String]),
         ReturnType::Int,
-        guest_function1 as i64,
+        guest_function1 as usize,
     );
     register_function(guest_function1_def);
 
@@ -191,7 +191,7 @@ pub extern "C" fn hyperlight_main() {
         "GuestMethod2".to_string(),
         Vec::from(&[ParameterType::String]),
         ReturnType::Int,
-        guest_function2 as i64,
+        guest_function2 as usize,
     );
     register_function(guest_function2_def);
 
@@ -199,7 +199,7 @@ pub extern "C" fn hyperlight_main() {
         "GuestMethod3".to_string(),
         Vec::from(&[ParameterType::String]),
         ReturnType::Int,
-        guest_function3 as i64,
+        guest_function3 as usize,
     );
     register_function(guest_function3_def);
 
@@ -207,7 +207,7 @@ pub extern "C" fn hyperlight_main() {
         "GuestMethod4".to_string(),
         Vec::new(),
         ReturnType::Int,
-        guest_function4 as i64,
+        guest_function4 as usize,
     );
     register_function(guest_function4_def);
 
@@ -219,7 +219,7 @@ pub extern "C" fn hyperlight_main() {
             ParameterType::Int,
         ]),
         ReturnType::Int,
-        guest_log_message as i64,
+        guest_log_message as usize,
     );
     register_function(guest_log_message_def);
 
@@ -227,7 +227,7 @@ pub extern "C" fn hyperlight_main() {
         "CallErrorMethod".to_string(),
         Vec::from(&[ParameterType::String]),
         ReturnType::Int,
-        call_error_method as i64,
+        call_error_method as usize,
     );
     register_function(call_error_method_def);
 
@@ -235,7 +235,7 @@ pub extern "C" fn hyperlight_main() {
         "CallHostSpin".to_string(),
         Vec::new(),
         ReturnType::Int,
-        call_host_spin as i64,
+        call_host_spin as usize,
     );
     register_function(call_host_spin_def);
 }

--- a/src/tests/rust_guests/simpleguest/src/main.rs
+++ b/src/tests/rust_guests/simpleguest/src/main.rs
@@ -1105,7 +1105,7 @@ pub extern "C" fn hyperlight_main() {
         "TriggerException".to_string(),
         Vec::new(),
         ReturnType::Void,
-        trigger_exception as i64,
+        trigger_exception as usize,
     );
     register_function(trigger_exception_def);
 }

--- a/src/tests/rust_guests/simpleguest/src/main.rs
+++ b/src/tests/rust_guests/simpleguest/src/main.rs
@@ -26,9 +26,9 @@ const MAX_BUFFER_SIZE: usize = 1024;
 extern crate alloc;
 
 use alloc::boxed::Box;
-use alloc::format;
 use alloc::string::ToString;
 use alloc::vec::Vec;
+use alloc::{format, vec};
 use core::ffi::c_char;
 use core::hint::black_box;
 use core::ptr::write_volatile;
@@ -54,13 +54,12 @@ extern crate hyperlight_guest;
 
 static mut BIGARRAY: [i32; 1024 * 1024] = [0; 1024 * 1024];
 
-fn set_static() -> Result<Vec<u8>> {
+fn set_static(_: &FunctionCall) -> Result<Vec<u8>> {
     unsafe {
-        let length = BIGARRAY.len();
-        for i in 0..length {
-            BIGARRAY[i] = i as i32;
+        for val in BIGARRAY.iter_mut() {
+            *val = 1;
         }
-        Ok(get_flatbuffer_result(length as i32))
+        Ok(get_flatbuffer_result(BIGARRAY.len() as i32))
     }
 }
 
@@ -423,13 +422,13 @@ fn buffer_overrun(function_call: &FunctionCall) -> Result<Vec<u8>> {
 }
 
 #[allow(unconditional_recursion)]
-fn infinite_recursion(a: &FunctionCall) -> Result<Vec<u8>> {
+fn infinite_recursion(_a: &FunctionCall) -> Result<Vec<u8>> {
     // blackbox is needed so something
     //is written to the stack in release mode,
     //to trigger guard page violation
     let param = black_box(5);
     black_box(param);
-    infinite_recursion(a)
+    infinite_recursion(_a)
 }
 
 fn stack_overflow(function_call: &FunctionCall) -> Result<Vec<u8>> {
@@ -482,8 +481,7 @@ fn malloc_and_free(function_call: &FunctionCall) -> Result<Vec<u8>> {
         } else {
             size.min(MAX_BUFFER_SIZE as i32)
         };
-        let mut allocated_buffer = Vec::with_capacity(alloc_length as usize);
-        allocated_buffer.resize(alloc_length as usize, 0);
+        let allocated_buffer = vec![0; alloc_length as usize];
         drop(allocated_buffer);
 
         Ok(get_flatbuffer_result(size))
@@ -517,6 +515,10 @@ fn get_size_prefixed_buffer(function_call: &FunctionCall) -> Result<Vec<u8>> {
     }
 }
 
+#[expect(
+    clippy::empty_loop,
+    reason = "This function is used to keep the CPU busy"
+)]
 fn spin(_: &FunctionCall) -> Result<Vec<u8>> {
     loop {
         // Keep the CPU 100% busy forever
@@ -718,7 +720,7 @@ pub extern "C" fn hyperlight_main() {
         "SetStatic".to_string(),
         Vec::new(),
         ReturnType::Int,
-        set_static as i64,
+        set_static as usize,
     );
 
     register_function(set_static_def);
@@ -727,7 +729,7 @@ pub extern "C" fn hyperlight_main() {
         "PrintOutput".to_string(),
         Vec::from(&[ParameterType::String]),
         ReturnType::Int,
-        simple_print_output as i64,
+        simple_print_output as usize,
     );
     register_function(simple_print_output_def);
 
@@ -735,7 +737,7 @@ pub extern "C" fn hyperlight_main() {
         "PrintUsingPrintf".to_string(),
         Vec::from(&[ParameterType::String]),
         ReturnType::Int,
-        simple_print_output as i64, // alias to simple_print_output for now
+        simple_print_output as usize, // alias to simple_print_output for now
     );
     register_function(print_using_printf_def);
 
@@ -743,7 +745,7 @@ pub extern "C" fn hyperlight_main() {
         "StackOverflow".to_string(),
         Vec::from(&[ParameterType::Int]),
         ReturnType::Int,
-        stack_overflow as i64,
+        stack_overflow as usize,
     );
     register_function(stack_overflow_def);
 
@@ -751,7 +753,7 @@ pub extern "C" fn hyperlight_main() {
         "BufferOverrun".to_string(),
         Vec::from(&[ParameterType::String]),
         ReturnType::Int,
-        buffer_overrun as i64,
+        buffer_overrun as usize,
     );
     register_function(buffer_overrun_def);
 
@@ -759,7 +761,7 @@ pub extern "C" fn hyperlight_main() {
         "LargeVar".to_string(),
         Vec::new(),
         ReturnType::Int,
-        large_var as i64,
+        large_var as usize,
     );
     register_function(large_var_def);
 
@@ -767,7 +769,7 @@ pub extern "C" fn hyperlight_main() {
         "SmallVar".to_string(),
         Vec::new(),
         ReturnType::Int,
-        small_var as i64,
+        small_var as usize,
     );
     register_function(small_var_def);
 
@@ -775,7 +777,7 @@ pub extern "C" fn hyperlight_main() {
         "CallMalloc".to_string(),
         Vec::from(&[ParameterType::Int]),
         ReturnType::Int,
-        call_malloc as i64,
+        call_malloc as usize,
     );
     register_function(call_malloc_def);
 
@@ -783,7 +785,7 @@ pub extern "C" fn hyperlight_main() {
         "MallocAndFree".to_string(),
         Vec::from(&[ParameterType::Int]),
         ReturnType::Int,
-        malloc_and_free as i64,
+        malloc_and_free as usize,
     );
     register_function(malloc_and_free_def);
 
@@ -791,7 +793,7 @@ pub extern "C" fn hyperlight_main() {
         "PrintTwoArgs".to_string(),
         Vec::from(&[ParameterType::String, ParameterType::Int]),
         ReturnType::Int,
-        print_two_args as i64,
+        print_two_args as usize,
     );
     register_function(print_two_args_def);
 
@@ -803,7 +805,7 @@ pub extern "C" fn hyperlight_main() {
             ParameterType::Long,
         ]),
         ReturnType::Int,
-        print_three_args as i64,
+        print_three_args as usize,
     );
     register_function(print_three_args_def);
 
@@ -816,7 +818,7 @@ pub extern "C" fn hyperlight_main() {
             ParameterType::String,
         ]),
         ReturnType::Int,
-        print_four_args as i64,
+        print_four_args as usize,
     );
     register_function(print_four_args_def);
 
@@ -830,7 +832,7 @@ pub extern "C" fn hyperlight_main() {
             ParameterType::String,
         ]),
         ReturnType::Int,
-        print_five_args as i64,
+        print_five_args as usize,
     );
     register_function(print_five_args_def);
 
@@ -845,7 +847,7 @@ pub extern "C" fn hyperlight_main() {
             ParameterType::Bool,
         ]),
         ReturnType::Int,
-        print_six_args as i64,
+        print_six_args as usize,
     );
     register_function(print_six_args_def);
 
@@ -861,7 +863,7 @@ pub extern "C" fn hyperlight_main() {
             ParameterType::Bool,
         ]),
         ReturnType::Int,
-        print_seven_args as i64,
+        print_seven_args as usize,
     );
     register_function(print_seven_args_def);
 
@@ -878,7 +880,7 @@ pub extern "C" fn hyperlight_main() {
             ParameterType::UInt,
         ]),
         ReturnType::Int,
-        print_eight_args as i64,
+        print_eight_args as usize,
     );
     register_function(print_eight_args_def);
 
@@ -896,7 +898,7 @@ pub extern "C" fn hyperlight_main() {
             ParameterType::ULong,
         ]),
         ReturnType::Int,
-        print_nine_args as i64,
+        print_nine_args as usize,
     );
     register_function(print_nine_args_def);
 
@@ -915,7 +917,7 @@ pub extern "C" fn hyperlight_main() {
             ParameterType::Int,
         ]),
         ReturnType::Int,
-        print_ten_args as i64,
+        print_ten_args as usize,
     );
     register_function(print_ten_args_def);
 
@@ -935,7 +937,7 @@ pub extern "C" fn hyperlight_main() {
             ParameterType::Float,
         ]),
         ReturnType::Int,
-        print_eleven_args as i64,
+        print_eleven_args as usize,
     );
     register_function(print_eleven_args_def);
 
@@ -943,7 +945,7 @@ pub extern "C" fn hyperlight_main() {
         "SetByteArrayToZero".to_string(),
         Vec::from(&[ParameterType::VecBytes]),
         ReturnType::VecBytes,
-        set_byte_array_to_zero as i64,
+        set_byte_array_to_zero as usize,
     );
     register_function(set_byte_array_to_zero_def);
 
@@ -951,7 +953,7 @@ pub extern "C" fn hyperlight_main() {
         "Echo".to_string(),
         Vec::from(&[ParameterType::String]),
         ReturnType::String,
-        echo as i64,
+        echo as usize,
     );
     register_function(echo_def);
 
@@ -959,19 +961,23 @@ pub extern "C" fn hyperlight_main() {
         "GetSizePrefixedBuffer".to_string(),
         Vec::from(&[ParameterType::VecBytes]),
         ReturnType::Int,
-        get_size_prefixed_buffer as i64,
+        get_size_prefixed_buffer as usize,
     );
     register_function(get_size_prefixed_buffer_def);
 
-    let spin_def =
-        GuestFunctionDefinition::new("Spin".to_string(), Vec::new(), ReturnType::Int, spin as i64);
+    let spin_def = GuestFunctionDefinition::new(
+        "Spin".to_string(),
+        Vec::new(),
+        ReturnType::Int,
+        spin as usize,
+    );
     register_function(spin_def);
 
     let abort_def = GuestFunctionDefinition::new(
         "GuestAbortWithCode".to_string(),
         Vec::from(&[ParameterType::Int]),
         ReturnType::Void,
-        test_abort as i64,
+        test_abort as usize,
     );
     register_function(abort_def);
 
@@ -979,7 +985,7 @@ pub extern "C" fn hyperlight_main() {
         "GuestAbortWithMessage".to_string(),
         Vec::from(&[ParameterType::Int, ParameterType::String]),
         ReturnType::Void,
-        test_abort_with_code_and_message as i64,
+        test_abort_with_code_and_message as usize,
     );
     register_function(abort_with_code_message_def);
 
@@ -987,7 +993,7 @@ pub extern "C" fn hyperlight_main() {
         "guest_panic".to_string(),
         Vec::from(&[ParameterType::String]),
         ReturnType::Void,
-        test_guest_panic as i64,
+        test_guest_panic as usize,
     );
     register_function(guest_panic_def);
 
@@ -995,7 +1001,7 @@ pub extern "C" fn hyperlight_main() {
         "TestMalloc".to_string(),
         Vec::from(&[ParameterType::Int]),
         ReturnType::Int,
-        test_rust_malloc as i64,
+        test_rust_malloc as usize,
     );
     register_function(rust_malloc_def);
 
@@ -1003,7 +1009,7 @@ pub extern "C" fn hyperlight_main() {
         "LogMessage".to_string(),
         Vec::from(&[ParameterType::String, ParameterType::Int]),
         ReturnType::Void,
-        log_message as i64,
+        log_message as usize,
     );
     register_function(log_message_def);
 
@@ -1011,7 +1017,7 @@ pub extern "C" fn hyperlight_main() {
         "InfiniteRecursion".to_string(),
         Vec::new(),
         ReturnType::Void,
-        infinite_recursion as i64,
+        infinite_recursion as usize,
     );
     register_function(infinite_recursion_def);
 
@@ -1019,7 +1025,7 @@ pub extern "C" fn hyperlight_main() {
         "test_write_raw_ptr".to_string(),
         Vec::from(&[ParameterType::Long]),
         ReturnType::String,
-        test_write_raw_ptr as i64,
+        test_write_raw_ptr as usize,
     );
     register_function(test_write_raw_ptr_def);
 
@@ -1027,7 +1033,7 @@ pub extern "C" fn hyperlight_main() {
         "ExecuteOnStack".to_string(),
         Vec::new(),
         ReturnType::String,
-        execute_on_stack as i64,
+        execute_on_stack as usize,
     );
     register_function(execute_on_stack_def);
 
@@ -1035,7 +1041,7 @@ pub extern "C" fn hyperlight_main() {
         "ExecuteOnHeap".to_string(),
         Vec::new(),
         ReturnType::String,
-        execute_on_heap as i64,
+        execute_on_heap as usize,
     );
     register_function(execute_on_heap_def);
 
@@ -1043,7 +1049,7 @@ pub extern "C" fn hyperlight_main() {
         "AddToStatic".to_string(),
         Vec::from(&[ParameterType::Int]),
         ReturnType::Int,
-        add_to_static as i64,
+        add_to_static as usize,
     );
     register_function(add_to_static_def);
 
@@ -1051,7 +1057,7 @@ pub extern "C" fn hyperlight_main() {
         "GetStatic".to_string(),
         Vec::new(),
         ReturnType::Int,
-        get_static as i64,
+        get_static as usize,
     );
     register_function(get_static_def);
 
@@ -1059,7 +1065,7 @@ pub extern "C" fn hyperlight_main() {
         "AddToStaticAndFail".to_string(),
         Vec::new(),
         ReturnType::Int,
-        add_to_static_and_fail as i64,
+        add_to_static_and_fail as usize,
     );
     register_function(add_to_static_and_fail_def);
 
@@ -1067,7 +1073,7 @@ pub extern "C" fn hyperlight_main() {
         "ViolateSeccompFilters".to_string(),
         Vec::new(),
         ReturnType::ULong,
-        violate_seccomp_filters as i64,
+        violate_seccomp_filters as usize,
     );
     register_function(violate_seccomp_filters_def);
 
@@ -1075,7 +1081,7 @@ pub extern "C" fn hyperlight_main() {
         "EchoFloat".to_string(),
         Vec::from(&[ParameterType::Float]),
         ReturnType::Float,
-        echo_float as i64,
+        echo_float as usize,
     );
     register_function(echo_float_def);
 
@@ -1083,7 +1089,7 @@ pub extern "C" fn hyperlight_main() {
         "EchoDouble".to_string(),
         Vec::from(&[ParameterType::Double]),
         ReturnType::Double,
-        echo_double as i64,
+        echo_double as usize,
     );
     register_function(echo_double_def);
 
@@ -1091,7 +1097,7 @@ pub extern "C" fn hyperlight_main() {
         "Add".to_string(),
         Vec::from(&[ParameterType::Int, ParameterType::Int]),
         ReturnType::Int,
-        add as i64,
+        add as usize,
     );
     register_function(add_def);
 
@@ -1116,7 +1122,7 @@ pub fn guest_dispatch_function(function_call: FunctionCall) -> Result<Vec<u8>> {
 
     logging::log_message(
         LogLevel::Information,
-        &message,
+        message,
         "source",
         "caller",
         "file",


### PR DESCRIPTION
closes #217 by running cargo clippy on the guests in CI. Also fixes existing clippy violations that have snuck in. Note that the change from i64->usize is a breaking change

also closes #216