### PR TITLE
Increase fuzzing memory limit

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -189,19 +189,24 @@ bench-ci baseline target=default-target features="":
 bench target=default-target features="":
     cargo bench --profile={{ if target == "debug" { "dev" } else { target } }} {{ if features =="" {''} else { "--features " + features } }} -- --verbose
 
+#####################################
 # FUZZING
+#####################################
+
+# Enough memory (4GB) for the fuzzer to run for 5 hours, with address sanitizer turned on
+fuzz_memory_limit := "4096"
 
 # Fuzzes the given target
 fuzz fuzz-target:
-    cargo +nightly fuzz run {{ fuzz-target }} --release
+    cargo +nightly fuzz run {{ fuzz-target }} --release -- -rss_limit_mb={{ fuzz_memory_limit }}
 
 # Fuzzes the given target. Stops after `max_time` seconds
 fuzz-timed fuzz-target max_time:
-    cargo +nightly fuzz run {{ fuzz-target }} --release -- -max_total_time={{ max_time }}
+    cargo +nightly fuzz run {{ fuzz-target }} --release -- -rss_limit_mb={{ fuzz_memory_limit }} -max_total_time={{ max_time }}
 
 # Builds fuzzers for submission to external fuzzing services
 build-fuzzers: (build-fuzzer "fuzz_guest_call") (build-fuzzer "fuzz_host_call") (build-fuzzer "fuzz_host_print")
 
 # Builds the given fuzzer
 build-fuzzer fuzz-target:
-    cargo +nightly fuzz build {{ fuzz-target }} --release -s none
+    cargo +nightly fuzz build {{ fuzz-target }} --release


### PR DESCRIPTION
Increase fuzzing memory limit required by address sanitization, and enable sanitizer for build-fuzzer recipe