### PR TITLE
Update fuzzing test to check for simpleguest in same directory as executable

### DIFF
--- a/.github/workflows/Fuzzing.yml
+++ b/.github/workflows/Fuzzing.yml
@@ -13,6 +13,6 @@ jobs:
   fuzzing:
     uses: ./.github/workflows/dep_fuzzing.yml
     with:
-      targets: '["host_print", "guest_call", "host_call"]' # Pass as a JSON array
+      targets: '["fuzz_host_print", "fuzz_guest_call", "fuzz_host_call"]' # Pass as a JSON array
       max_total_time: 18000 # 5 hours in seconds
     secrets: inherit

--- a/.github/workflows/ValidatePullRequest.yml
+++ b/.github/workflows/ValidatePullRequest.yml
@@ -54,7 +54,7 @@ jobs:
       - docs-pr
     uses: ./.github/workflows/dep_fuzzing.yml
     with:
-      targets: '["host_print", "guest_call", "host_call"]' # Pass as a JSON array
+      targets: '["fuzz_host_print", "fuzz_guest_call", "fuzz_host_call"]' # Pass as a JSON array
       max_total_time: 300 # 5 minutes in seconds
       docs_only: ${{needs.docs-pr.outputs.docs-only}}
     secrets: inherit

--- a/Justfile
+++ b/Justfile
@@ -198,3 +198,10 @@ fuzz fuzz-target:
 # Fuzzes the given target. Stops after `max_time` seconds
 fuzz-timed fuzz-target max_time:
     cargo +nightly fuzz run {{ fuzz-target }} --release -- -max_total_time={{ max_time }}
+
+# Builds fuzzers for submission to external fuzzing services
+build-fuzzers: (build-fuzzer "fuzz_guest_call") (build-fuzzer "fuzz_host_call") (build-fuzzer "fuzz_host_print")
+
+# Builds the given fuzzer
+build-fuzzer fuzz-target:
+    cargo +nightly fuzz build {{ fuzz-target }} --release -s none

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -13,21 +13,21 @@ hyperlight-testing = { workspace = true }
 hyperlight-host = { workspace = true, default-features = true, features = ["fuzzing"]}
 
 [[bin]]
-name = "host_print"
+name = "fuzz_host_print"
 path = "fuzz_targets/host_print.rs"
 test = false
 doc = false
 bench = false
 
 [[bin]]
-name = "guest_call"
+name = "fuzz_guest_call"
 path = "fuzz_targets/guest_call.rs"
 test = false
 doc = false
 bench = false
 
 [[bin]]
-name = "host_call"
+name = "fuzz_host_call"
 path = "fuzz_targets/host_call.rs"
 test = false
 doc = false

--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -6,7 +6,7 @@ You can run the fuzzers with:
 ```sh
 just fuzz <fuzz_target>
 ```
-which evaluates to the following command `cargo +nightly fuzz run host_print --release`. We use the release profile to make sure the release-optimized guest is used. The default fuzz profile which is release+debugsymbols would cause our debug guests to be loaded, since we currently determine which test guest to load based on whether debug symbols are present.
+which evaluates to the following command `cargo +nightly fuzz run fuzz_host_print --release`. We use the release profile to make sure the release-optimized guest is used. The default fuzz profile which is release+debugsymbols would cause our debug guests to be loaded, since we currently determine which test guest to load based on whether debug symbols are present.
 
 As per Microsoft's Offensive Research & Security Engineering (MORSE) team, all host exposed functions that receive or interact with guest data must be continuously fuzzed for, at least, 500 million fuzz test cases without any crashes. Because `cargo-fuzz` doesn't support setting a maximum number of iterations; instead, we use the `--max_total_time` flag to set a maximum time to run the fuzzer. We have a GitHub action (acting like a CRON job) that runs the fuzzers for 24 hours every week.
 

