### PR TITLE
devcontainer: install gdb and vscode ext for debugging

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -14,6 +14,7 @@ RUN apt-get update \
         build-essential \
         cmake \
         curl \
+        gdb \
         git \
         gnupg \
         gnuplot \

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -23,6 +23,7 @@
   "customizations": {
     "vscode": {
       "extensions": [
+        "ms-vscode.cpptools-extension-pack",
         "ms-vscode.cmake-tools",
         "rust-lang.rust-analyzer",
         "vadimcn.vscode-lldb"


### PR DESCRIPTION
This installs `gdb`  and `C/C++ Extension pack` for a better experience debugging in a devcontainer either locally or in Github Codespaces.
Not having these installed means the user needs to do it every time the container gets started