### PR TITLE
Fix CI rust toolchain

### DIFF
--- a/.github/workflows/dep_rust.yml
+++ b/.github/workflows/dep_rust.yml
@@ -48,9 +48,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # For rust-fmt 
+      - name: Set up nightly rust 
+        uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: rustfmt
+
       - uses: hyperlight-dev/ci-setup-workflow@v1.2.0
         with:
-          rust-toolchain: "nightly"
+          rust-toolchain: "1.81.0" 
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
Rustup 1.28.0 stopped implicitly downloading the toolchain in `rust-toolchain.toml` by default (if it is not already installed when you install specific targets), so we'll need to add it explicitly. Note that it's important we download nightly first, and then 1.81, so that 1.81 is left as the default.