### PR TITLE
Gdb support for mshv guests

### DIFF
--- a/.github/workflows/dep_rust.yml
+++ b/.github/workflows/dep_rust.yml
@@ -124,11 +124,11 @@ jobs:
         run: just run-rust-examples-linux ${{ matrix.config }} ${{ matrix.hypervisor == 'mshv3' && 'mshv3' || ''}}
 
       - name: Run Rust Gdb tests - linux
-        if: runner.os == 'Linux' && matrix.hypervisor == 'kvm'
+        if: runner.os == 'Linux'
         env:
           CARGO_TERM_COLOR: always
           RUST_LOG: debug
-        run: just test-rust-gdb-debugging ${{ matrix.config }}
+        run: just test-rust-gdb-debugging ${{ matrix.config }} ${{ matrix.hypervisor == 'mshv3' && 'mshv3' || ''}}
 
       ### Benchmarks ###
       - name: Install github-cli (Linux mariner)

--- a/Justfile
+++ b/Justfile
@@ -117,9 +117,9 @@ test-rust-feature-compilation-fail target=default-target:
     {{ if os() == "linux" { "! cargo check -p hyperlight-host --no-default-features 2> /dev/null"} else { "" } }}
 
 # Test rust gdb debugging
-test-rust-gdb-debugging target=default-target: (build-rust target)
-    {{ set-trace-env-vars }} cargo test --profile={{ if target == "debug" { "dev" } else { target } }} --example guest-debugging --features gdb
-    {{ set-trace-env-vars }} cargo test --profile={{ if target == "debug" { "dev" } else { target } }} --features gdb -- test_gdb
+test-rust-gdb-debugging target=default-target features="": (build-rust target)
+    {{ set-trace-env-vars }} cargo test --profile={{ if target == "debug" { "dev" } else { target } }} --example guest-debugging {{ if features =="" {'--features gdb'} else { "--features gdb," + features } }}
+    {{ set-trace-env-vars }} cargo test --profile={{ if target == "debug" { "dev" } else { target } }} {{ if features =="" {'--features gdb'} else { "--features gdb," + features } }} -- test_gdb
 
 test target=default-target: (test-rust target)
 

--- a/docs/debugging-hyperlight.md
+++ b/docs/debugging-hyperlight.md
@@ -42,3 +42,7 @@ cargo test --package hyperlight-host --test integration_test --features print_de
 To dump the details of the memory configuration, the virtual processors register state and the contents of the VM memory set the feature `crashdump` and run a debug build. This will result in a dump file being created in the temporary directory. The name and location of the dump file will be printed to the console and logged as an error message.
 
 There are no tools at this time to analyze the dump file, but it can be useful for debugging.
+
+## Debugging guests
+
+For more information on how to debug the Hyperlight guests check the following [link](./how-to-debug-a-hyperlight-guest.md).

--- a/docs/how-to-debug-a-hyperlight-guest.md
+++ b/docs/how-to-debug-a-hyperlight-guest.md
@@ -1,13 +1,13 @@
-# How to debug a Hyperlight **KVM** guest using gdb
+# How to debug a Hyperlight guest using gdb on Linux
 
-Hyperlight supports gdb debugging of a **KVM** guest running inside a Hyperlight sandbox.
-When Hyperlight is compiled with the `gdb` feature enabled, a Hyperlight KVM sandbox can be configured
+Hyperlight supports gdb debugging of a **KVM** or **MSHV** guest running inside a Hyperlight sandbox on Linux.
+When Hyperlight is compiled with the `gdb` feature enabled, a Hyperlight sandbox can be configured
 to start listening for a gdb connection.
 
 ## Supported features
 
-The Hyperlight `gdb` feature enables **KVM** guest debugging:
-   - an entry point breakpoint is automatically set for the guest to stop
+The Hyperlight `gdb` feature enables **KVM** and **MSHV** guest debugging to:
+   - stop at an entry point breakpoint which is automatically set by Hyperlight
    - add and remove HW breakpoints (maximum 4 set breakpoints at a time)
    - add and remove SW breakpoints
    - read and write registers
@@ -18,7 +18,7 @@ The Hyperlight `gdb` feature enables **KVM** guest debugging:
 ## Expected behavior
 
 Below is a list describing some cases of expected behavior from a gdb debug 
-session of a guest binary running inside a KVM Hyperlight sandbox.
+session of a guest binary running inside a Hyperlight sandbox on Linux.
 
 - when the `gdb` feature is enabled and a SandboxConfiguration is provided a
   debug port, the created sandbox will wait for a gdb client to connect on the
@@ -154,7 +154,7 @@ is sent over the communication channel to the hypervisor handler for the sandbox
 to resolve.
 
 Below is a sequence diagram that shows the interaction between the entities
