### PR TITLE
Review/remove and prevent unintentional use of `expect/assert*/panic/unwrap` in hyperlight_host and hyperlght_common

### DIFF
--- a/src/hyperlight_common/src/clippy.toml
+++ b/src/hyperlight_common/src/clippy.toml
@@ -1,0 +1,7 @@
+disallowed-macros = [
+    { path = "std::assert", reason = "no asserts in release builds" },
+    { path = "std::assert_eq", reason = "no asserts in release builds" },
+    { path = "std::assert_ne", reason = "no asserts in release builds" },
+    { path = "std::assert_true", reason = "no asserts in release builds" },
+    { path = "std::assert_false", reason = "no asserts in release builds" },
+]

--- a/src/hyperlight_common/src/lib.rs
+++ b/src/hyperlight_common/src/lib.rs
@@ -14,6 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+#![cfg_attr(not(any(test, debug_assertions)), warn(clippy::panic))]
+#![cfg_attr(not(any(test, debug_assertions)), warn(clippy::expect_used))]
+#![cfg_attr(not(any(test, debug_assertions)), warn(clippy::unwrap_used))]
 // We use Arbitrary during fuzzing, which requires std
 #![cfg_attr(not(feature = "fuzzing"), no_std)]
 
@@ -26,6 +29,7 @@ pub mod flatbuffer_wrappers;
     dead_code,
     unused_imports,
     clippy::all,
+    clippy::unwrap_used,
     unsafe_op_in_unsafe_fn,
     non_camel_case_types
 )]

--- a/src/hyperlight_host/src/clippy.toml
+++ b/src/hyperlight_host/src/clippy.toml
@@ -1,0 +1,7 @@
+disallowed-macros = [
+    { path = "std::assert", reason = "no asserts in release builds" },
+    { path = "std::assert_eq", reason = "no asserts in release builds" },
+    { path = "std::assert_ne", reason = "no asserts in release builds" },
+    { path = "std::assert_true", reason = "no asserts in release builds" },
+    { path = "std::assert_false", reason = "no asserts in release builds" },
+]

--- a/src/hyperlight_host/src/hypervisor/windows_hypervisor_platform.rs
+++ b/src/hyperlight_host/src/hypervisor/windows_hypervisor_platform.rs
@@ -165,6 +165,8 @@ pub unsafe fn try_load_whv_map_gpa_range2() -> Result<WHvMapGpaRange2Func> {
         return Err(new_error!("{}", e));
     }
 
+    #[allow(clippy::unwrap_used)]
+    // We know this will succeed because we just checked for an error above
     let library = library.unwrap();
 
     let address = unsafe { GetProcAddress(library, s!("WHvMapGpaRange2")) };

--- a/src/hyperlight_host/src/lib.rs
+++ b/src/hyperlight_host/src/lib.rs
@@ -17,6 +17,7 @@ limitations under the License.
 //! This crate contains an SDK that is used to execute specially-
 // compiled binaries within a very lightweight hypervisor environment.
 
+#![cfg_attr(not(any(test, debug_assertions)), warn(clippy::panic))]
 #![cfg_attr(not(any(test, debug_assertions)), warn(clippy::expect_used))]
 
 use std::sync::Once;

--- a/src/hyperlight_host/src/lib.rs
+++ b/src/hyperlight_host/src/lib.rs
@@ -17,6 +17,8 @@ limitations under the License.
 //! This crate contains an SDK that is used to execute specially-
 // compiled binaries within a very lightweight hypervisor environment.
 
+#![cfg_attr(not(any(test, debug_assertions)), warn(clippy::expect_used))]
+
 use std::sync::Once;
 
 use log::info;

--- a/src/hyperlight_host/src/lib.rs
+++ b/src/hyperlight_host/src/lib.rs
@@ -20,6 +20,7 @@ limitations under the License.
 #![cfg_attr(not(any(test, debug_assertions)), warn(clippy::panic))]
 #![cfg_attr(not(any(test, debug_assertions)), warn(clippy::expect_used))]
 #![cfg_attr(not(any(test, debug_assertions)), warn(clippy::unwrap_used))]
+#![cfg_attr(any(test, debug_assertions), allow(clippy::disallowed_macros))]
 
 use std::sync::Once;
 

--- a/src/hyperlight_host/src/lib.rs
+++ b/src/hyperlight_host/src/lib.rs
@@ -19,6 +19,7 @@ limitations under the License.
 
 #![cfg_attr(not(any(test, debug_assertions)), warn(clippy::panic))]
 #![cfg_attr(not(any(test, debug_assertions)), warn(clippy::expect_used))]
+#![cfg_attr(not(any(test, debug_assertions)), warn(clippy::unwrap_used))]
 
 use std::sync::Once;
 