--- a/fuzz/fuzz_targets/guest_call.rs
+++ b/fuzz/fuzz_targets/guest_call.rs
@@ -23,7 +23,7 @@ use hyperlight_host::sandbox::uninitialized::GuestBinary;
 use hyperlight_host::sandbox_state::sandbox::EvolvableSandbox;
 use hyperlight_host::sandbox_state::transition::Noop;
 use hyperlight_host::{MultiUseSandbox, UninitializedSandbox};
-use hyperlight_testing::simple_guest_as_string;
+use hyperlight_testing::simple_guest_for_fuzzing_as_string;
 use libfuzzer_sys::fuzz_target;
 static SANDBOX: OnceLock<Mutex<MultiUseSandbox>> = OnceLock::new();
 
@@ -31,8 +31,9 @@ static SANDBOX: OnceLock<Mutex<MultiUseSandbox>> = OnceLock::new();
 // For fuzzing efficiency, we create one Sandbox and reuse it for all fuzzing iterations.
 fuzz_target!(
     init: {
+
         let u_sbox = UninitializedSandbox::new(
-            GuestBinary::FilePath(simple_guest_as_string().expect("Guest Binary Missing")),
+            GuestBinary::FilePath(simple_guest_for_fuzzing_as_string().expect("Guest Binary Missing")),
             None,
             None,
             None,

--- a/fuzz/fuzz_targets/host_call.rs
+++ b/fuzz/fuzz_targets/host_call.rs
@@ -24,7 +24,7 @@ use hyperlight_host::sandbox::SandboxConfiguration;
 use hyperlight_host::sandbox_state::sandbox::EvolvableSandbox;
 use hyperlight_host::sandbox_state::transition::Noop;
 use hyperlight_host::{HyperlightError, MultiUseSandbox, UninitializedSandbox};
-use hyperlight_testing::simple_guest_as_string;
+use hyperlight_testing::simple_guest_for_fuzzing_as_string;
 use libfuzzer_sys::fuzz_target;
 static SANDBOX: OnceLock<Mutex<MultiUseSandbox>> = OnceLock::new();
 
@@ -33,7 +33,7 @@ static SANDBOX: OnceLock<Mutex<MultiUseSandbox>> = OnceLock::new();
 fuzz_target!(
     init: {
         let u_sbox = UninitializedSandbox::new(
-            GuestBinary::FilePath(simple_guest_as_string().expect("Guest Binary Missing")),
+            GuestBinary::FilePath(simple_guest_for_fuzzing_as_string().expect("Guest Binary Missing")),
             None,
             None,
             None,

--- a/fuzz/fuzz_targets/host_print.rs
+++ b/fuzz/fuzz_targets/host_print.rs
@@ -7,7 +7,7 @@ use hyperlight_host::sandbox::uninitialized::GuestBinary;
 use hyperlight_host::sandbox_state::sandbox::EvolvableSandbox;
 use hyperlight_host::sandbox_state::transition::Noop;
 use hyperlight_host::{MultiUseSandbox, UninitializedSandbox};
-use hyperlight_testing::simple_guest_as_string;
+use hyperlight_testing::simple_guest_for_fuzzing_as_string;
 use libfuzzer_sys::{fuzz_target, Corpus};
 
 static SANDBOX: OnceLock<Mutex<MultiUseSandbox>> = OnceLock::new();
@@ -19,7 +19,7 @@ static SANDBOX: OnceLock<Mutex<MultiUseSandbox>> = OnceLock::new();
 fuzz_target!(
     init: {
         let u_sbox = UninitializedSandbox::new(
-            GuestBinary::FilePath(simple_guest_as_string().expect("Guest Binary Missing")),
+            GuestBinary::FilePath(simple_guest_for_fuzzing_as_string().expect("Guest Binary Missing")),
             None,
             None,
             None,


### PR DESCRIPTION
Some fuzzing scenarios we want to report require building a fuzzing binary with `cargo fuzz build` and submitting that binary to a fuzzing harness. In those instances we also want to submit a guestbinary and this PR makes sure that the guestbinary can be found in the same directory as the fuzzing binary.