### PR TITLE
Fix mshv crates version to 0.3.2

### DIFF
--- a/src/hyperlight_host/Cargo.toml
+++ b/src/hyperlight_host/Cargo.toml
@@ -78,8 +78,8 @@ kvm-bindings = { version = "0.11", features = ["fam-wrappers"], optional = true 
 kvm-ioctls = { version = "0.20", optional = true }
 mshv-bindings2 = { package="mshv-bindings", version = "=0.2.1", optional = true }
 mshv-ioctls2 = { package="mshv-ioctls",  version = "=0.2.1", optional = true}
-mshv-bindings3 = { package="mshv-bindings", version = "0.3.2", optional = true }
-mshv-ioctls3 = { package="mshv-ioctls",  version = "0.3.2", optional = true}
+mshv-bindings3 = { package="mshv-bindings", version = "=0.3.2", optional = true }
+mshv-ioctls3 = { package="mshv-ioctls",  version = "=0.3.2", optional = true}
 
 [dev-dependencies]
 uuid = { version = "1.13.2", features = ["v4"] }


### PR DESCRIPTION
Fixes `mshv` crates to version 0.3.2 as version 0.3.3 causes failures in CI.