--- a/src/hyperlight_host/src/mem/elf.rs
+++ b/src/hyperlight_host/src/mem/elf.rs
@@ -52,20 +52,22 @@ impl ElfInfo {
         self.entry
     }
     pub(crate) fn get_base_va(&self) -> u64 {
+        #[allow(clippy::unwrap_used)] // guaranteed not to panic because of the check in new()
         let min_phdr = self
             .phdrs
             .iter()
             .find(|phdr| phdr.p_type == PT_LOAD)
-            .unwrap(); // guaranteed not to panic because of the check in new()
+            .unwrap();
         min_phdr.p_vaddr
     }
     pub(crate) fn get_va_size(&self) -> usize {
+        #[allow(clippy::unwrap_used)] // guaranteed not to panic because of the check in new()
         let max_phdr = self
             .phdrs
             .iter()
             .rev()
             .find(|phdr| phdr.p_type == PT_LOAD)
-            .unwrap(); // guaranteed not to panic because of the check in new()
+            .unwrap();
         (max_phdr.p_vaddr + max_phdr.p_memsz - self.get_base_va()) as usize
     }
     pub(crate) fn load_at(&self, load_addr: usize, target: &mut [u8]) -> Result<()> {

--- a/src/hyperlight_host/src/mem/loaded_lib.rs
+++ b/src/hyperlight_host/src/mem/loaded_lib.rs
@@ -54,7 +54,7 @@ impl LoadedLib {
         // arc reference is dropped, but before the destructor is executed. This however
         // is ok, as it means that the old library is not going to be used anymore and
         // we can use it instead.
-        let mut lock = LOADED_LIB.lock().unwrap();
+        let mut lock = LOADED_LIB.lock()?;
         if lock.upgrade().is_some() {
             // An owning copy of the loaded library still exists somewhere,
             // we can't load a new library yet

--- a/src/hyperlight_host/src/mem/memory_region.rs
+++ b/src/hyperlight_host/src/mem/memory_region.rs
@@ -202,6 +202,8 @@ impl MemoryRegionVecBuilder {
             return guest_end - self.guest_base_phys_addr;
         }
 
+        #[allow(clippy::unwrap_used)]
+        // we know this is safe because we check if the regions are empty above
         let last_region = self.regions.last().unwrap();
         let new_region = MemoryRegion {
             guest_region: last_region.guest_region.end..last_region.guest_region.end + size,

--- a/src/hyperlight_host/src/mem/mgr.rs
+++ b/src/hyperlight_host/src/mem/mgr.rs
@@ -300,6 +300,7 @@ where
         if last.is_none() {
             log_then_return!(NoMemorySnapshot);
         }
+        #[allow(clippy::unwrap_used)] // We know that last is not None because we checked it above
         let snapshot = last.unwrap();
         snapshot.restore_from_snapshot(&mut self.shared_mem)
     }

--- a/src/hyperlight_host/src/mem/pe/base_relocations.rs
+++ b/src/hyperlight_host/src/mem/pe/base_relocations.rs
@@ -91,6 +91,7 @@ impl<'a> Iterator for BaseRelocations<'a> {
         let word = u16::from_le_bytes(block);
 
         // Shift the word over so that we are only reading a number from the first (most significant) 4 bits
+        #[allow(clippy::unwrap_used)] // this is safe as we are only reading 4 bits from a u16
         let typ = u8::try_from(word >> 12).unwrap();
 
         // Set the first 4 bits to 0 so that we only use the lower 12 bits for the location of the RVA in the PE file

--- a/src/hyperlight_host/src/mem/pe/base_relocations.rs
+++ b/src/hyperlight_host/src/mem/pe/base_relocations.rs
@@ -132,9 +132,10 @@ pub(super) fn get_base_relocations(
         // Process each block of relocations until we have processed the expected amount of relocation data
         while size_processed < table_size {
             // Read the header for the block, which is the same format as a DataDirectory so I'm reusing its parse function
-            let block_header =
-                goblin::pe::data_directories::DataDirectory::parse(payload, &mut next_block_offset)
-                    .expect("oops");
+            let block_header = goblin::pe::data_directories::DataDirectory::parse(
+                payload,
+                &mut next_block_offset,
+            )?;
             // All relocation blocks in a page contain offsets against this address
             let page_virtual_address = block_header.virtual_address;
 

--- a/src/hyperlight_host/src/mem/shared_mem.rs
+++ b/src/hyperlight_host/src/mem/shared_mem.rs
@@ -328,10 +328,13 @@ impl ExclusiveSharedMemory {
             .checked_add(2 * PAGE_SIZE_USIZE) // guard page around the memory
             .ok_or_else(|| new_error!("Memory required for sandbox exceeded usize::MAX"))?;
 
-        assert!(
-            total_size % PAGE_SIZE_USIZE == 0,
-            "shared memory must be a multiple of 4096"
-        );
+        if total_size % PAGE_SIZE_USIZE != 0 {
+            return Err(new_error!(
+                "shared memory must be a multiple of {}",
+                PAGE_SIZE_USIZE
+            ));
+        }
+
         // usize and isize are guaranteed to be the same size, and
         // isize::MAX should be positive, so this cast should be safe.
         if total_size > isize::MAX as usize {

--- a/src/hyperlight_host/src/mem/shared_mem.rs
+++ b/src/hyperlight_host/src/mem/shared_mem.rs
@@ -885,7 +885,7 @@ impl HostSharedMemory {
         buffer_size: usize,
         data: &[u8],
     ) -> Result<()> {
-        let stack_pointer_rel = self.read::<u64>(buffer_start_offset).unwrap() as usize;
+        let stack_pointer_rel = self.read::<u64>(buffer_start_offset)? as usize;
         let buffer_size_u64: u64 = buffer_size.try_into()?;
 
         if stack_pointer_rel > buffer_size || stack_pointer_rel < 8 {
@@ -953,7 +953,7 @@ impl HostSharedMemory {
 
         // go back 8 bytes to get offset to element on top of stack
         let last_element_offset_rel: usize =
-            self.read::<u64>(last_element_offset_abs - 8).unwrap() as usize;
+            self.read::<u64>(last_element_offset_abs - 8)? as usize;
 
         // make it absolute
         let last_element_offset_abs = last_element_offset_rel + buffer_start_offset;

--- a/src/hyperlight_host/src/metrics/int_gauge_vec.rs
+++ b/src/hyperlight_host/src/metrics/int_gauge_vec.rs
@@ -16,7 +16,7 @@ limitations under the License.
 
 use prometheus::core::{AtomicI64, GenericGaugeVec};
 use prometheus::register_int_gauge_vec_with_registry;
-use tracing::{instrument, Span};
+use tracing::{error, instrument, Span};
 
 use super::{
     get_metric_opts, get_metrics_registry, GetHyperlightMetric, HyperlightMetric,
@@ -44,50 +44,53 @@ impl IntGaugeVec {
     /// Increments a gauge by 1
     #[instrument(skip_all, parent = Span::current(), level= "Trace")]
     pub fn inc(&self, label_vals: &[&str]) {
-        self.gauge
-            .get_metric_with_label_values(label_vals)
-            .unwrap()
-            .inc();
+        match self.gauge.get_metric_with_label_values(label_vals) {
+            Ok(gauge) => gauge.inc(),
+            Err(e) => error!("Failed to get metric with label values: {}", e),
+        }
     }
     /// Decrements a gauge by 1
     #[instrument(skip_all, parent = Span::current(), level= "Trace")]
     pub fn dec(&self, label_vals: &[&str]) {
-        self.gauge
-            .get_metric_with_label_values(label_vals)
-            .unwrap()
-            .dec();
+        match self.gauge.get_metric_with_label_values(label_vals) {
+            Ok(gauge) => gauge.dec(),
+            Err(e) => error!("Failed to get metric with label values: {}", e),
+        }
     }
     /// Gets the value of a gauge
     #[instrument(skip_all, parent = Span::current(), level= "Trace")]
     pub fn get(&self, label_vals: &[&str]) -> i64 {
-        self.gauge
-            .get_metric_with_label_values(label_vals)
-            .unwrap()
-            .get()
+        match self.gauge.get_metric_with_label_values(label_vals) {
+            Ok(gauge) => gauge.get(),
+            Err(e) => {
+                error!("Failed to get metric with label values: {}", e);
+                0
+            }
+        }
     }
     /// Resets a gauge
     #[instrument(skip_all, parent = Span::current(), level= "Trace")]
     pub fn set(&self, label_vals: &[&str], val: i64) {
-        self.gauge
-            .get_metric_with_label_values(label_vals)
-            .unwrap()
-            .set(val);
+        match self.gauge.get_metric_with_label_values(label_vals) {
+            Ok(gauge) => gauge.set(val),
+            Err(e) => error!("Failed to get metric with label values: {}", e),
+        }
     }
     /// Adds a value to a gauge
     #[instrument(skip_all, parent = Span::current(), level= "Trace")]
     pub fn add(&self, label_vals: &[&str], val: i64) {
-        self.gauge
-            .get_metric_with_label_values(label_vals)
-            .unwrap()
-            .add(val);
+        match self.gauge.get_metric_with_label_values(label_vals) {
+            Ok(gauge) => gauge.add(val),
+            Err(e) => error!("Failed to get metric with label values: {}", e),
+        }
     }
     /// Subtracts a value from a gauge
     #[instrument(skip_all, parent = Span::current(), level= "Trace")]
     pub fn sub(&self, label_vals: &[&str], val: i64) {
-        self.gauge
-            .get_metric_with_label_values(label_vals)
-            .unwrap()
-            .sub(val);
+        match self.gauge.get_metric_with_label_values(label_vals) {
+            Ok(gauge) => gauge.sub(val),
+            Err(e) => error!("Failed to get metric with label values: {}", e),
+        }
     }
 }
 

--- a/src/hyperlight_host/src/metrics/mod.rs
+++ b/src/hyperlight_host/src/metrics/mod.rs
@@ -259,6 +259,7 @@ fn get_histogram_opts(name: &str, help: &str, buckets: Vec<f64>) -> HistogramOpt
     opts.buckets(buckets)
 }
 
+#[allow(clippy::disallowed_macros)]
 /// Provides functionality to help with testing Hyperlight Metrics
 pub mod tests {
     use std::collections::HashSet;

--- a/src/hyperlight_host/src/sandbox/outb.rs
+++ b/src/hyperlight_host/src/sandbox/outb.rs
@@ -137,7 +137,7 @@ fn handle_outb_impl(
         }
         OutBAction::Abort => {
             let guest_error = ErrorCode::from(byte);
-            let panic_context = mem_mgr.as_mut().read_guest_panic_context_data().unwrap();
+            let panic_context = mem_mgr.as_mut().read_guest_panic_context_data()?;
             // trim off trailing \0 bytes if they exist
             let index_opt = panic_context.iter().position(|&x| x == 0x00);
             let trimmed = match index_opt {

--- a/src/hyperlight_host/src/sandbox/uninitialized_evolve.rs
+++ b/src/hyperlight_host/src/sandbox/uninitialized_evolve.rs
@@ -76,7 +76,9 @@ where
 
         {
             let dispatch_function_addr = hshm.as_ref().get_pointer_to_dispatch_function()?;
-            assert_ne!(dispatch_function_addr, 0);
+            if dispatch_function_addr == 0 {
+                return Err(new_error!("Dispatch function address is null"));
+            }
             hv_handler.set_dispatch_function_addr(RawPtr::from(dispatch_function_addr))?;
         }
 

--- a/src/hyperlight_host/src/sandbox_state/sandbox.rs
+++ b/src/hyperlight_host/src/sandbox_state/sandbox.rs
@@ -15,12 +15,11 @@ limitations under the License.
 */
 
 use std::fmt::Debug;
-use std::panic;
 
 use tracing::{instrument, Span};
 
 use super::transition::TransitionMetadata;
-use crate::Result;
+use crate::{new_error, Result};
 
 /// The minimal functionality of a Hyperlight sandbox. Most of the types
 /// and operations within this crate require `Sandbox` implementations.
@@ -48,7 +47,9 @@ pub trait Sandbox: Sized + Debug {
     // The default implementation is provided so that types that implement Sandbox (e.g. JSSandbox) but do not need to implement this trait do not need to provide an implementation
     #[instrument(skip_all, parent = Span::current(), level= "Trace")]
     fn check_stack_guard(&self) -> Result<bool> {
-        panic!("check_stack_guard not implemented for this type");
+        Err(new_error!(
+            "check_stack_guard not implemented for this type"
+        ))
     }
 }
 

--- a/src/hyperlight_host/src/seccomp/guest.rs
+++ b/src/hyperlight_host/src/seccomp/guest.rs
@@ -89,7 +89,7 @@ pub(crate) fn get_seccomp_filter_for_host_function_worker_thread(
         allowed_syscalls.into_iter().collect(),
         SeccompAction::Trap,  // non-match syscall will kill the offending thread
         SeccompAction::Allow, // match syscall will be allowed
-        std::env::consts::ARCH.try_into().unwrap(),
+        std::env::consts::ARCH.try_into()?,
     )
     .and_then(|filter| filter.try_into())?)
 }


### PR DESCRIPTION
This PR:

Adds a clippy lints to check for use of expect, panic and unwrap in hyperlight-host for non test/non dev code in hyperlight_host and hyperlight_common
Removes all uses of expect in non test/dev code in hyperlight-host.
Removes all uses of panic in non test/dev code in hyperlight-host.
Removes all uses of unwrap in non test/dev code in hyperlight-host.

Adds a clippy.toml file to hyperlight_host/src and hyperlight_common/src to prevent the use of assert* using disallowed_macros lint
Disables the disallowed_macros lint for test and dev code

Fixes #320 

