### PR TITLE
Generic guest/host result API

### DIFF
--- a/src/hyperlight_common/src/flatbuffer_wrappers/util.rs
+++ b/src/hyperlight_common/src/flatbuffer_wrappers/util.rs
@@ -16,12 +16,13 @@ limitations under the License.
 
 use alloc::vec::Vec;
 
-use flatbuffers::{FlatBufferBuilder, UnionWIPOffset, WIPOffset};
+use flatbuffers::FlatBufferBuilder;
 
 use crate::flatbuffers::hyperlight::generated::{
-    hldouble as Fbhldouble, hldoubleArgs as FbhldoubleArgs, hlfloat as Fbhlfloat,
-    hlfloatArgs as FbhlfloatArgs, hlint as Fbhlint, hlintArgs as FbhlintArgs, hllong as Fbhllong,
-    hllongArgs as FbhllongArgs, hlsizeprefixedbuffer as Fbhlsizeprefixedbuffer,
+    hlbool as Fbhlbool, hlboolArgs as FbhlboolArgs, hldouble as Fbhldouble,
+    hldoubleArgs as FbhldoubleArgs, hlfloat as Fbhlfloat, hlfloatArgs as FbhlfloatArgs,
+    hlint as Fbhlint, hlintArgs as FbhlintArgs, hllong as Fbhllong, hllongArgs as FbhllongArgs,
+    hlsizeprefixedbuffer as Fbhlsizeprefixedbuffer,
     hlsizeprefixedbufferArgs as FbhlsizeprefixedbufferArgs, hlstring as Fbhlstring,
     hlstringArgs as FbhlstringArgs, hluint as Fbhluint, hluintArgs as FbhluintArgs,
     hlulong as Fbhlulong, hlulongArgs as FbhlulongArgs, hlvoid as Fbhlvoid,
@@ -29,128 +30,142 @@ use crate::flatbuffers::hyperlight::generated::{
     FunctionCallResultArgs as FbFunctionCallResultArgs, ReturnValue as FbReturnValue,
 };
 
-pub fn get_flatbuffer_result_from_double(value: f64) -> Vec<u8> {
+/// Flatbuffer-encodes the given value
+pub fn get_flatbuffer_result<T: FlatbufferSerializable>(val: T) -> Vec<u8> {
     let mut builder = FlatBufferBuilder::new();
-    let hldouble = Fbhldouble::create(&mut builder, &FbhldoubleArgs { value });
-
-    let rt = FbReturnValue::hldouble;
-    let rv: Option<WIPOffset<UnionWIPOffset>> = Some(hldouble.as_union_value());
-
-    get_flatbuffer_result(&mut builder, rt, rv)
-}
-
-pub fn get_flatbuffer_result_from_float(value: f32) -> Vec<u8> {
-    let mut builder = FlatBufferBuilder::new();
-    let hlfloat = Fbhlfloat::create(&mut builder, &FbhlfloatArgs { value });
-
-    let rt = FbReturnValue::hlfloat;
-    let rv: Option<WIPOffset<UnionWIPOffset>> = Some(hlfloat.as_union_value());
-
-    get_flatbuffer_result(&mut builder, rt, rv)
-}
-
-pub fn get_flatbuffer_result_from_int(value: i32) -> Vec<u8> {
-    let mut builder = FlatBufferBuilder::new();
-    let hlint = Fbhlint::create(&mut builder, &FbhlintArgs { value });
-
-    let rt = FbReturnValue::hlint;
-    let rv: Option<WIPOffset<UnionWIPOffset>> = Some(hlint.as_union_value());
-
-    get_flatbuffer_result(&mut builder, rt, rv)
-}
-
-pub fn get_flatbuffer_result_from_uint(value: u32) -> Vec<u8> {
-    let mut builder = FlatBufferBuilder::new();
-    let hluint = Fbhluint::create(&mut builder, &FbhluintArgs { value });
-
-    let rt = FbReturnValue::hluint;
-    let rv: Option<WIPOffset<UnionWIPOffset>> = Some(hluint.as_union_value());
-
-    get_flatbuffer_result(&mut builder, rt, rv)
-}
-
-pub fn get_flatbuffer_result_from_long(value: i64) -> Vec<u8> {
-    let mut builder = FlatBufferBuilder::new();
-    let hllong = Fbhllong::create(&mut builder, &FbhllongArgs { value });
-
-    let rt = FbReturnValue::hllong;
-    let rv: Option<WIPOffset<UnionWIPOffset>> = Some(hllong.as_union_value());
-
-    get_flatbuffer_result(&mut builder, rt, rv)
-}
-
-pub fn get_flatbuffer_result_from_ulong(value: u64) -> Vec<u8> {
-    let mut builder = FlatBufferBuilder::new();
-    let hlulong = Fbhlulong::create(&mut builder, &FbhlulongArgs { value });
-
-    let rt = FbReturnValue::hlulong;
-    let rv: Option<WIPOffset<UnionWIPOffset>> = Some(hlulong.as_union_value());
-
-    get_flatbuffer_result(&mut builder, rt, rv)
-}
-
-pub fn get_flatbuffer_result_from_void() -> Vec<u8> {
-    let mut builder = FlatBufferBuilder::new();
-    let hlvoid = Fbhlvoid::create(&mut builder, &FbhlvoidArgs {});
-
-    let rt = FbReturnValue::hlvoid;
-    let rv: Option<WIPOffset<UnionWIPOffset>> = Some(hlvoid.as_union_value());
-
-    get_flatbuffer_result(&mut builder, rt, rv)
-}
-
-pub fn get_flatbuffer_result_from_string(value: &str) -> Vec<u8> {
-    let mut builder = FlatBufferBuilder::new();
-
-    let string_offset = builder.create_string(value);
-    let hlstring = Fbhlstring::create(
-        &mut builder,
-        &FbhlstringArgs {
-            value: Some(string_offset),
-        },
-    );
-
-    let rt = FbReturnValue::hlstring;
-    let rv: Option<WIPOffset<UnionWIPOffset>> = Some(hlstring.as_union_value());
-
-    get_flatbuffer_result(&mut builder, rt, rv)
-}
-
-pub fn get_flatbuffer_result_from_vec(data: &[u8]) -> Vec<u8> {
-    let mut builder = FlatBufferBuilder::new();
-
-    let vec_offset = builder.create_vector(data);
-
-    let hlsizeprefixedbuffer = Fbhlsizeprefixedbuffer::create(
-        &mut builder,
-        &FbhlsizeprefixedbufferArgs {
-            size_: data.len() as i32,
-            value: Some(vec_offset),
-        },
-    );
-
-    // Indicate that the return value is a size-prefixed buffer.
-    let rt = FbReturnValue::hlsizeprefixedbuffer;
-    let rv: Option<WIPOffset<UnionWIPOffset>> = Some(hlsizeprefixedbuffer.as_union_value());
-
-    // Get the FlatBuffer result.
-    get_flatbuffer_result(&mut builder, rt, rv)
-}
-
-fn get_flatbuffer_result(
-    builder: &mut FlatBufferBuilder,
-    return_value_type: FbReturnValue,
-    return_value: Option<WIPOffset<UnionWIPOffset>>,
-) -> Vec<u8> {
-    let result_offset = FbFunctionCallResult::create(
-        builder,
-        &FbFunctionCallResultArgs {
-            return_value,
-            return_value_type,
-        },
-    );
+    let res = &T::serialize(&val, &mut builder);
+    let result_offset = FbFunctionCallResult::create(&mut builder, res);
 
     builder.finish_size_prefixed(result_offset, None);
 
     builder.finished_data().to_vec()
+}
+
+pub trait FlatbufferSerializable {
+    fn serialize(&self, builder: &mut FlatBufferBuilder) -> FbFunctionCallResultArgs;
+}
+
+/// Implementations for basic types below
+
+impl FlatbufferSerializable for () {
+    fn serialize(&self, builder: &mut FlatBufferBuilder) -> FbFunctionCallResultArgs {
+        FbFunctionCallResultArgs {
+            return_value: Some(Fbhlvoid::create(builder, &FbhlvoidArgs {}).as_union_value()),
+            return_value_type: FbReturnValue::hlvoid,
+        }
+    }
+}
+
+impl FlatbufferSerializable for &str {
+    fn serialize(&self, builder: &mut FlatBufferBuilder) -> FbFunctionCallResultArgs {
+        let string_offset = builder.create_string(self);
+        FbFunctionCallResultArgs {
+            return_value: Some(
+                Fbhlstring::create(
+                    builder,
+                    &FbhlstringArgs {
+                        value: Some(string_offset),
+                    },
+                )
+                .as_union_value(),
+            ),
+            return_value_type: FbReturnValue::hlstring,
+        }
+    }
+}
+
+impl FlatbufferSerializable for &[u8] {
+    fn serialize(&self, builder: &mut FlatBufferBuilder) -> FbFunctionCallResultArgs {
+        let vec_offset = builder.create_vector(self);
+        FbFunctionCallResultArgs {
+            return_value: Some(
+                Fbhlsizeprefixedbuffer::create(
+                    builder,
+                    &FbhlsizeprefixedbufferArgs {
+                        size_: self.len() as i32,
+                        value: Some(vec_offset),
+                    },
+                )
+                .as_union_value(),
+            ),
+            return_value_type: FbReturnValue::hlsizeprefixedbuffer,
+        }
+    }
+}
+
+impl FlatbufferSerializable for f32 {
+    fn serialize(&self, builder: &mut FlatBufferBuilder) -> FbFunctionCallResultArgs {
+        FbFunctionCallResultArgs {
+            return_value: Some(
+                Fbhlfloat::create(builder, &FbhlfloatArgs { value: *self }).as_union_value(),
+            ),
+            return_value_type: FbReturnValue::hlfloat,
+        }
+    }
+}
+
+impl FlatbufferSerializable for f64 {
+    fn serialize(&self, builder: &mut FlatBufferBuilder) -> FbFunctionCallResultArgs {
+        FbFunctionCallResultArgs {
+            return_value: Some(
+                Fbhldouble::create(builder, &FbhldoubleArgs { value: *self }).as_union_value(),
+            ),
+            return_value_type: FbReturnValue::hldouble,
+        }
+    }
+}
+
+impl FlatbufferSerializable for i32 {
+    fn serialize(&self, builder: &mut FlatBufferBuilder) -> FbFunctionCallResultArgs {
+        FbFunctionCallResultArgs {
+            return_value: Some(
+                Fbhlint::create(builder, &FbhlintArgs { value: *self }).as_union_value(),
+            ),
+            return_value_type: FbReturnValue::hlint,
+        }
+    }
+}
+
+impl FlatbufferSerializable for i64 {
+    fn serialize(&self, builder: &mut FlatBufferBuilder) -> FbFunctionCallResultArgs {
+        FbFunctionCallResultArgs {
+            return_value: Some(
+                Fbhllong::create(builder, &FbhllongArgs { value: *self }).as_union_value(),
+            ),
+            return_value_type: FbReturnValue::hllong,
+        }
+    }
+}
+
+impl FlatbufferSerializable for u32 {
+    fn serialize(&self, builder: &mut FlatBufferBuilder) -> FbFunctionCallResultArgs {
+        FbFunctionCallResultArgs {
+            return_value: Some(
+                Fbhluint::create(builder, &FbhluintArgs { value: *self }).as_union_value(),
+            ),
+            return_value_type: FbReturnValue::hluint,
+        }
+    }
+}
+
+impl FlatbufferSerializable for u64 {
+    fn serialize(&self, builder: &mut FlatBufferBuilder) -> FbFunctionCallResultArgs {
+        FbFunctionCallResultArgs {
+            return_value: Some(
+                Fbhlulong::create(builder, &FbhlulongArgs { value: *self }).as_union_value(),
+            ),
+            return_value_type: FbReturnValue::hlulong,
+        }
+    }
+}
+
+impl FlatbufferSerializable for bool {
+    fn serialize(&self, builder: &mut FlatBufferBuilder) -> FbFunctionCallResultArgs {
+        FbFunctionCallResultArgs {
+            return_value: Some(
+                Fbhlbool::create(builder, &FbhlboolArgs { value: *self }).as_union_value(),
+            ),
+            return_value_type: FbReturnValue::hlbool,
+        }
+    }
 }

--- a/src/hyperlight_guest/src/host_function_call.rs
+++ b/src/hyperlight_guest/src/host_function_call.rs
@@ -17,13 +17,13 @@ limitations under the License.
 use alloc::string::ToString;
 use alloc::vec::Vec;
 use core::arch::global_asm;
+use hyperlight_common::flatbuffer_wrappers::util::get_flatbuffer_result;
 
 use hyperlight_common::flatbuffer_wrappers::function_call::{FunctionCall, FunctionCallType};
 use hyperlight_common::flatbuffer_wrappers::function_types::{
     ParameterValue, ReturnType, ReturnValue,
 };
 use hyperlight_common::flatbuffer_wrappers::guest_error::ErrorCode;
-use hyperlight_common::flatbuffer_wrappers::util::get_flatbuffer_result_from_int;
 use hyperlight_common::mem::RunMode;
 
 use crate::error::{HyperlightGuestError, Result};
@@ -195,7 +195,7 @@ pub fn print_output_as_guest_function(function_call: &FunctionCall) -> Result<Ve
             ReturnType::Int,
         )?;
         let res_i = get_host_value_return_as_int()?;
-        Ok(get_flatbuffer_result_from_int(res_i))
+        Ok(get_flatbuffer_result(res_i))
     } else {
         Err(HyperlightGuestError::new(
             ErrorCode::GuestError,

--- a/src/hyperlight_guest/src/host_function_call.rs
+++ b/src/hyperlight_guest/src/host_function_call.rs
@@ -14,16 +14,17 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+use alloc::format;
 use alloc::string::ToString;
 use alloc::vec::Vec;
 use core::arch::global_asm;
-use hyperlight_common::flatbuffer_wrappers::util::get_flatbuffer_result;
 
 use hyperlight_common::flatbuffer_wrappers::function_call::{FunctionCall, FunctionCallType};
 use hyperlight_common::flatbuffer_wrappers::function_types::{
     ParameterValue, ReturnType, ReturnValue,
 };
 use hyperlight_common::flatbuffer_wrappers::guest_error::ErrorCode;
+use hyperlight_common::flatbuffer_wrappers::util::get_flatbuffer_result;
 use hyperlight_common::mem::RunMode;
 
 use crate::error::{HyperlightGuestError, Result};
@@ -39,94 +40,20 @@ pub enum OutBAction {
     Abort = 102,
 }
 
-pub fn get_host_value_return_as_void() -> Result<()> {
+/// Get a return value from a host function call.
+/// This usually requires a host function to be called first using `call_host_function`.
+pub fn get_host_return_value<T: TryFrom<ReturnValue>>() -> Result<T> {
     let return_value = try_pop_shared_input_data_into::<ReturnValue>()
         .expect("Unable to deserialize a return value from host");
-    if let ReturnValue::Void = return_value {
-        Ok(())
-    } else {
-        Err(HyperlightGuestError::new(
+    T::try_from(return_value).map_err(|_| {
+        HyperlightGuestError::new(
             ErrorCode::GuestError,
-            "Host return value was not void as expected".to_string(),
-        ))
-    }
-}
-
-pub fn get_host_value_return_as_int() -> Result<i32> {
-    let return_value = try_pop_shared_input_data_into::<ReturnValue>()
-        .expect("Unable to deserialize return value from host");
-
-    // check that return value is an int and return
-    if let ReturnValue::Int(i) = return_value {
-        Ok(i)
-    } else {
-        Err(HyperlightGuestError::new(
-            ErrorCode::GuestError,
-            "Host return value was not an int as expected".to_string(),
-        ))
-    }
-}
-
-pub fn get_host_value_return_as_uint() -> Result<u32> {
-    let return_value = try_pop_shared_input_data_into::<ReturnValue>()
-        .expect("Unable to deserialize return value from host");
-
-    // check that return value is an int and return
-    if let ReturnValue::UInt(ui) = return_value {
-        Ok(ui)
-    } else {
-        Err(HyperlightGuestError::new(
-            ErrorCode::GuestError,
-            "Host return value was not a uint as expected".to_string(),
-        ))
-    }
-}
-
-pub fn get_host_value_return_as_long() -> Result<i64> {
-    let return_value = try_pop_shared_input_data_into::<ReturnValue>()
-        .expect("Unable to deserialize return value from host");
-
-    // check that return value is an int and return
-    if let ReturnValue::Long(l) = return_value {
-        Ok(l)
-    } else {
-        Err(HyperlightGuestError::new(
-            ErrorCode::GuestError,
-            "Host return value was not a long as expected".to_string(),
-        ))
-    }
-}
-
-pub fn get_host_value_return_as_ulong() -> Result<u64> {
-    let return_value = try_pop_shared_input_data_into::<ReturnValue>()
-        .expect("Unable to deserialize return value from host");
-
-    // check that return value is an int and return
-    if let ReturnValue::ULong(ul) = return_value {
-        Ok(ul)
-    } else {
-        Err(HyperlightGuestError::new(
-            ErrorCode::GuestError,
-            "Host return value was not a ulong as expected".to_string(),
-        ))
-    }
-}
-
-// TODO: Make this generic, return a Result<T, ErrorCode>
-
-pub fn get_host_value_return_as_vecbytes() -> Result<Vec<u8>> {
-    let return_value = try_pop_shared_input_data_into::<ReturnValue>()
-        .expect("Unable to deserialize return value from host");
-
-    // check that return value is an Vec<u8> and return
-    if let ReturnValue::VecBytes(v) = return_value {
-        Ok(v)
-    } else {
-        Err(HyperlightGuestError::new(
-            ErrorCode::GuestError,
-            "Host return value was not an VecBytes as expected".to_string(),
-        ))
-    }
+            format!(
+                "Host return value was not a {} as expected",
+                core::any::type_name::<T>()
+            ),
+        )
+    })
 }
 
 // TODO: Make this generic, return a Result<T, ErrorCode> this should allow callers to call this function and get the result type they expect
@@ -194,7 +121,7 @@ pub fn print_output_as_guest_function(function_call: &FunctionCall) -> Result<Ve
             Some(Vec::from(&[ParameterValue::String(message.to_string())])),
             ReturnType::Int,
         )?;
-        let res_i = get_host_value_return_as_int()?;
+        let res_i = get_host_return_value::<i32>()?;
         Ok(get_flatbuffer_result(res_i))
     } else {
         Err(HyperlightGuestError::new(

--- a/src/hyperlight_guest_capi/src/flatbuffer.rs
+++ b/src/hyperlight_guest_capi/src/flatbuffer.rs
@@ -1,13 +1,7 @@
 use alloc::boxed::Box;
 use core::ffi::{c_char, CStr};
 
-use hyperlight_common::flatbuffer_wrappers::util::{
-    get_flatbuffer_result_from_double, get_flatbuffer_result_from_float,
-    get_flatbuffer_result_from_int, get_flatbuffer_result_from_long,
-    get_flatbuffer_result_from_string, get_flatbuffer_result_from_uint,
-    get_flatbuffer_result_from_ulong, get_flatbuffer_result_from_vec,
-    get_flatbuffer_result_from_void,
-};
+use hyperlight_common::flatbuffer_wrappers::util::get_flatbuffer_result;
 use hyperlight_guest::host_function_call::{
     get_host_value_return_as_int, get_host_value_return_as_long, get_host_value_return_as_uint,
     get_host_value_return_as_ulong,
@@ -21,49 +15,49 @@ use crate::types::FfiVec;
 
 #[no_mangle]
 pub extern "C" fn hl_flatbuffer_result_from_Int(value: i32) -> Box<FfiVec> {
-    let vec = get_flatbuffer_result_from_int(value);
+    let vec = get_flatbuffer_result(value);
 
     Box::new(unsafe { FfiVec::from_vec(vec) })
 }
 
 #[no_mangle]
 pub extern "C" fn hl_flatbuffer_result_from_UInt(value: u32) -> Box<FfiVec> {
-    let vec = get_flatbuffer_result_from_uint(value);
+    let vec = get_flatbuffer_result(value);
 
     Box::new(unsafe { FfiVec::from_vec(vec) })
 }
 
 #[no_mangle]
 pub extern "C" fn hl_flatbuffer_result_from_Long(value: i64) -> Box<FfiVec> {
-    let vec = get_flatbuffer_result_from_long(value);
+    let vec = get_flatbuffer_result(value);
 
     Box::new(unsafe { FfiVec::from_vec(vec) })
 }
 
 #[no_mangle]
 pub extern "C" fn hl_flatbuffer_result_from_ULong(value: u64) -> Box<FfiVec> {
-    let vec = get_flatbuffer_result_from_ulong(value);
+    let vec = get_flatbuffer_result(value);
 
     Box::new(unsafe { FfiVec::from_vec(vec) })
 }
 
 #[no_mangle]
 pub extern "C" fn hl_flatbuffer_result_from_Float(value: f32) -> Box<FfiVec> {
-    let vec = get_flatbuffer_result_from_float(value);
+    let vec = get_flatbuffer_result(value);
 
     Box::new(unsafe { FfiVec::from_vec(vec) })
 }
 
 #[no_mangle]
 pub extern "C" fn hl_flatbuffer_result_from_Double(value: f64) -> Box<FfiVec> {
-    let vec = get_flatbuffer_result_from_double(value);
+    let vec = get_flatbuffer_result(value);
 
     Box::new(unsafe { FfiVec::from_vec(vec) })
 }
 
 #[no_mangle]
 pub extern "C" fn hl_flatbuffer_result_from_Void() -> Box<FfiVec> {
-    let vec = get_flatbuffer_result_from_void();
+    let vec = get_flatbuffer_result(());
 
     Box::new(unsafe { FfiVec::from_vec(vec) })
 }
@@ -71,7 +65,7 @@ pub extern "C" fn hl_flatbuffer_result_from_Void() -> Box<FfiVec> {
 #[no_mangle]
 pub extern "C" fn hl_flatbuffer_result_from_String(value: *const c_char) -> Box<FfiVec> {
     let str = unsafe { CStr::from_ptr(value) };
-    let vec = get_flatbuffer_result_from_string(str.to_string_lossy().as_ref());
+    let vec = get_flatbuffer_result(str.to_string_lossy().as_ref());
 
     Box::new(unsafe { FfiVec::from_vec(vec) })
 }
@@ -80,7 +74,7 @@ pub extern "C" fn hl_flatbuffer_result_from_String(value: *const c_char) -> Box<
 pub extern "C" fn hl_flatbuffer_result_from_Bytes(data: *const u8, len: usize) -> Box<FfiVec> {
     let slice = unsafe { core::slice::from_raw_parts(data, len) };
 
-    let vec = get_flatbuffer_result_from_vec(slice);
+    let vec = get_flatbuffer_result(slice);
 
     Box::new(unsafe { FfiVec::from_vec(vec) })
 }

--- a/src/hyperlight_guest_capi/src/flatbuffer.rs
+++ b/src/hyperlight_guest_capi/src/flatbuffer.rs
@@ -2,10 +2,7 @@ use alloc::boxed::Box;
 use core::ffi::{c_char, CStr};
 
 use hyperlight_common::flatbuffer_wrappers::util::get_flatbuffer_result;
-use hyperlight_guest::host_function_call::{
-    get_host_value_return_as_int, get_host_value_return_as_long, get_host_value_return_as_uint,
-    get_host_value_return_as_ulong,
-};
+use hyperlight_guest::host_function_call::get_host_return_value;
 
 use crate::types::FfiVec;
 
@@ -83,23 +80,23 @@ pub extern "C" fn hl_flatbuffer_result_from_Bytes(data: *const u8, len: usize) -
 
 #[no_mangle]
 pub extern "C" fn hl_get_host_return_value_as_Int() -> i32 {
-    get_host_value_return_as_int().expect("Unable to get host return value as int")
+    get_host_return_value().expect("Unable to get host return value as int")
 }
 
 #[no_mangle]
 pub extern "C" fn hl_get_host_return_value_as_UInt() -> u32 {
-    get_host_value_return_as_uint().expect("Unable to get host return value as uint")
+    get_host_return_value().expect("Unable to get host return value as uint")
 }
 
 // the same for long, ulong
 #[no_mangle]
 pub extern "C" fn hl_get_host_return_value_as_Long() -> i64 {
-    get_host_value_return_as_long().expect("Unable to get host return value as long")
+    get_host_return_value().expect("Unable to get host return value as long")
 }
 
 #[no_mangle]
 pub extern "C" fn hl_get_host_return_value_as_ULong() -> u64 {
-    get_host_value_return_as_ulong().expect("Unable to get host return value as ulong")
+    get_host_return_value().expect("Unable to get host return value as ulong")
 }
 
 // TODO add bool, float, double, string, vecbytes

--- a/src/tests/rust_guests/callbackguest/src/main.rs
+++ b/src/tests/rust_guests/callbackguest/src/main.rs
@@ -30,9 +30,7 @@ use hyperlight_common::flatbuffer_wrappers::function_types::{
 };
 use hyperlight_common::flatbuffer_wrappers::guest_error::ErrorCode;
 use hyperlight_common::flatbuffer_wrappers::guest_log_level::LogLevel;
-use hyperlight_common::flatbuffer_wrappers::util::{
-    get_flatbuffer_result_from_int, get_flatbuffer_result_from_void,
-};
+use hyperlight_common::flatbuffer_wrappers::util::get_flatbuffer_result;
 use hyperlight_guest::error::{HyperlightGuestError, Result};
 use hyperlight_guest::guest_function_definition::GuestFunctionDefinition;
 use hyperlight_guest::guest_function_register::register_function;
@@ -55,7 +53,7 @@ fn send_message_to_host_method(
 
     let result = get_host_value_return_as_int()?;
 
-    Ok(get_flatbuffer_result_from_int(result))
+    Ok(get_flatbuffer_result(result))
 }
 
 fn guest_function(function_call: &FunctionCall) -> Result<Vec<u8>> {
@@ -111,7 +109,7 @@ fn guest_function4() -> Result<Vec<u8>> {
         ReturnType::Void,
     )?;
 
-    Ok(get_flatbuffer_result_from_void())
+    Ok(get_flatbuffer_result(()))
 }
 
 fn guest_log_message(function_call: &FunctionCall) -> Result<Vec<u8>> {
@@ -138,7 +136,7 @@ fn guest_log_message(function_call: &FunctionCall) -> Result<Vec<u8>> {
             line!(),
         );
 
-        Ok(get_flatbuffer_result_from_int(message.len() as i32))
+        Ok(get_flatbuffer_result(message.len() as i32))
     } else {
         return Err(HyperlightGuestError::new(
             ErrorCode::GuestFunctionParameterTypeMismatch,
@@ -160,7 +158,7 @@ fn call_error_method(function_call: &FunctionCall) -> Result<Vec<u8>> {
 
 fn call_host_spin() -> Result<Vec<u8>> {
     call_host_function("Spin", None, ReturnType::Void)?;
-    Ok(get_flatbuffer_result_from_void())
+    Ok(get_flatbuffer_result(()))
 }
 
 #[no_mangle]

--- a/src/tests/rust_guests/callbackguest/src/main.rs
+++ b/src/tests/rust_guests/callbackguest/src/main.rs
@@ -35,7 +35,7 @@ use hyperlight_guest::error::{HyperlightGuestError, Result};
 use hyperlight_guest::guest_function_definition::GuestFunctionDefinition;
 use hyperlight_guest::guest_function_register::register_function;
 use hyperlight_guest::host_function_call::{
-    call_host_function, get_host_value_return_as_int, print_output_as_guest_function,
+    call_host_function, get_host_return_value, print_output_as_guest_function,
 };
 use hyperlight_guest::logging::log_message;
 
@@ -51,7 +51,7 @@ fn send_message_to_host_method(
         ReturnType::Int,
     )?;
 
-    let result = get_host_value_return_as_int()?;
+    let result = get_host_return_value::<i32>()?;
 
     Ok(get_flatbuffer_result(result))
 }

--- a/src/tests/rust_guests/simpleguest/src/main.rs
+++ b/src/tests/rust_guests/simpleguest/src/main.rs
@@ -45,9 +45,7 @@ use hyperlight_guest::entrypoint::{abort_with_code, abort_with_code_and_message}
 use hyperlight_guest::error::{HyperlightGuestError, Result};
 use hyperlight_guest::guest_function_definition::GuestFunctionDefinition;
 use hyperlight_guest::guest_function_register::register_function;
-use hyperlight_guest::host_function_call::{
-    call_host_function, get_host_value_return_as_int, get_host_value_return_as_ulong,
-};
+use hyperlight_guest::host_function_call::{call_host_function, get_host_return_value};
 use hyperlight_guest::memory::malloc;
 use hyperlight_guest::{logging, MIN_STACK_ADDRESS};
 use log::{error, LevelFilter};
@@ -94,7 +92,7 @@ fn print_output(message: &str) -> Result<Vec<u8>> {
         Some(Vec::from(&[ParameterValue::String(message.to_string())])),
         ReturnType::Int,
     )?;
-    let result = get_host_value_return_as_int()?;
+    let result = get_host_return_value::<i32>()?;
     Ok(get_flatbuffer_result(result))
 }
 
@@ -681,7 +679,7 @@ fn violate_seccomp_filters(function_call: &FunctionCall) -> Result<Vec<u8>> {
     if function_call.parameters.is_none() {
         call_host_function("MakeGetpidSyscall", None, ReturnType::ULong)?;
 
-        let res = get_host_value_return_as_ulong()?;
+        let res = get_host_return_value::<u64>()?;
 
         Ok(get_flatbuffer_result(res))
     } else {
@@ -703,7 +701,7 @@ fn add(function_call: &FunctionCall) -> Result<Vec<u8>> {
             ReturnType::Int,
         )?;
 
-        let res = get_host_value_return_as_int()?;
+        let res = get_host_return_value::<i32>()?;
 
         Ok(get_flatbuffer_result(res))
     } else {
@@ -1130,7 +1128,7 @@ pub fn guest_dispatch_function(function_call: FunctionCall) -> Result<Vec<u8>> {
         Some(Vec::from(&[ParameterValue::String(message.to_string())])),
         ReturnType::Int,
     )?;
-    let result = get_host_value_return_as_int()?;
+    let result = get_host_return_value::<i32>()?;
     let function_name = function_call.function_name.clone();
     let param_len = function_call.parameters.clone().unwrap_or_default().len();
     let call_type = function_call.function_call_type().clone();

--- a/src/tests/rust_guests/simpleguest/src/main.rs
+++ b/src/tests/rust_guests/simpleguest/src/main.rs
@@ -39,12 +39,7 @@ use hyperlight_common::flatbuffer_wrappers::function_types::{
 };
 use hyperlight_common::flatbuffer_wrappers::guest_error::ErrorCode;
 use hyperlight_common::flatbuffer_wrappers::guest_log_level::LogLevel;
-use hyperlight_common::flatbuffer_wrappers::util::{
-    get_flatbuffer_result_from_double, get_flatbuffer_result_from_float,
-    get_flatbuffer_result_from_int, get_flatbuffer_result_from_string,
-    get_flatbuffer_result_from_ulong, get_flatbuffer_result_from_vec,
-    get_flatbuffer_result_from_void,
-};
+use hyperlight_common::flatbuffer_wrappers::util::get_flatbuffer_result;
 use hyperlight_common::mem::PAGE_SIZE;
 use hyperlight_guest::entrypoint::{abort_with_code, abort_with_code_and_message};
 use hyperlight_guest::error::{HyperlightGuestError, Result};
@@ -67,13 +62,13 @@ fn set_static() -> Result<Vec<u8>> {
         for i in 0..length {
             BIGARRAY[i] = i as i32;
         }
-        Ok(get_flatbuffer_result_from_int(length as i32))
+        Ok(get_flatbuffer_result(length as i32))
     }
 }
 
 fn echo_double(function_call: &FunctionCall) -> Result<Vec<u8>> {
     if let ParameterValue::Double(value) = function_call.parameters.clone().unwrap()[0].clone() {
-        Ok(get_flatbuffer_result_from_double(value))
+        Ok(get_flatbuffer_result(value))
     } else {
         Err(HyperlightGuestError::new(
             ErrorCode::GuestFunctionParameterTypeMismatch,
@@ -84,7 +79,7 @@ fn echo_double(function_call: &FunctionCall) -> Result<Vec<u8>> {
 
 fn echo_float(function_call: &FunctionCall) -> Result<Vec<u8>> {
     if let ParameterValue::Float(value) = function_call.parameters.clone().unwrap()[0].clone() {
-        Ok(get_flatbuffer_result_from_float(value))
+        Ok(get_flatbuffer_result(value))
     } else {
         Err(HyperlightGuestError::new(
             ErrorCode::GuestFunctionParameterTypeMismatch,
@@ -100,7 +95,7 @@ fn print_output(message: &str) -> Result<Vec<u8>> {
         ReturnType::Int,
     )?;
     let result = get_host_value_return_as_int()?;
-    Ok(get_flatbuffer_result_from_int(result))
+    Ok(get_flatbuffer_result(result))
 }
 
 fn simple_print_output(function_call: &FunctionCall) -> Result<Vec<u8>> {
@@ -118,7 +113,7 @@ fn set_byte_array_to_zero(function_call: &FunctionCall) -> Result<Vec<u8>> {
     if let ParameterValue::VecBytes(mut vec) = function_call.parameters.clone().unwrap()[0].clone()
     {
         vec.fill(0);
-        Ok(get_flatbuffer_result_from_vec(&vec))
+        Ok(get_flatbuffer_result(&*vec))
     } else {
         Err(HyperlightGuestError::new(
             ErrorCode::GuestFunctionParameterTypeMismatch,
@@ -420,7 +415,7 @@ fn buffer_overrun(function_call: &FunctionCall) -> Result<Vec<u8>> {
 
         let result = (17i32).saturating_sub(length as i32);
 
-        Ok(get_flatbuffer_result_from_int(result))
+        Ok(get_flatbuffer_result(result))
     } else {
         Err(HyperlightGuestError::new(
             ErrorCode::GuestFunctionParameterTypeMismatch,
@@ -442,7 +437,7 @@ fn infinite_recursion(a: &FunctionCall) -> Result<Vec<u8>> {
 fn stack_overflow(function_call: &FunctionCall) -> Result<Vec<u8>> {
     if let ParameterValue::Int(i) = function_call.parameters.clone().unwrap()[0].clone() {
         loop_stack_overflow(i);
-        Ok(get_flatbuffer_result_from_int(i))
+        Ok(get_flatbuffer_result(i))
     } else {
         Err(HyperlightGuestError::new(
             ErrorCode::GuestFunctionParameterTypeMismatch,
@@ -460,12 +455,12 @@ fn loop_stack_overflow(i: i32) {
 
 fn large_var(_: &FunctionCall) -> Result<Vec<u8>> {
     let _buffer = black_box([0u8; (DEFAULT_GUEST_STACK_SIZE + 1) as usize]);
-    Ok(get_flatbuffer_result_from_int(DEFAULT_GUEST_STACK_SIZE + 1))
+    Ok(get_flatbuffer_result(DEFAULT_GUEST_STACK_SIZE + 1))
 }
 
 fn small_var(_: &FunctionCall) -> Result<Vec<u8>> {
     let _buffer = black_box([0u8; 1024]);
-    Ok(get_flatbuffer_result_from_int(1024))
+    Ok(get_flatbuffer_result(1024))
 }
 
 fn call_malloc(function_call: &FunctionCall) -> Result<Vec<u8>> {
@@ -473,7 +468,7 @@ fn call_malloc(function_call: &FunctionCall) -> Result<Vec<u8>> {
         // will panic if OOM, and we need blackbox to avoid optimizing away this test
         let buffer = Vec::<u8>::with_capacity(size as usize);
         black_box(buffer);
-        Ok(get_flatbuffer_result_from_int(size))
+        Ok(get_flatbuffer_result(size))
     } else {
         Err(HyperlightGuestError::new(
             ErrorCode::GuestFunctionParameterTypeMismatch,
@@ -493,7 +488,7 @@ fn malloc_and_free(function_call: &FunctionCall) -> Result<Vec<u8>> {
         allocated_buffer.resize(alloc_length as usize, 0);
         drop(allocated_buffer);
 
-        Ok(get_flatbuffer_result_from_int(size))
+        Ok(get_flatbuffer_result(size))
     } else {
         Err(HyperlightGuestError::new(
             ErrorCode::GuestFunctionParameterTypeMismatch,
@@ -504,7 +499,7 @@ fn malloc_and_free(function_call: &FunctionCall) -> Result<Vec<u8>> {
 
 fn echo(function_call: &FunctionCall) -> Result<Vec<u8>> {
     if let ParameterValue::String(value) = function_call.parameters.clone().unwrap()[0].clone() {
-        Ok(get_flatbuffer_result_from_string(&value))
+        Ok(get_flatbuffer_result(&*value))
     } else {
         Err(HyperlightGuestError::new(
             ErrorCode::GuestFunctionParameterTypeMismatch,
@@ -515,7 +510,7 @@ fn echo(function_call: &FunctionCall) -> Result<Vec<u8>> {
 
 fn get_size_prefixed_buffer(function_call: &FunctionCall) -> Result<Vec<u8>> {
     if let ParameterValue::VecBytes(data) = function_call.parameters.clone().unwrap()[0].clone() {
-        Ok(get_flatbuffer_result_from_vec(&data))
+        Ok(get_flatbuffer_result(&*data))
     } else {
         Err(HyperlightGuestError::new(
             ErrorCode::GuestFunctionParameterTypeMismatch,
@@ -530,14 +525,14 @@ fn spin(_: &FunctionCall) -> Result<Vec<u8>> {
     }
 
     #[allow(unreachable_code)]
-    Ok(get_flatbuffer_result_from_void())
+    Ok(get_flatbuffer_result(()))
 }
 
 fn test_abort(function_call: &FunctionCall) -> Result<Vec<u8>> {
     if let ParameterValue::Int(code) = function_call.parameters.clone().unwrap()[0].clone() {
         abort_with_code(code);
     }
-    Ok(get_flatbuffer_result_from_void())
+    Ok(get_flatbuffer_result(()))
 }
 
 fn test_abort_with_code_and_message(function_call: &FunctionCall) -> Result<Vec<u8>> {
@@ -549,14 +544,14 @@ fn test_abort_with_code_and_message(function_call: &FunctionCall) -> Result<Vec<
             abort_with_code_and_message(code, message.as_ptr() as *const c_char);
         }
     }
-    Ok(get_flatbuffer_result_from_void())
+    Ok(get_flatbuffer_result(()))
 }
 
 fn test_guest_panic(function_call: &FunctionCall) -> Result<Vec<u8>> {
     if let ParameterValue::String(message) = function_call.parameters.clone().unwrap()[0].clone() {
         panic!("{}", message);
     }
-    Ok(get_flatbuffer_result_from_void())
+    Ok(get_flatbuffer_result(()))
 }
 
 fn test_write_raw_ptr(function_call: &FunctionCall) -> Result<Vec<u8>> {
@@ -577,9 +572,9 @@ fn test_write_raw_ptr(function_call: &FunctionCall) -> Result<Vec<u8>> {
             // print_output(format!("writing to {:#x}\n", addr).as_str()).unwrap();
             write_volatile(addr as *mut u8, 0u8);
         }
-        return Ok(get_flatbuffer_result_from_string("success"));
+        return Ok(get_flatbuffer_result("success"));
     }
-    Ok(get_flatbuffer_result_from_string("fail"))
+    Ok(get_flatbuffer_result("fail"))
 }
 
 fn execute_on_stack(_function_call: &FunctionCall) -> Result<Vec<u8>> {
@@ -588,7 +583,7 @@ fn execute_on_stack(_function_call: &FunctionCall) -> Result<Vec<u8>> {
         let stack_fn: fn() = core::mem::transmute(&mut noop as *mut u8);
         stack_fn();
     };
-    Ok(get_flatbuffer_result_from_string("fail"))
+    Ok(get_flatbuffer_result("fail"))
 }
 
 fn execute_on_heap(_function_call: &FunctionCall) -> Result<Vec<u8>> {
@@ -600,13 +595,13 @@ fn execute_on_heap(_function_call: &FunctionCall) -> Result<Vec<u8>> {
         black_box(heap_fn); // avoid optimization when running in release mode
     }
     // will only reach this point if heap is executable
-    Ok(get_flatbuffer_result_from_string("fail"))
+    Ok(get_flatbuffer_result("fail"))
 }
 
 fn test_rust_malloc(function_call: &FunctionCall) -> Result<Vec<u8>> {
     if let ParameterValue::Int(code) = function_call.parameters.clone().unwrap()[0].clone() {
         let ptr = unsafe { malloc(code as usize) };
-        Ok(get_flatbuffer_result_from_int(ptr as i32))
+        Ok(get_flatbuffer_result(ptr as i32))
     } else {
         Err(HyperlightGuestError::new(
             ErrorCode::GuestFunctionParameterTypeMismatch,
@@ -628,7 +623,7 @@ fn log_message(function_call: &FunctionCall) -> Result<Vec<u8>> {
                 // was passed LevelFilter::Off, do nothing
             }
         }
-        Ok(get_flatbuffer_result_from_void())
+        Ok(get_flatbuffer_result(()))
     } else {
         Err(HyperlightGuestError::new(
             ErrorCode::GuestFunctionParameterTypeMismatch,
@@ -652,7 +647,7 @@ fn add_to_static(function_call: &FunctionCall) -> Result<Vec<u8>> {
             COUNTER += i;
             COUNTER
         };
-        Ok(get_flatbuffer_result_from_int(res))
+        Ok(get_flatbuffer_result(res))
     } else {
         Err(HyperlightGuestError::new(
             ErrorCode::GuestFunctionParameterTypeMismatch,
@@ -663,7 +658,7 @@ fn add_to_static(function_call: &FunctionCall) -> Result<Vec<u8>> {
 
 fn get_static(function_call: &FunctionCall) -> Result<Vec<u8>> {
     if function_call.parameters.is_none() {
-        Ok(get_flatbuffer_result_from_int(unsafe { COUNTER }))
+        Ok(get_flatbuffer_result(unsafe { COUNTER }))
     } else {
         Err(HyperlightGuestError::new(
             ErrorCode::GuestFunctionParameterTypeMismatch,
@@ -688,7 +683,7 @@ fn violate_seccomp_filters(function_call: &FunctionCall) -> Result<Vec<u8>> {
 
         let res = get_host_value_return_as_ulong()?;
 
-        Ok(get_flatbuffer_result_from_ulong(res))
+        Ok(get_flatbuffer_result(res))
     } else {
         Err(HyperlightGuestError::new(
             ErrorCode::GuestFunctionParameterTypeMismatch,
@@ -710,7 +705,7 @@ fn add(function_call: &FunctionCall) -> Result<Vec<u8>> {
 
         let res = get_host_value_return_as_int()?;
 
-        Ok(get_flatbuffer_result_from_int(res))
+        Ok(get_flatbuffer_result(res))
     } else {
         Err(HyperlightGuestError::new(
             ErrorCode::GuestFunctionParameterTypeMismatch,
@@ -1151,5 +1146,5 @@ pub fn guest_dispatch_function(function_call: FunctionCall) -> Result<Vec<u8>> {
         ));
     }
 
-    Ok(get_flatbuffer_result_from_int(99))
+    Ok(get_flatbuffer_result(99))
 }

--- a/src/tests/rust_guests/simpleguest/src/main.rs
+++ b/src/tests/rust_guests/simpleguest/src/main.rs
@@ -634,7 +634,7 @@ fn trigger_exception(_: &FunctionCall) -> Result<Vec<u8>> {
     unsafe {
         core::arch::asm!("ud2");
     } // trigger an undefined instruction exception
-    Ok(get_flatbuffer_result_from_void())
+    Ok(get_flatbuffer_result(()))
 }
 
 static mut COUNTER: i32 = 0;


### PR DESCRIPTION
Makes `get_flatbuffer_result` and `get_host_value_return_as` generic, see 2 commits.