### PR TITLE
add back minimal vscode settings file for rust-analyzer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -448,6 +448,7 @@ $RECYCLE.BIN/
 ## Visual Studio Code
 ##
 .vscode/*
+!.vscode/settings.json
 
 /downloads
 

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+    "rust-analyzer.linkedProjects": [
+        "Cargo.toml", 
+        // guest crates for testing, not part of the workspace
+        "src/tests/rust_guests/simpleguest/Cargo.toml",
+        "src/tests/rust_guests/callbackguest/Cargo.toml"
+    ]
+}


### PR DESCRIPTION
#66 removed .vscode/settings.json and .vscode/launch.json. After some thinking, I think we removed a bit too much in that PR.

This PR adds back a minimal settings.json, which makes rust-analyzer work with simpleguest and callbackguest. Importantly, the setting should have no impact on users not using vscode. If anyone has a strong opinion why we should NOT check-in this file, please let me know. 