### PR TITLE
Switch to mostly manual release notes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,4 +10,4 @@ updates:
     schedule:
       interval: "daily"
     labels:
-      - "area/dependencies"
+      - "kind/dependencies"

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,34 +1,11 @@
 # .github/release.yml
 
 changelog:
-  exclude:
-    labels:
-      - chore
   categories:
-    - title: 🛠 Breaking Changes 
-      labels:
-        - breaking-change
-    - title: 🎉 New Features 
-      labels:
-        - enhancement
-    - title: 🐛 Bug Fixes
-      labels:
-        - bug
-    - title: 🔒 Security Fixes
-      labels:
-        - security
-    - title: 🚀 Performance Improvements
-      labels:
-        - performance
-    - title: 👒 Dependencies
-      labels:
-        - dependencies
-    - title: 📚 Documentation
-      labels:
-        - documentation
-    - title: 🔬 Testing
-      labels:
-        - testing
-    - title: 📝 Other Changes
+    - title: Full Changelog (excl. dependencies)
       labels:
         - "*"
+    - title: Full Changelog (dependencies)
+      labels:
+        - area/dependencies
+

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -7,5 +7,5 @@ changelog:
         - "*"
     - title: Full Changelog (dependencies)
       labels:
-        - area/dependencies
+        - kind/dependencies
 

--- a/.github/workflows/CreateRelease.yml
+++ b/.github/workflows/CreateRelease.yml
@@ -108,7 +108,8 @@ jobs:
           rust-toolchain: "1.81.0"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
+      
+      # HYPERLIGHT_VERSION does not include the v prefix
       - name: Set HYPERLIGHT_VERSION
         if: ${{ contains(github.ref, 'refs/heads/release/') }}
         id: set_hyperlight_version
@@ -176,12 +177,24 @@ jobs:
           Write-Host "msiexec exited with code $LASTEXITCCODE"
           if ($LASTEXITCODE -ne 0) { cat log.txt; exit 1 }
 
+      - name: Extract release notes from changelog
+        if: ${{ contains(github.ref, 'refs/heads/release/') }}
+        run: |
+          # Extract the changelog from the changelog file
+          just create-release-notes v${{ env.HYPERLIGHT_VERSION }} > RELEASE_NOTES.md
+
+      - name: Extract prerelease notes from changelog
+        if: ${{ github.ref=='refs/heads/main' }}
+        run: |
+          # Extract the changelog from the changelog file
+          just create-release-notes dev-latest > RELEASE_NOTES.md
+
       # Publish the native guests so that its possible to use Hyperlight without building it.
       - name: Create release
         # Only create a release from tag if we are on a release branch
         if: ${{ contains(github.ref, 'refs/heads/release/') }}
         run: |
-            gh release create v${{ env.HYPERLIGHT_VERSION }} -t "Release v${{ env.HYPERLIGHT_VERSION }}" --generate-notes `
+            gh release create v${{ env.HYPERLIGHT_VERSION }} -t "Release v${{ env.HYPERLIGHT_VERSION }}" --notes-file RELEASE_NOTES.md `
             src/tests/rust_guests/bin/${{ env.CONFIG }}/callbackguest `
             src/tests/rust_guests/bin/${{ env.CONFIG }}/callbackguest.exe `
             src/tests/rust_guests/bin/${{ env.CONFIG }}/simpleguest `
@@ -203,7 +216,7 @@ jobs:
         if: ${{ github.ref=='refs/heads/main' }}
         run:  |    
             gh release delete dev-latest -y --cleanup-tag || $true
-            gh release create dev-latest -t "Latest prerelease from main branch" --latest=false -p `
+            gh release create dev-latest -t "Latest prerelease from main branch" --notes-file RELEASE_NOTES.md --latest=false -p `
             src/tests/rust_guests/bin/${{ env.CONFIG }}/callbackguest `
             src/tests/rust_guests/bin/${{ env.CONFIG }}/callbackguest.exe `
             src/tests/rust_guests/bin/${{ env.CONFIG }}/simpleguest `

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 The Initial Hyperlight Release 🎉 
 
 
-[Prerelease]: <https://github.com/hyperlight-dev/hyperlight/releases/tag/dev-latest>
+[Prerelease]: <https://github.com/hyperlight-dev/hyperlight/compare/v0.2.0..HEAD>
 [v0.2.0]: <https://github.com/hyperlight-dev/hyperlight/compare/v0.1.0...v0.2.0>
 [v0.1.0]: <https://github.com/hyperlight-dev/hyperlight/releases/tag/v0.1.0>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,55 @@
