### PR TITLE
Fix release workflow

### DIFF
--- a/.github/workflows/CreateRelease.yml
+++ b/.github/workflows/CreateRelease.yml
@@ -57,12 +57,6 @@ jobs:
     uses: ./.github/workflows/dep_build_guest_binaries.yml
     secrets: inherit
 
-  fuzzing:
-    uses: ./.github/workflows/dep_fuzzing.yml
-    with:
-      max_total_time: 3600 # 1 hour in seconds
-    secrets: inherit
-
   benchmarks:
     needs: [build-guest-binaries]
     uses: ./.github/workflows/Benchmarks.yml


### PR DESCRIPTION
The release workflow broke by #301 because I didn't update the CreateRelease.yml to take into account the new required parameters. Instead of fixing it, I'm removing the fuzzing from the release workflow, because we shouldn't fuzz in the release job anyway.