-involved in the gdb debugging of a Hyperlight guest running inside a KVM sandbox.
+involved in the gdb debugging of a Hyperlight guest running inside a **KVM** or **MSHV** sandbox.
 
 ```
                                ┌───────────────────────────────────────────────────────────────────────────────────────────────┐

--- a/src/hyperlight_host/build.rs
+++ b/src/hyperlight_host/build.rs
@@ -89,7 +89,7 @@ fn main() -> Result<()> {
     // Essentially the kvm and mshv features are ignored on windows as long as you use #[cfg(kvm)] and not #[cfg(feature = "kvm")].
     // You should never use #[cfg(feature = "kvm")] or #[cfg(feature = "mshv")] in the codebase.
     cfg_aliases::cfg_aliases! {
-        gdb: { all(feature = "gdb", debug_assertions, feature = "kvm", target_os = "linux") },
+        gdb: { all(feature = "gdb", debug_assertions, any(feature = "kvm", feature = "mshv2", feature = "mshv3"), target_os = "linux") },
         kvm: { all(feature = "kvm", target_os = "linux") },
         mshv: { all(any(feature = "mshv2", feature = "mshv3"), target_os = "linux") },
         // inprocess feature is aliased with debug_assertions to make it only available in debug-builds.

--- a/src/hyperlight_host/examples/guest-debugging/main.rs
+++ b/src/hyperlight_host/examples/guest-debugging/main.rs
@@ -107,7 +107,7 @@ mod tests {
 
                 set pagination off
                 set logging file {out_file_path}
-                set logging enabled on
+                set logging on
 
                 break hyperlight_main
                     commands
@@ -118,7 +118,7 @@ mod tests {
 
                 continue
 
-                set logging enabled off
+                set logging off
                 quit
             "
             )
@@ -134,12 +134,17 @@ mod tests {
         write_cmds_file(&cmd_file_path, &out_file_path)
             .expect("Failed to write gdb commands to file");
 
+        #[cfg(mshv3)]
+        let features = "gdb,mshv3";
+        #[cfg(not(mshv3))]
+        let features = "gdb";
+
         let mut guest_child = Command::new("cargo")
             .arg("run")
             .arg("--example")
             .arg("guest-debugging")
             .arg("--features")
-            .arg("gdb")
+            .arg(features)
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .spawn()

--- a/src/hyperlight_host/src/hypervisor/gdb/event_loop.rs
+++ b/src/hyperlight_host/src/hypervisor/gdb/event_loop.rs
@@ -23,7 +23,7 @@ use libc::{pthread_kill, SIGRTMIN};
 use super::x86_64_target::HyperlightSandboxTarget;
 use super::{DebugResponse, GdbTargetError, VcpuStopReason};
 
-pub struct GdbBlockingEventLoop;
+struct GdbBlockingEventLoop;
 
 impl run_blocking::BlockingEventLoop for GdbBlockingEventLoop {
     type Connection = Box<dyn ConnectionExt<Error = std::io::Error>>;
@@ -115,7 +115,7 @@ impl run_blocking::BlockingEventLoop for GdbBlockingEventLoop {
     }
 }
 
-pub fn event_loop_thread(
+pub(crate) fn event_loop_thread(
     debugger: GdbStub<HyperlightSandboxTarget, Box<dyn ConnectionExt<Error = std::io::Error>>>,
     target: &mut HyperlightSandboxTarget,
 ) {

--- a/src/hyperlight_host/src/hypervisor/gdb/event_loop.rs
+++ b/src/hyperlight_host/src/hypervisor/gdb/event_loop.rs
@@ -16,8 +16,9 @@ limitations under the License.
 
 use gdbstub::common::Signal;
 use gdbstub::conn::ConnectionExt;
-use gdbstub::stub::run_blocking::{self, WaitForStopReasonError};
-use gdbstub::stub::{BaseStopReason, DisconnectReason, GdbStub, SingleThreadStopReason};
+use gdbstub::stub::{
+    run_blocking, BaseStopReason, DisconnectReason, GdbStub, SingleThreadStopReason,
+};
 use libc::{pthread_kill, SIGRTMIN};
 
 use super::x86_64_target::HyperlightSandboxTarget;
@@ -57,13 +58,10 @@ impl run_blocking::BlockingEventLoop for GdbBlockingEventLoop {
                             signal: Signal(SIGRTMIN() as u8),
                         },
                         VcpuStopReason::Unknown => {
-                            log::warn!("Unknown stop reason - resuming execution");
+                            log::warn!("Unknown stop reason received");
 
-                            target
-                                .resume_vcpu()
-                                .map_err(WaitForStopReasonError::Target)?;
-
-                            continue;
+                            // Marking as a SwBreak so the gdb inspect where/why it stopped
+                            BaseStopReason::SwBreak(())
                         }
                     };
 

--- a/src/hyperlight_host/src/hypervisor/gdb/kvm_debug.rs
+++ b/src/hyperlight_host/src/hypervisor/gdb/kvm_debug.rs
@@ -36,7 +36,7 @@ pub(crate) struct KvmDebug {
     /// Array of addresses for HW breakpoints
     hw_breakpoints: Vec<u64>,
     /// Saves the bytes modified to enable SW breakpoints
-    pub(crate) sw_breakpoints: HashMap<u64, [u8; SW_BP_SIZE]>,
+    sw_breakpoints: HashMap<u64, [u8; SW_BP_SIZE]>,
 
     /// Sent to KVM for enabling guest debug
     dbg_cfg: kvm_guest_debug,
@@ -140,6 +140,9 @@ impl GuestDebug for KvmDebug {
     fn is_hw_breakpoint(&self, addr: &u64) -> bool {
         self.hw_breakpoints.contains(addr)
     }
+    fn is_sw_breakpoint(&self, addr: &u64) -> bool {
+        self.sw_breakpoints.contains_key(addr)
+    }
     fn save_hw_breakpoint(&mut self, addr: &u64) -> bool {
         if self.hw_breakpoints.len() >= MAX_NO_OF_HW_BP {
             false
@@ -149,8 +152,14 @@ impl GuestDebug for KvmDebug {
             true
         }
     }
+    fn save_sw_breakpoint_data(&mut self, addr: u64, data: [u8; 1]) {
+        _ = self.sw_breakpoints.insert(addr, data);
+    }
     fn delete_hw_breakpoint(&mut self, addr: &u64) {
         self.hw_breakpoints.retain(|&a| a != *addr);
+    }
+    fn delete_sw_breakpoint_data(&mut self, addr: &u64) -> Option<[u8; 1]> {
+        self.sw_breakpoints.remove(addr)
     }
 
     fn read_regs(&self, vcpu_fd: &Self::Vcpu, regs: &mut X86_64Regs) -> Result<()> {

--- a/src/hyperlight_host/src/hypervisor/gdb/kvm_debug.rs
+++ b/src/hyperlight_host/src/hypervisor/gdb/kvm_debug.rs
@@ -1,0 +1,126 @@
+/*
+Copyright 2024 The Hyperlight Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use std::collections::HashMap;
+
+use kvm_bindings::{
+    kvm_guest_debug, KVM_GUESTDBG_ENABLE, KVM_GUESTDBG_SINGLESTEP, KVM_GUESTDBG_USE_HW_BP,
+    KVM_GUESTDBG_USE_SW_BP,
+};
+use kvm_ioctls::VcpuFd;
+
+use super::*;
+use crate::{new_error, Result};
+
+/// KVM Debug struct
+/// This struct is used to abstract the internal details of the kvm
+/// guest debugging settings
+#[derive(Default)]
+pub(crate) struct KvmDebug {
+    /// vCPU stepping state
+    pub(crate) single_step: bool,
+
+    /// Array of addresses for HW breakpoints
+    pub(crate) hw_breakpoints: Vec<u64>,
+    /// Saves the bytes modified to enable SW breakpoints
+    pub(crate) sw_breakpoints: HashMap<u64, [u8; SW_BP_SIZE]>,
+
+    /// Sent to KVM for enabling guest debug
+    dbg_cfg: kvm_guest_debug,
+}
+
+impl KvmDebug {
+    const MAX_NO_OF_HW_BP: usize = 4;
+
+    pub(crate) fn new() -> Self {
+        let dbg = kvm_guest_debug {
+            control: KVM_GUESTDBG_ENABLE | KVM_GUESTDBG_USE_SW_BP,
+            ..Default::default()
+        };
+
+        Self {
+            single_step: false,
+            hw_breakpoints: vec![],
+            sw_breakpoints: HashMap::new(),
+            dbg_cfg: dbg,
+        }
+    }
+
+    /// This method sets the kvm debugreg fields to enable breakpoints at
+    /// specific addresses
+    ///
+    /// The first 4 debug registers are used to set the addresses
+    /// The 4th and 5th debug registers are obsolete and not used
+    /// The 7th debug register is used to enable the breakpoints
+    /// For more information see: DEBUG REGISTERS chapter in the architecture
+    /// manual
+    pub(crate) fn set_debug_config(&mut self, vcpu_fd: &VcpuFd, step: bool) -> Result<()> {
+        let addrs = &self.hw_breakpoints;
+
+        self.dbg_cfg.arch.debugreg = [0; 8];
+        for (k, addr) in addrs.iter().enumerate() {
+            self.dbg_cfg.arch.debugreg[k] = *addr;
+            self.dbg_cfg.arch.debugreg[7] |= 1 << (k * 2);
+        }
+
+        if !addrs.is_empty() {
+            self.dbg_cfg.control |= KVM_GUESTDBG_USE_HW_BP;
+        } else {
+            self.dbg_cfg.control &= !KVM_GUESTDBG_USE_HW_BP;
+        }
+
+        if step {
+            self.dbg_cfg.control |= KVM_GUESTDBG_SINGLESTEP;
+        } else {
+            self.dbg_cfg.control &= !KVM_GUESTDBG_SINGLESTEP;
+        }
+
+        log::debug!("Setting bp: {:?} cfg: {:?}", addrs, self.dbg_cfg);
+        vcpu_fd
+            .set_guest_debug(&self.dbg_cfg)
+            .map_err(|e| new_error!("Could not set guest debug: {:?}", e))?;
+
+        self.single_step = step;
+
+        Ok(())
+    }
+
+    /// Method that adds a breakpoint
+    pub(crate) fn add_breakpoint(&mut self, vcpu_fd: &VcpuFd, addr: u64) -> Result<bool> {
+        if self.hw_breakpoints.len() >= Self::MAX_NO_OF_HW_BP {
+            Ok(false)
+        } else if self.hw_breakpoints.contains(&addr) {
+            Ok(true)
+        } else {
+            self.hw_breakpoints.push(addr);
+            self.set_debug_config(vcpu_fd, self.single_step)?;
+
+            Ok(true)
+        }
+    }
+
+    /// Method that removes a breakpoint
+    pub(crate) fn remove_breakpoint(&mut self, vcpu_fd: &VcpuFd, addr: u64) -> Result<bool> {
+        if self.hw_breakpoints.contains(&addr) {
+            self.hw_breakpoints.retain(|&a| a != addr);
+            self.set_debug_config(vcpu_fd, self.single_step)?;
+
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+}

--- a/src/hyperlight_host/src/hypervisor/gdb/kvm_debug.rs
+++ b/src/hyperlight_host/src/hypervisor/gdb/kvm_debug.rs
@@ -22,8 +22,8 @@ use kvm_bindings::{
 };
 use kvm_ioctls::VcpuFd;
 
-use super::*;
-use crate::{new_error, Result};
+use super::{GuestDebug, MAX_NO_OF_HW_BP, SW_BP_SIZE};
+use crate::{new_error, HyperlightError, Result};
 
 /// KVM Debug struct
 /// This struct is used to abstract the internal details of the kvm
@@ -43,8 +43,6 @@ pub(crate) struct KvmDebug {
 }
 
 impl KvmDebug {
-    const MAX_NO_OF_HW_BP: usize = 4;
-
     pub(crate) fn new() -> Self {
         let dbg = kvm_guest_debug {
             control: KVM_GUESTDBG_ENABLE | KVM_GUESTDBG_USE_SW_BP,
@@ -67,7 +65,7 @@ impl KvmDebug {
     /// The 7th debug register is used to enable the breakpoints
     /// For more information see: DEBUG REGISTERS chapter in the architecture
     /// manual
-    pub(crate) fn set_debug_config(&mut self, vcpu_fd: &VcpuFd, step: bool) -> Result<()> {
+    fn set_debug_config(&mut self, vcpu_fd: &VcpuFd, step: bool) -> Result<()> {
         let addrs = &self.hw_breakpoints;
 
         self.dbg_cfg.arch.debugreg = [0; 8];
@@ -99,8 +97,8 @@ impl KvmDebug {
     }
 
     /// Method that adds a breakpoint
-    pub(crate) fn add_breakpoint(&mut self, vcpu_fd: &VcpuFd, addr: u64) -> Result<bool> {
-        if self.hw_breakpoints.len() >= Self::MAX_NO_OF_HW_BP {
+    fn add_breakpoint(&mut self, vcpu_fd: &VcpuFd, addr: u64) -> Result<bool> {
+        if self.hw_breakpoints.len() >= MAX_NO_OF_HW_BP {
             Ok(false)
         } else if self.hw_breakpoints.contains(&addr) {
             Ok(true)
@@ -113,7 +111,7 @@ impl KvmDebug {
     }
 
     /// Method that removes a breakpoint
-    pub(crate) fn remove_breakpoint(&mut self, vcpu_fd: &VcpuFd, addr: u64) -> Result<bool> {
+    fn remove_breakpoint(&mut self, vcpu_fd: &VcpuFd, addr: u64) -> Result<bool> {
         if self.hw_breakpoints.contains(&addr) {
             self.hw_breakpoints.retain(|&a| a != addr);
             self.set_debug_config(vcpu_fd, self.single_step)?;
@@ -122,5 +120,38 @@ impl KvmDebug {
         } else {
             Ok(false)
         }
+    }
+
+    /// Translates the guest address to physical address
+    fn translate_gva(&self, vcpu_fd: &VcpuFd, gva: u64) -> Result<u64> {
+        let tr = vcpu_fd
+            .translate_gva(gva)
+            .map_err(|_| HyperlightError::TranslateGuestAddress(gva))?;
+
+        if tr.valid == 0 {
+            Err(HyperlightError::TranslateGuestAddress(gva))
+        } else {
+            Ok(tr.physical_address)
+        }
+    }
+}
+
+impl GuestDebug for KvmDebug {
+    type Vcpu = VcpuFd;
+
+    fn add_hw_breakpoint(&mut self, vcpu_fd: &Self::Vcpu, addr: u64) -> Result<bool> {
+        let addr = self.translate_gva(vcpu_fd, addr)?;
+
+        self.add_breakpoint(vcpu_fd, addr)
+    }
+
+    fn remove_hw_breakpoint(&mut self, vcpu_fd: &Self::Vcpu, addr: u64) -> Result<bool> {
+        let addr = self.translate_gva(vcpu_fd, addr)?;
+
+        self.remove_breakpoint(vcpu_fd, addr)
+    }
+
+    fn set_single_step(&mut self, vcpu_fd: &Self::Vcpu, enable: bool) -> Result<()> {
+        self.set_debug_config(vcpu_fd, enable)
     }
 }

--- a/src/hyperlight_host/src/hypervisor/gdb/mod.rs
+++ b/src/hyperlight_host/src/hypervisor/gdb/mod.rs
@@ -50,6 +50,17 @@ const SW_BP: [u8; SW_BP_SIZE] = [SW_BP_OP];
 /// Maximum number of supported hardware breakpoints
 const MAX_NO_OF_HW_BP: usize = 4;
 
+/// Check page 19-4 Vol. 3B of Intel 64 and IA-32
+/// Architectures Software Developer's Manual
+/// Bit position of BS flag in DR6 debug register
+const DR6_BS_FLAG_POS: usize = 14;
+/// Bit mask of BS flag in DR6 debug register
+const DR6_BS_FLAG_MASK: u64 = 1 << DR6_BS_FLAG_POS;
+/// Bit position of HW breakpoints status in DR6 debug register
+const DR6_HW_BP_FLAGS_POS: usize = 0;
+/// Bit mask of HW breakpoints status in DR6 debug register
+const DR6_HW_BP_FLAGS_MASK: u64 = 0x0F << DR6_HW_BP_FLAGS_POS;
+
 #[derive(Debug, Error)]
 pub(crate) enum GdbTargetError {
     #[error("Error encountered while binding to address and port")]

--- a/src/hyperlight_host/src/hypervisor/gdb/mod.rs
+++ b/src/hyperlight_host/src/hypervisor/gdb/mod.rs
@@ -15,6 +15,8 @@ limitations under the License.
 */
 
 mod event_loop;
+#[cfg(kvm)]
+mod kvm_debug;
 mod x86_64_target;
 
 use std::io::{self, ErrorKind};
@@ -26,8 +28,19 @@ use event_loop::event_loop_thread;
 use gdbstub::conn::ConnectionExt;
 use gdbstub::stub::GdbStub;
 use gdbstub::target::TargetError;
+#[cfg(kvm)]
+pub(crate) use kvm_debug::KvmDebug;
 use thiserror::Error;
 use x86_64_target::HyperlightSandboxTarget;
+
+/// Software Breakpoint size in memory
+pub(crate) const SW_BP_SIZE: usize = 1;
+/// Software Breakpoint opcode - INT3
+/// Check page 7-28 Vol. 3A of Intel 64 and IA-32
+/// Architectures Software Developer's Manual
+const SW_BP_OP: u8 = 0xCC;
+/// Software Breakpoint written to memory
+pub(crate) const SW_BP: [u8; SW_BP_SIZE] = [SW_BP_OP];
 
 #[derive(Debug, Error)]
 pub(crate) enum GdbTargetError {

--- a/src/hyperlight_host/src/hypervisor/gdb/mod.rs
+++ b/src/hyperlight_host/src/hypervisor/gdb/mod.rs
@@ -41,6 +41,8 @@ pub(crate) const SW_BP_SIZE: usize = 1;
 const SW_BP_OP: u8 = 0xCC;
 /// Software Breakpoint written to memory
 pub(crate) const SW_BP: [u8; SW_BP_SIZE] = [SW_BP_OP];
+/// Maximum number of supported hardware breakpoints
+pub(crate) const MAX_NO_OF_HW_BP: usize = 4;
 
 #[derive(Debug, Error)]
 pub(crate) enum GdbTargetError {
@@ -146,6 +148,19 @@ pub(crate) enum DebugResponse {
     VcpuStopped(VcpuStopReason),
     WriteAddr,
     WriteRegisters,
+}
+
+/// This trait is used to define common debugging functionality for Hypervisors
+pub(crate) trait GuestDebug {
+    /// Type that wraps the vCPU functionality
+    type Vcpu;
+
+    /// Adds hardware breakpoint
+    fn add_hw_breakpoint(&mut self, vcpu_fd: &Self::Vcpu, addr: u64) -> crate::Result<bool>;
+    /// Removes hardware breakpoint
+    fn remove_hw_breakpoint(&mut self, vcpu_fd: &Self::Vcpu, addr: u64) -> crate::Result<bool>;
+    /// Enables or disables stepping and sets the vCPU debug configuration
+    fn set_single_step(&mut self, vcpu_fd: &Self::Vcpu, enable: bool) -> crate::Result<()>;
 }
 
 /// Debug communication channel that is used for sending a request type and

--- a/src/hyperlight_host/src/hypervisor/gdb/mod.rs
+++ b/src/hyperlight_host/src/hypervisor/gdb/mod.rs
@@ -157,10 +157,14 @@ pub(crate) trait GuestDebug {
 
     /// Adds hardware breakpoint
     fn add_hw_breakpoint(&mut self, vcpu_fd: &Self::Vcpu, addr: u64) -> crate::Result<bool>;
+    /// Read registers
+    fn read_regs(&self, vcpu_fd: &Self::Vcpu, regs: &mut X86_64Regs) -> crate::Result<()>;
     /// Removes hardware breakpoint
     fn remove_hw_breakpoint(&mut self, vcpu_fd: &Self::Vcpu, addr: u64) -> crate::Result<bool>;
     /// Enables or disables stepping and sets the vCPU debug configuration
     fn set_single_step(&mut self, vcpu_fd: &Self::Vcpu, enable: bool) -> crate::Result<()>;
+    /// Write registers
+    fn write_regs(&self, vcpu_fd: &Self::Vcpu, regs: &X86_64Regs) -> crate::Result<()>;
 }
 
 /// Debug communication channel that is used for sending a request type and

--- a/src/hyperlight_host/src/hypervisor/gdb/mod.rs
+++ b/src/hyperlight_host/src/hypervisor/gdb/mod.rs
@@ -17,6 +17,8 @@ limitations under the License.
 mod event_loop;
 #[cfg(kvm)]
 mod kvm_debug;
+#[cfg(mshv)]
+mod mshv_debug;
 mod x86_64_target;
 
 use std::io::{self, ErrorKind};
@@ -32,6 +34,8 @@ use gdbstub::target::TargetError;
 use hyperlight_common::mem::PAGE_SIZE;
 #[cfg(kvm)]
 pub(crate) use kvm_debug::KvmDebug;
+#[cfg(mshv)]
+pub(crate) use mshv_debug::MshvDebug;
 use thiserror::Error;
 use x86_64_target::HyperlightSandboxTarget;
 

--- a/src/hyperlight_host/src/hypervisor/gdb/mshv_debug.rs
+++ b/src/hyperlight_host/src/hypervisor/gdb/mshv_debug.rs
@@ -14,11 +14,255 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+#[cfg(mshv2)]
+extern crate mshv_bindings2 as mshv_bindings;
+#[cfg(mshv2)]
+extern crate mshv_ioctls2 as mshv_ioctls;
+
+#[cfg(mshv3)]
+extern crate mshv_bindings3 as mshv_bindings;
+#[cfg(mshv3)]
+extern crate mshv_ioctls3 as mshv_ioctls;
+
+use mshv_bindings::{
+    DebugRegisters, StandardRegisters, HV_TRANSLATE_GVA_VALIDATE_READ,
+    HV_TRANSLATE_GVA_VALIDATE_WRITE,
+};
+use mshv_ioctls::VcpuFd;
+
+use super::{
+    GuestDebug, VcpuStopReason, X86_64Regs, DR6_BS_FLAG_MASK, DR6_HW_BP_FLAGS_MASK, MAX_NO_OF_HW_BP,
+};
+use crate::{new_error, HyperlightError, Result};
+
 #[derive(Debug, Default)]
-pub(crate) struct MshvDebug {}
+pub(crate) struct MshvDebug {
+    /// vCPU stepping state
+    single_step: bool,
+
+    /// Array of addresses for HW breakpoints
+    hw_breakpoints: Vec<u64>,
+    /// Debug registers
+    dbg_cfg: DebugRegisters,
+}
 
 impl MshvDebug {
     pub(crate) fn new() -> Self {
-        Self {}
+        Self {
+            single_step: false,
+            hw_breakpoints: vec![],
+            dbg_cfg: DebugRegisters::default(),
+        }
+    }
+
+    /// Returns the instruction pointer from the stopped vCPU
+    fn get_instruction_pointer(&self, vcpu_fd: &VcpuFd) -> Result<u64> {
+        let regs = vcpu_fd
+            .get_regs()
+            .map_err(|e| new_error!("Could not retrieve registers from vCPU: {:?}", e))?;
+
+        Ok(regs.rip)
+    }
+
+    /// This method sets the vCPU debug register fields to enable breakpoints at
+    /// specific addresses
+    ///
+    /// The first 4 debug registers are used to set the addresses
+    /// The 4th and 5th debug registers are obsolete and not used
+    /// The 7th debug register is used to enable the breakpoints
+    /// For more information see: DEBUG REGISTERS chapter in the architecture
+    /// manual
+    fn set_debug_config(&mut self, vcpu_fd: &VcpuFd, step: bool) -> Result<()> {
+        let addrs = &self.hw_breakpoints;
+
+        let mut dbg_cfg = DebugRegisters::default();
+        for (k, addr) in addrs.iter().enumerate() {
+            match k {
+                0 => {
+                    dbg_cfg.dr0 = *addr;
+                }
+                1 => {
+                    dbg_cfg.dr1 = *addr;
+                }
+                2 => {
+                    dbg_cfg.dr2 = *addr;
+                }
+                3 => {
+                    dbg_cfg.dr3 = *addr;
+                }
+                _ => {
+                    Err(new_error!("Tried to set more than 4 HW breakpoints"))?;
+                }
+            }
+            dbg_cfg.dr7 |= 1 << (k * 2);
+        }
+
+        self.dbg_cfg = dbg_cfg;
+        vcpu_fd
+            .set_debug_regs(&self.dbg_cfg)
+            .map_err(|e| new_error!("Could not set guest debug: {:?}", e))?;
+
+        self.single_step = step;
+
+        let mut regs = vcpu_fd
+            .get_regs()
+            .map_err(|e| new_error!("Could not get registers: {:?}", e))?;
+
+        // Set TF Flag to enable Traps
+        if self.single_step {
+            regs.rflags |= 1 << 8;
+        } else {
+            regs.rflags &= !(1 << 8);
+        }
+
+        vcpu_fd
+            .set_regs(&regs)
+            .map_err(|e| new_error!("Could not set registers: {:?}", e))?;
+
+        Ok(())
+    }
+
+    /// Returns the vCPU stop reason
+    pub(crate) fn get_stop_reason(
+        &mut self,
+        vcpu_fd: &VcpuFd,
+        entrypoint: u64,
+    ) -> Result<VcpuStopReason> {
+        // MSHV does not provide info on the vCPU exits but the debug
+        // information can be retrieved from the DEBUG REGISTERS
+        let regs = vcpu_fd
+            .get_debug_regs()
+            .map_err(|e| new_error!("Cannot retrieve debug registers from vCPU: {}", e))?;
+
+        // DR6 register contains debug state related information
+        let debug_status = regs.dr6;
+
+        // If the BS flag in DR6 register is set, it means a single step
+        // instruction triggered the exit
+        // Check page 19-4 Vol. 3B of Intel 64 and IA-32
+        // Architectures Software Developer's Manual
+        if debug_status & DR6_BS_FLAG_MASK != 0 && self.single_step {
+            return Ok(VcpuStopReason::DoneStep);
+        }
+
+        let ip = self.get_instruction_pointer(vcpu_fd)?;
+        let gpa = self.translate_gva(vcpu_fd, ip)?;
+
+        // If any of the B0-B3 flags in DR6 register is set, it means a
+        // hardware breakpoint triggered the exit
+        // Check page 19-4 Vol. 3B of Intel 64 and IA-32
+        // Architectures Software Developer's Manual
+        if debug_status & DR6_HW_BP_FLAGS_MASK != 0 && self.hw_breakpoints.contains(&gpa) {
+            // In case the hw breakpoint is the entry point, remove it to
+            // avoid hanging here as gdb does not remove breakpoints it
+            // has not set.
+            // Gdb expects the target to be stopped when connected.
+            if gpa == entrypoint {
+                self.remove_hw_breakpoint(vcpu_fd, entrypoint)?;
+            }
+            return Ok(VcpuStopReason::HwBp);
+        }
+
+        Ok(VcpuStopReason::Unknown)
+    }
+}
+
+impl GuestDebug for MshvDebug {
+    type Vcpu = VcpuFd;
+
+    fn is_hw_breakpoint(&self, addr: &u64) -> bool {
+        self.hw_breakpoints.contains(addr)
+    }
+    fn is_sw_breakpoint(&self, _addr: &u64) -> bool {
+        unimplemented!()
+    }
+    fn save_hw_breakpoint(&mut self, addr: &u64) -> bool {
+        if self.hw_breakpoints.len() >= MAX_NO_OF_HW_BP {
+            false
+        } else {
+            self.hw_breakpoints.push(*addr);
+
+            true
+        }
+    }
+    fn save_sw_breakpoint_data(&mut self, _addr: u64, _data: [u8; 1]) {
+        unimplemented!()
+    }
+    fn delete_hw_breakpoint(&mut self, addr: &u64) {
+        self.hw_breakpoints.retain(|&a| a != *addr);
+    }
+    fn delete_sw_breakpoint_data(&mut self, _addr: &u64) -> Option<[u8; 1]> {
+        unimplemented!()
+    }
+
+    fn read_regs(&self, vcpu_fd: &Self::Vcpu, regs: &mut X86_64Regs) -> Result<()> {
+        log::debug!("Read registers");
+        let vcpu_regs = vcpu_fd
+            .get_regs()
+            .map_err(|e| new_error!("Could not read guest registers: {:?}", e))?;
+
+        regs.rax = vcpu_regs.rax;
+        regs.rbx = vcpu_regs.rbx;
+        regs.rcx = vcpu_regs.rcx;
+        regs.rdx = vcpu_regs.rdx;
+        regs.rsi = vcpu_regs.rsi;
+        regs.rdi = vcpu_regs.rdi;
+        regs.rbp = vcpu_regs.rbp;
+        regs.rsp = vcpu_regs.rsp;
+        regs.r8 = vcpu_regs.r8;
+        regs.r9 = vcpu_regs.r9;
+        regs.r10 = vcpu_regs.r10;
+        regs.r11 = vcpu_regs.r11;
+        regs.r12 = vcpu_regs.r12;
+        regs.r13 = vcpu_regs.r13;
+        regs.r14 = vcpu_regs.r14;
+        regs.r15 = vcpu_regs.r15;
+
+        regs.rip = vcpu_regs.rip;
+        regs.rflags = vcpu_regs.rflags;
+
+        Ok(())
+    }
+
+    fn set_single_step(&mut self, vcpu_fd: &Self::Vcpu, enable: bool) -> Result<()> {
+        self.set_debug_config(vcpu_fd, enable)
+    }
+
+    fn translate_gva(&self, vcpu_fd: &Self::Vcpu, gva: u64) -> Result<u64> {
+        let flags = (HV_TRANSLATE_GVA_VALIDATE_READ | HV_TRANSLATE_GVA_VALIDATE_WRITE) as u64;
+        let (addr, _) = vcpu_fd
+            .translate_gva(gva, flags)
+            .map_err(|_| HyperlightError::TranslateGuestAddress(gva))?;
+
+        Ok(addr)
+    }
+
+    fn write_regs(&self, vcpu_fd: &Self::Vcpu, regs: &X86_64Regs) -> Result<()> {
+        log::debug!("Write registers");
+        let new_regs = StandardRegisters {
+            rax: regs.rax,
+            rbx: regs.rbx,
+            rcx: regs.rcx,
+            rdx: regs.rdx,
+            rsi: regs.rsi,
+            rdi: regs.rdi,
+            rbp: regs.rbp,
+            rsp: regs.rsp,
+            r8: regs.r8,
+            r9: regs.r9,
+            r10: regs.r10,
+            r11: regs.r11,
+            r12: regs.r12,
+            r13: regs.r13,
+            r14: regs.r14,
+            r15: regs.r15,
+
+            rip: regs.rip,
+            rflags: regs.rflags,
+        };
+
+        vcpu_fd
+            .set_regs(&new_regs)
+            .map_err(|e| new_error!("Could not write guest registers: {:?}", e))
     }
 }

--- a/src/hyperlight_host/src/hypervisor/gdb/mshv_debug.rs
+++ b/src/hyperlight_host/src/hypervisor/gdb/mshv_debug.rs
@@ -1,0 +1,24 @@
+/*
+Copyright 2024 The Hyperlight Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#[derive(Debug, Default)]
+pub(crate) struct MshvDebug {}
+
+impl MshvDebug {
+    pub(crate) fn new() -> Self {
+        Self {}
+    }
+}

--- a/src/hyperlight_host/src/hypervisor/gdb/x86_64_target.rs
+++ b/src/hyperlight_host/src/hypervisor/gdb/x86_64_target.rs
@@ -32,7 +32,7 @@ use gdbstub_arch::x86::X86_64_SSE as GdbTargetArch;
 use super::{DebugCommChannel, DebugMsg, DebugResponse, GdbTargetError, X86_64Regs};
 
 /// Gdbstub target used by the gdbstub crate to provide GDB protocol implementation
-pub struct HyperlightSandboxTarget {
+pub(crate) struct HyperlightSandboxTarget {
     /// Hypervisor communication channels
     hyp_conn: DebugCommChannel<DebugMsg, DebugResponse>,
     /// Thread ID
@@ -40,7 +40,7 @@ pub struct HyperlightSandboxTarget {
 }
 
 impl HyperlightSandboxTarget {
-    pub fn new(hyp_conn: DebugCommChannel<DebugMsg, DebugResponse>, thread_id: u64) -> Self {
+    pub(crate) fn new(hyp_conn: DebugCommChannel<DebugMsg, DebugResponse>, thread_id: u64) -> Self {
         HyperlightSandboxTarget {
             hyp_conn,
             thread_id,
@@ -61,23 +61,23 @@ impl HyperlightSandboxTarget {
     }
 
     /// Returns the thread ID
-    pub fn get_thread_id(&self) -> u64 {
+    pub(crate) fn get_thread_id(&self) -> u64 {
         self.thread_id
     }
 
     /// Waits for a response over the communication channel
-    pub fn recv(&self) -> Result<DebugResponse, GdbTargetError> {
+    pub(crate) fn recv(&self) -> Result<DebugResponse, GdbTargetError> {
         self.hyp_conn.recv()
     }
 
     /// Non-Blocking check for a response over the communication channel
-    pub fn try_recv(&self) -> Result<DebugResponse, TryRecvError> {
+    pub(crate) fn try_recv(&self) -> Result<DebugResponse, TryRecvError> {
         self.hyp_conn.try_recv()
     }
 
     /// Sends an event to the Hypervisor that tells it to resume vCPU execution
     /// Note: The method waits for a confirmation message
-    pub fn resume_vcpu(&mut self) -> Result<(), GdbTargetError> {
+    pub(crate) fn resume_vcpu(&mut self) -> Result<(), GdbTargetError> {
         log::info!("Resume vCPU execution");
 
         match self.send_command(DebugMsg::Continue)? {
@@ -92,7 +92,7 @@ impl HyperlightSandboxTarget {
     /// Sends an event to the Hypervisor that tells it to disable debugging
     /// and continue executing
     /// Note: The method waits for a confirmation message
-    pub fn disable_debug(&mut self) -> Result<(), GdbTargetError> {
+    pub(crate) fn disable_debug(&mut self) -> Result<(), GdbTargetError> {
         log::info!("Disable debugging and resume execution");
 
         match self.send_command(DebugMsg::DisableDebug)? {

--- a/src/hyperlight_host/src/hypervisor/gdb/x86_64_target.rs
+++ b/src/hyperlight_host/src/hypervisor/gdb/x86_64_target.rs
@@ -70,11 +70,6 @@ impl HyperlightSandboxTarget {
         self.hyp_conn.recv()
     }
 
-    /// Non-Blocking check for a response over the communication channel
-    pub(crate) fn try_recv(&self) -> Result<DebugResponse, TryRecvError> {
-        self.hyp_conn.try_recv()
-    }
-
     /// Sends an event to the Hypervisor that tells it to resume vCPU execution
     /// Note: The method waits for a confirmation message
     pub(crate) fn resume_vcpu(&mut self) -> Result<(), GdbTargetError> {
@@ -87,6 +82,11 @@ impl HyperlightSandboxTarget {
                 Err(GdbTargetError::UnexpectedMessage)
             }
         }
+    }
+
+    /// Non-Blocking check for a response over the communication channel
+    pub(crate) fn try_recv(&self) -> Result<DebugResponse, TryRecvError> {
+        self.hyp_conn.try_recv()
     }
 
     /// Sends an event to the Hypervisor that tells it to disable debugging

--- a/src/hyperlight_host/src/hypervisor/hypervisor_handler.rs
+++ b/src/hyperlight_host/src/hypervisor/hypervisor_handler.rs
@@ -943,6 +943,8 @@ fn set_up_hypervisor_partition(
                     entrypoint_ptr,
                     rsp_ptr,
                     pml4_ptr,
+                    #[cfg(gdb)]
+                    gdb_conn,
                 )?;
                 Ok(Box::new(hv))
             }

--- a/src/hyperlight_host/src/hypervisor/kvm.rs
+++ b/src/hyperlight_host/src/hypervisor/kvm.rs
@@ -109,19 +109,40 @@ mod debug {
             if let Some(debug) = self.debug.as_mut() {
                 match req {
                     DebugMsg::AddHwBreakpoint(addr) => Ok(DebugResponse::AddHwBreakpoint(
-                        debug.add_hw_breakpoint(&self.vcpu_fd, addr).is_ok(),
+                        debug
+                            .add_hw_breakpoint(&self.vcpu_fd, addr)
+                            .map_err(|e| {
+                                log::error!("Failed to add hw breakpoint: {:?}", e);
+
+                                e
+                            })
+                            .is_ok(),
                     )),
                     DebugMsg::AddSwBreakpoint(addr) => Ok(DebugResponse::AddSwBreakpoint(
                         debug
                             .add_sw_breakpoint(&self.vcpu_fd, addr, dbg_mem_access_fn)
+                            .map_err(|e| {
+                                log::error!("Failed to add sw breakpoint: {:?}", e);
+
+                                e
+                            })
                             .is_ok(),
                     )),
                     DebugMsg::Continue => {
-                        debug.set_single_step(&self.vcpu_fd, false)?;
+                        debug.set_single_step(&self.vcpu_fd, false).map_err(|e| {
+                            log::error!("Failed to continue execution: {:?}", e);
+
+                            e
+                        })?;
+
                         Ok(DebugResponse::Continue)
                     }
                     DebugMsg::DisableDebug => {
-                        self.disable_debug()?;
+                        self.disable_debug().map_err(|e| {
+                            log::error!("Failed to disable debugging: {:?}", e);
+
+                            e
+                        })?;
 
                         Ok(DebugResponse::DisableDebug)
                     }
@@ -131,14 +152,25 @@ mod debug {
                             .map_err(|e| {
                                 new_error!("Error locking at {}:{}: {}", file!(), line!(), e)
                             })?
-                            .get_code_offset()?;
+                            .get_code_offset()
+                            .map_err(|e| {
+                                log::error!("Failed to get code offset: {:?}", e);
+
+                                e
+                            })?;
 
                         Ok(DebugResponse::GetCodeSectionOffset(offset as u64))
                     }
                     DebugMsg::ReadAddr(addr, len) => {
                         let mut data = vec![0u8; len];
 
-                        debug.read_addrs(&self.vcpu_fd, addr, &mut data, dbg_mem_access_fn)?;
+                        debug
+                            .read_addrs(&self.vcpu_fd, addr, &mut data, dbg_mem_access_fn)
+                            .map_err(|e| {
+                                log::error!("Failed to read from address: {:?}", e);
+
+                                e
+                            })?;
 
                         Ok(DebugResponse::ReadAddr(data))
                     }
@@ -147,27 +179,60 @@ mod debug {
 
                         debug
                             .read_regs(&self.vcpu_fd, &mut regs)
+                            .map_err(|e| {
+                                log::error!("Failed to read registers: {:?}", e);
+
+                                e
+                            })
                             .map(|_| DebugResponse::ReadRegisters(regs))
                     }
                     DebugMsg::RemoveHwBreakpoint(addr) => Ok(DebugResponse::RemoveHwBreakpoint(
-                        debug.remove_hw_breakpoint(&self.vcpu_fd, addr).is_ok(),
+                        debug
+                            .remove_hw_breakpoint(&self.vcpu_fd, addr)
+                            .map_err(|e| {
+                                log::error!("Failed to remove hw breakpoint: {:?}", e);
+
+                                e
+                            })
+                            .is_ok(),
                     )),
                     DebugMsg::RemoveSwBreakpoint(addr) => Ok(DebugResponse::RemoveSwBreakpoint(
                         debug
                             .remove_sw_breakpoint(&self.vcpu_fd, addr, dbg_mem_access_fn)
+                            .map_err(|e| {
+                                log::error!("Failed to remove sw breakpoint: {:?}", e);
+
+                                e
+                            })
                             .is_ok(),
                     )),
                     DebugMsg::Step => {
-                        debug.set_single_step(&self.vcpu_fd, true)?;
+                        debug.set_single_step(&self.vcpu_fd, true).map_err(|e| {
+                            log::error!("Failed to enable step instruction: {:?}", e);
+
+                            e
+                        })?;
+
                         Ok(DebugResponse::Step)
                     }
                     DebugMsg::WriteAddr(addr, data) => {
-                        debug.write_addrs(&self.vcpu_fd, addr, &data, dbg_mem_access_fn)?;
+                        debug
+                            .write_addrs(&self.vcpu_fd, addr, &data, dbg_mem_access_fn)
+                            .map_err(|e| {
+                                log::error!("Failed to write to address: {:?}", e);
+
+                                e
+                            })?;
 
                         Ok(DebugResponse::WriteAddr)
                     }
                     DebugMsg::WriteRegisters(regs) => debug
                         .write_regs(&self.vcpu_fd, &regs)
+                        .map_err(|e| {
+                            log::error!("Failed to write registers: {:?}", e);
+
+                            e
+                        })
                         .map(|_| DebugResponse::WriteRegisters),
                 }
             } else {

--- a/src/hyperlight_host/src/hypervisor/kvm.rs
+++ b/src/hyperlight_host/src/hypervisor/kvm.rs
@@ -82,17 +82,17 @@ mod debug {
     use crate::{new_error, HyperlightError, Result};
 
     /// Software Breakpoint size in memory
-    pub const SW_BP_SIZE: usize = 1;
+    pub(crate) const SW_BP_SIZE: usize = 1;
     /// Software Breakpoint opcode
     const SW_BP_OP: u8 = 0xCC;
     /// Software Breakpoint written to memory
-    pub const SW_BP: [u8; SW_BP_SIZE] = [SW_BP_OP];
+    pub(crate) const SW_BP: [u8; SW_BP_SIZE] = [SW_BP_OP];
 
     /// KVM Debug struct
     /// This struct is used to abstract the internal details of the kvm
     /// guest debugging settings
     #[derive(Default)]
-    pub struct KvmDebug {
+    pub(crate) struct KvmDebug {
         /// vCPU stepping state
         single_step: bool,
 
@@ -108,7 +108,7 @@ mod debug {
     impl KvmDebug {
         const MAX_NO_OF_HW_BP: usize = 4;
 
-        pub fn new() -> Self {
+        pub(crate) fn new() -> Self {
             let dbg = kvm_guest_debug {
                 control: KVM_GUESTDBG_ENABLE | KVM_GUESTDBG_USE_SW_BP,
                 ..Default::default()
@@ -436,7 +436,7 @@ mod debug {
         /// Gdb expects the target to be stopped when connected.
         /// This method provides a way to set a breakpoint at the entry point
         /// it does not keep this breakpoint set after the vCPU already stopped at the address
-        pub fn set_entrypoint_bp(&self) -> Result<()> {
+        pub(crate) fn set_entrypoint_bp(&self) -> Result<()> {
             if self.debug.is_some() {
                 log::debug!("Setting entrypoint bp {:X}", self.entrypoint);
                 let mut entrypoint_debug = KvmDebug::new();
@@ -449,7 +449,7 @@ mod debug {
         }
 
         /// Get the reason the vCPU has stopped
-        pub fn get_stop_reason(&self) -> Result<VcpuStopReason> {
+        pub(crate) fn get_stop_reason(&self) -> Result<VcpuStopReason> {
             let debug = self
                 .debug
                 .as_ref()
@@ -476,7 +476,7 @@ mod debug {
             Ok(VcpuStopReason::Unknown)
         }
 
-        pub fn process_dbg_request(
+        pub(crate) fn process_dbg_request(
             &mut self,
             req: DebugMsg,
             dbg_mem_access_fn: Arc<Mutex<dyn DbgMemAccessHandlerCaller>>,
@@ -539,7 +539,7 @@ mod debug {
             }
         }
 
-        pub fn recv_dbg_msg(&mut self) -> Result<DebugMsg> {
+        pub(crate) fn recv_dbg_msg(&mut self) -> Result<DebugMsg> {
             let gdb_conn = self
                 .gdb_conn
                 .as_mut()
@@ -553,7 +553,7 @@ mod debug {
             })
         }
 
-        pub fn send_dbg_msg(&mut self, cmd: DebugResponse) -> Result<()> {
+        pub(crate) fn send_dbg_msg(&mut self, cmd: DebugResponse) -> Result<()> {
             log::debug!("Sending {:?}", cmd);
 
             let gdb_conn = self

--- a/src/hyperlight_host/src/hypervisor/kvm.rs
+++ b/src/hyperlight_host/src/hypervisor/kvm.rs
@@ -260,9 +260,9 @@ mod debug {
         ) -> Result<DebugResponse> {
             if let Some(debug) = self.debug.as_mut() {
                 match req {
-                    DebugMsg::AddHwBreakpoint(addr) => debug
-                        .add_hw_breakpoint(&self.vcpu_fd, addr)
-                        .map(DebugResponse::AddHwBreakpoint),
+                    DebugMsg::AddHwBreakpoint(addr) => Ok(DebugResponse::AddHwBreakpoint(
+                        debug.add_hw_breakpoint(&self.vcpu_fd, addr).is_ok(),
+                    )),
                     DebugMsg::AddSwBreakpoint(addr) => self
                         .add_sw_breakpoint(addr, dbg_mem_access_fn)
                         .map(DebugResponse::AddSwBreakpoint),
@@ -299,9 +299,9 @@ mod debug {
                             .read_regs(&self.vcpu_fd, &mut regs)
                             .map(|_| DebugResponse::ReadRegisters(regs))
                     }
-                    DebugMsg::RemoveHwBreakpoint(addr) => debug
-                        .remove_hw_breakpoint(&self.vcpu_fd, addr)
-                        .map(DebugResponse::RemoveHwBreakpoint),
+                    DebugMsg::RemoveHwBreakpoint(addr) => Ok(DebugResponse::RemoveHwBreakpoint(
+                        debug.remove_hw_breakpoint(&self.vcpu_fd, addr).is_ok(),
+                    )),
                     DebugMsg::RemoveSwBreakpoint(addr) => self
                         .remove_sw_breakpoint(addr, dbg_mem_access_fn)
                         .map(DebugResponse::RemoveSwBreakpoint),


### PR DESCRIPTION
This PR address the #220 issue.
Additionally, the first 7 commits refactor the existing guest debugging code and moves code from `kvm.rs` to a new file that is to contain the hypervisor specific debugging functionality.