+# Changelog
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## [Prerelease] - Unreleased
+
+### Added  
+- Add fuzzing targets for fuzzing guest and host call parameters and return value by @ludfjig in [#259](https://github.com/hyperlight-dev/hyperlight/pull/259)
+
+### Changed
+- Make host-guest result API generic by @ludfjig in [#259](https://github.com/hyperlight-dev/hyperlight/pull/259)
+
+### Removed  
+- 
+
+### Fixed  
+- Fixed devcontainer permission issues by @myadav in [#326](https://github.com/hyperlight-dev/hyperlight/pull/326)
+
+## [v0.2.0] - 2025-02-25
+
+### Added  
+- Adds support for Azure Linux 3 by @simongdavies in [#51](https://github.com/hyperlight-dev/hyperlight/pull/51)  
+- Add GDB support by @dblnz in [#111](https://github.com/hyperlight-dev/hyperlight/pull/111)  
+- Document DCO by @devigned in [#22](https://github.com/hyperlight-dev/hyperlight/pull/22)  
+- Run CI on intel machines by @danbugs in [#32](https://github.com/hyperlight-dev/hyperlight/pull/32)  
+- Run spell checks on repo by @andreiltd in [#58](https://github.com/hyperlight-dev/hyperlight/pull/58)  
+- Add devcontainer config by @dblnz in [#54](https://github.com/hyperlight-dev/hyperlight/pull/54)  
+- Add exception handling to Hyperlight guest by @danbugs in [#250](https://github.com/hyperlight-dev/hyperlight/pull/250)  
+- Add community meeting info to our README.md by @marosset in [#231](https://github.com/hyperlight-dev/hyperlight/pull/231)  
+
+### Changed  
+- Avoid eagerly doing unnecessary string formatting by @ludfjig in [#73](https://github.com/hyperlight-dev/hyperlight/pull/73)  
+- Use `CreateFileMapping\MapViewOfFile` and `UnmapViewOfFile\CloseHandle` instead of `VirtualAllocEx` and `VirtualFreeEx` on Windows by @simongdavies in [#135](https://github.com/hyperlight-dev/hyperlight/pull/135)  
+- Avoid requiring specific environment variables during testing by @ludfjig in [#108](https://github.com/hyperlight-dev/hyperlight/pull/108)  
+
+### Removed  
+- Remove SingleUseSandbox by @ludfjig in [#125](https://github.com/hyperlight-dev/hyperlight/pull/125)  
+- Remove custom alloca by @ludfjig in [#106](https://github.com/hyperlight-dev/hyperlight/pull/106)  
+
+### Fixed  
+- Fix issues with using `CreateMapViewOfFile` with `inprocess` feature by @simongdavies in [#2340](https://github.com/hyperlight-dev/hyperlight/pull/2340)  
+- Reset guest memory when guest function fails by @ludfjig in [#208](https://github.com/hyperlight-dev/hyperlight/pull/208)  
+- Improve error when guest binary not found by @ludfjig in [#55](https://github.com/hyperlight-dev/hyperlight/pull/55)  
+- Ensure windows version is supported by @simongdavies in [#110](https://github.com/hyperlight-dev/hyperlight/pull/110)  
+
+
+
+## [v0.1.0] - 2024-11-24
+
+The Initial Hyperlight Release 🎉 
+
+
+[Prerelease]: <https://github.com/hyperlight-dev/hyperlight/releases/tag/dev-latest>
+[v0.2.0]: <https://github.com/hyperlight-dev/hyperlight/compare/v0.1.0...v0.2.0>
+[v0.1.0]: <https://github.com/hyperlight-dev/hyperlight/releases/tag/v0.1.0>

--- a/Justfile
+++ b/Justfile
@@ -32,6 +32,12 @@ tar-static-lib: (build-rust-capi "release") (build-rust-capi "debug")
     tar -zcvf hyperlight-guest-c-api-windows.tar.gz -C {{root}}/target/x86_64-pc-windows-msvc/ release/hyperlight_guest_capi.lib -C {{root}}/target/x86_64-pc-windows-msvc/ debug/hyperlight_guest_capi.lib
     tar -zcvf hyperlight-guest-c-api-linux.tar.gz -C {{root}}/target/x86_64-unknown-none/ release/libhyperlight_guest_capi.a -C {{root}}/target/x86_64-unknown-none/ debug/libhyperlight_guest_capi.a
 
+# Create release notes for the given tag. The expected format is a v-prefixed version number, e.g. v0.2.0
+# For prereleases, the version should be "dev-latest"
+@create-release-notes tag:
+    echo "## What's Changed"
+    ./dev/extract-changelog.sh {{ if tag == "dev-latest" { "Prerelease" } else { tag } }}
+    gh api repos/{owner}/{repo}/releases/generate-notes -f tag_name={{ tag }} | jq -r '.body' | sed '1,/## What'"'"'s Changed/d'
 
 # BUILDING
 build-rust-guests target=default-target:

--- a/dev/extract-changelog.sh
+++ b/dev/extract-changelog.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -Eeuo pipefail
+
+# Inspired by https://stackoverflow.com/questions/40450238/parse-a-changelog-and-extract-changes-for-a-version
+# This script will extract the changelog for a specific version from the CHANGELOG.md file
+# Usage: ./extract-changelog.sh <version>, for example ./extract-changelog.sh v0.2.0
+
+if [[ $# -lt 1 ]]; then
+  echo "Usage: $0 <version>"
+  echo "  Example: $0 v0.2.0"
+  echo "  Example: $0 Prerelease"
+  exit 1
+fi
+
+version=$1
+
+awk -v ver="$version" '
+/^## \[.*\]/ {
+  if (p) exit
+  if ($0 ~ "^## \\[" ver "\\]") { p=1; next }
+}
+p' CHANGELOG.md

--- a/docs/how-to-make-releases.md
+++ b/docs/how-to-make-releases.md
@@ -10,9 +10,26 @@ Currently, we need to manually update the workspace `Cargo.toml` version number 
 
 Create a PR with this change and merge it into the main branch.
 
+## Update `CHANGELOG.md`
+
+The `CHANGELOG.md` file is a critical document used to track changes made to Hyperlight. It serves as the foundation for generating release notes, so it's essential to keep it up to date with each release. While not every change needs to be added to this file (since a complete changelog of all PRs will be automatically generated), it's crucial to include all significant updates.
+
+### Steps to Update `CHANGELOG.md`:
+
+- **Manually update the `CHANGELOG.md`** with important changes since the latest release. Ideally, contributors should update this file as part of their PR, but this may not always happen.
+  
+- **Rename the `[Prerelease] - Unreleased` section** to reflect the new version number (if not already done). Ensure that it links to the GitHub comparison between the current and previous versions. For example, `v0.2.0` should link to `https://github.com/hyperlight-dev/hyperlight/compare/v0.1.0...v0.2.0` (see the footer of `CHANGELOG.md`).
+
+- **Add a new `[Prerelease]` section** at the top of the file. This section should initially be empty and will track changes for the next release.
+
+- **Preview the automatically generated release notes** locally using the command:  
+  `just create-release-notes v0.4.0 > notes.md`. Review the notes to ensure everything looks accurate.
+
+- **Create a PR** with the updated `CHANGELOG.md` and merge it into the main branch once all changes are confirmed.
+
 ## Create a tag
 
-When the above PR has merged into `main` branch you should create a tag. ***Make sure you have pulled the recently updated `main` branch***, and do the following on the `main` branch:
+When both above PRs has merged into `main` branch you should create a tag. ***Make sure you have pulled the recently updated `main` branch***, and do the following on the `main` branch:
 
 ```bash
 git tag -a v0.4.0 -m "A brief description of the release"


### PR DESCRIPTION
### Summary

This PR introduces a `CHANGELOG.md` file to the Hyperlight repository to systematically track and document changes. The goal is for this file to be updated with each PR that contributes to the release notes. However, in practice, it will be manually edited by the individual responsible for creating a Hyperlight release.

### Motivation

The need for manual release notes arose from the limitations of our automatic release notes system. The current automatic notes were generated from PR titles, which often don't adequately reflect the changes in a manner that's easily consumable by users.

### Changes

- A `CHANGELOG.md` file has been added to document key changes.
- The GitHub release notes will now include both the content from the `CHANGELOG.md` and a full list of PRs with their titles at the end of the release notes.

This approach draws inspiration from the release notes format used by Runwasi, as seen in [this example](https://github.com/containerd/runwasi/releases).

After this merges, I will replace the old release notes in 0.2.0 with the new ones