### PR TITLE
Using ci-workflow-setup@v1.3.0 to use clang18 on Ubuntu runners

### DIFF
--- a/.github/workflows/Benchmarks.yml
+++ b/.github/workflows/Benchmarks.yml
@@ -28,7 +28,7 @@ jobs:
 
       - uses: actions/checkout@v4
 
-      - uses: hyperlight-dev/ci-setup-workflow@v1.2.0
+      - uses: hyperlight-dev/ci-setup-workflow@v1.3.0
         with:
           rust-toolchain: "1.81.0"
         env:

--- a/.github/workflows/CargoPublish.yml
+++ b/.github/workflows/CargoPublish.yml
@@ -32,7 +32,7 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
 
-      - uses: hyperlight-dev/ci-setup-workflow@v1.2.0
+      - uses: hyperlight-dev/ci-setup-workflow@v1.3.0
         with:
           rust-toolchain: "1.81.0"
 

--- a/.github/workflows/CreateRelease.yml
+++ b/.github/workflows/CreateRelease.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: hyperlight-dev/ci-setup-workflow@v1.2.0
+      - uses: hyperlight-dev/ci-setup-workflow@v1.3.0
         with:
           rust-toolchain: "1.81.0"
         env:
@@ -41,7 +41,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: hyperlight-dev/ci-setup-workflow@v1.2.0
+      - uses: hyperlight-dev/ci-setup-workflow@v1.3.0
         with:
           rust-toolchain: "1.81.0"
         env:
@@ -103,7 +103,7 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
 
-      - uses: hyperlight-dev/ci-setup-workflow@v1.2.0
+      - uses: hyperlight-dev/ci-setup-workflow@v1.3.0
         with:
           rust-toolchain: "1.81.0"
         env:

--- a/.github/workflows/dep_build_guest_binaries.yml
+++ b/.github/workflows/dep_build_guest_binaries.yml
@@ -31,7 +31,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: hyperlight-dev/ci-setup-workflow@v1.2.0
+      - uses: hyperlight-dev/ci-setup-workflow@v1.3.0
         with:
           rust-toolchain: "1.81.0"
         env:

--- a/.github/workflows/dep_fuzzing.yml
+++ b/.github/workflows/dep_fuzzing.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - uses: hyperlight-dev/ci-setup-workflow@v1.2.0
+      - uses: hyperlight-dev/ci-setup-workflow@v1.3.0
         with:
           rust-toolchain: "1.81.0"
         env:

--- a/.github/workflows/dep_rust.yml
+++ b/.github/workflows/dep_rust.yml
@@ -54,7 +54,7 @@ jobs:
         with:
           components: rustfmt
 
-      - uses: hyperlight-dev/ci-setup-workflow@v1.2.0
+      - uses: hyperlight-dev/ci-setup-workflow@v1.3.0
         with:
           rust-toolchain: "1.81.0" 
         env:


### PR DESCRIPTION
Fixes https://github.com/hyperlight-dev/hyperlight/issues/165