### PR TITLE
Remove unused `page_size` guest parameter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1173,7 +1173,6 @@ dependencies = [
  "opentelemetry-otlp",
  "opentelemetry-semantic-conventions",
  "opentelemetry_sdk",
- "page_size",
  "paste",
  "proc-maps",
  "prometheus",
@@ -1892,16 +1891,6 @@ name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
-
-[[package]]
-name = "page_size"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
-dependencies = [
- "libc",
- "winapi",
-]
 
 [[package]]
 name = "parking_lot"

--- a/src/hyperlight_guest/src/entrypoint.rs
+++ b/src/hyperlight_guest/src/entrypoint.rs
@@ -29,8 +29,8 @@ use crate::guest_logger::init_logger;
 use crate::host_function_call::{outb, OutBAction};
 use crate::idtr::load_idt;
 use crate::{
-    __security_cookie, HEAP_ALLOCATOR, MIN_STACK_ADDRESS, OS_PAGE_SIZE, OUTB_PTR,
-    OUTB_PTR_WITH_CONTEXT, P_PEB, RUNNING_MODE,
+    __security_cookie, HEAP_ALLOCATOR, MIN_STACK_ADDRESS, OUTB_PTR, OUTB_PTR_WITH_CONTEXT, P_PEB,
+    RUNNING_MODE,
 };
 
 #[inline(never)]
@@ -77,7 +77,7 @@ static INIT: Once = Once::new();
 // Note: entrypoint cannot currently have a stackframe >4KB, as that will invoke __chkstk on msvc
 //       target without first having setup global `RUNNING_MODE` variable, which __chkstk relies on.
 #[no_mangle]
-pub extern "win64" fn entrypoint(peb_address: u64, seed: u64, ops: u64, max_log_level: u64) {
+pub extern "win64" fn entrypoint(peb_address: u64, seed: u64, max_log_level: u64) {
     if peb_address == 0 {
         panic!("PEB address is null");
     }
@@ -141,8 +141,6 @@ pub extern "win64" fn entrypoint(peb_address: u64, seed: u64, ops: u64, max_log_
                 .try_lock()
                 .expect("Failed to access HEAP_ALLOCATOR")
                 .init(heap_start, heap_size);
-
-            OS_PAGE_SIZE = ops as u32;
 
             (*peb_ptr).guest_function_dispatch_ptr = dispatch_function as usize as u64;
 

--- a/src/hyperlight_guest/src/lib.rs
+++ b/src/hyperlight_guest/src/lib.rs
@@ -97,7 +97,6 @@ pub(crate) static mut __security_cookie: u64 = 0;
 pub(crate) static mut P_PEB: Option<*mut HyperlightPEB> = None;
 pub static mut MIN_STACK_ADDRESS: u64 = 0;
 
-pub static mut OS_PAGE_SIZE: u32 = 0;
 pub(crate) static mut OUTB_PTR: Option<extern "win64" fn(u16, u8)> = None;
 pub(crate) static mut OUTB_PTR_WITH_CONTEXT: Option<
     extern "win64" fn(*mut core::ffi::c_void, u16, u8),

--- a/src/hyperlight_host/Cargo.toml
+++ b/src/hyperlight_host/Cargo.toml
@@ -27,7 +27,6 @@ cfg-if = { version = "1.0.0" }
 libc = { version = "0.2.170" }
 paste = "1.0"
 flatbuffers = "25.2.10"
-page_size = "0.6.0"
 termcolor = "1.2.0"
 bitflags = "2.9.0"
 lazy_static = "1.4.0"

--- a/src/hyperlight_host/src/hypervisor/hyperv_linux.rs
+++ b/src/hyperlight_host/src/hypervisor/hyperv_linux.rs
@@ -201,7 +201,6 @@ impl Hypervisor for HypervLinuxDriver {
         &mut self,
         peb_addr: RawPtr,
         seed: u64,
-        page_size: u32,
         outb_hdl: OutBHandlerWrapper,
         mem_access_hdl: MemAccessHandlerWrapper,
         hv_handler: Option<HypervisorHandler>,
@@ -215,8 +214,7 @@ impl Hypervisor for HypervLinuxDriver {
             // function args
             rcx: peb_addr.into(),
             rdx: seed,
-            r8: page_size.into(),
-            r9: self.get_max_log_level().into(),
+            r8: self.get_max_log_level().into(),
 
             ..Default::default()
         };

--- a/src/hyperlight_host/src/hypervisor/hyperv_windows.rs
+++ b/src/hyperlight_host/src/hypervisor/hyperv_windows.rs
@@ -303,7 +303,6 @@ impl Hypervisor for HypervWindowsDriver {
         &mut self,
         peb_address: RawPtr,
         seed: u64,
-        page_size: u32,
         outb_hdl: OutBHandlerWrapper,
         mem_access_hdl: MemAccessHandlerWrapper,
         hv_handler: Option<HypervisorHandler>,
@@ -316,8 +315,7 @@ impl Hypervisor for HypervWindowsDriver {
             // function args
             rcx: peb_address.into(),
             rdx: seed,
-            r8: page_size.into(),
-            r9: self.get_max_log_level().into(),
+            r8: self.get_max_log_level().into(),
             rflags: 1 << 1, // eflags bit index 1 is reserved and always needs to be 1
 
             ..Default::default()

--- a/src/hyperlight_host/src/hypervisor/hypervisor_handler.rs
+++ b/src/hyperlight_host/src/hypervisor/hypervisor_handler.rs
@@ -184,7 +184,6 @@ struct HvHandlerCommChannels {
 pub(crate) struct HvHandlerConfig {
     pub(crate) peb_addr: RawPtr,
     pub(crate) seed: u64,
-    pub(crate) page_size: u32,
     pub(crate) dispatch_function_addr: Arc<Mutex<Option<RawPtr>>>,
     pub(crate) max_init_time: Duration,
     pub(crate) max_exec_time: Duration,
@@ -353,7 +352,6 @@ impl HypervisorHandler {
                                 let res = hv.initialise(
                                     configuration.peb_addr.clone(),
                                     configuration.seed,
-                                    configuration.page_size,
                                     configuration.outb_handler.clone(),
                                     configuration.mem_access_handler.clone(),
                                     Some(hv_handler_clone.clone()),

--- a/src/hyperlight_host/src/hypervisor/inprocess.rs
+++ b/src/hyperlight_host/src/hypervisor/inprocess.rs
@@ -71,19 +71,17 @@ impl<'a> Hypervisor for InprocessDriver<'a> {
         &mut self,
         _peb_addr: crate::mem::ptr::RawPtr,
         seed: u64,
-        page_size: u32,
         _outb_handle_fn: super::handlers::OutBHandlerWrapper,
         _mem_access_fn: super::handlers::MemAccessHandlerWrapper,
         _hv_handler: Option<super::hypervisor_handler::HypervisorHandler>,
         #[cfg(gdb)] _dbg_mem_access_fn: DbgMemAccessHandlerWrapper,
     ) -> crate::Result<()> {
-        let entrypoint_fn: extern "win64" fn(u64, u64, u64, u64) =
+        let entrypoint_fn: extern "win64" fn(u64, u64, u64) =
             unsafe { std::mem::transmute(self.args.entrypoint_raw as *const c_void) };
 
         entrypoint_fn(
             self.args.peb_ptr_raw,
             seed,
-            page_size as u64,
             log::max_level() as u64,
         );
 

--- a/src/hyperlight_host/src/hypervisor/inprocess.rs
+++ b/src/hyperlight_host/src/hypervisor/inprocess.rs
@@ -79,11 +79,7 @@ impl<'a> Hypervisor for InprocessDriver<'a> {
         let entrypoint_fn: extern "win64" fn(u64, u64, u64) =
             unsafe { std::mem::transmute(self.args.entrypoint_raw as *const c_void) };
 
-        entrypoint_fn(
-            self.args.peb_ptr_raw,
-            seed,
-            log::max_level() as u64,
-        );
+        entrypoint_fn(self.args.peb_ptr_raw, seed, log::max_level() as u64);
 
         Ok(())
     }

--- a/src/hyperlight_host/src/hypervisor/kvm.rs
+++ b/src/hyperlight_host/src/hypervisor/kvm.rs
@@ -700,7 +700,6 @@ impl Hypervisor for KVMDriver {
         &mut self,
         peb_addr: RawPtr,
         seed: u64,
-        page_size: u32,
         outb_hdl: OutBHandlerWrapper,
         mem_access_hdl: MemAccessHandlerWrapper,
         hv_handler: Option<HypervisorHandler>,
@@ -713,8 +712,7 @@ impl Hypervisor for KVMDriver {
             // function args
             rcx: peb_addr.into(),
             rdx: seed,
-            r8: page_size.into(),
-            r9: self.get_max_log_level().into(),
+            r8: self.get_max_log_level().into(),
 
             ..Default::default()
         };

--- a/src/hyperlight_host/src/hypervisor/mod.rs
+++ b/src/hyperlight_host/src/hypervisor/mod.rs
@@ -126,7 +126,6 @@ pub(crate) trait Hypervisor: Debug + Sync + Send {
         &mut self,
         peb_addr: RawPtr,
         seed: u64,
-        page_size: u32,
         outb_handle_fn: OutBHandlerWrapper,
         mem_access_fn: MemAccessHandlerWrapper,
         hv_handler: Option<HypervisorHandler>,
@@ -344,7 +343,6 @@ pub(crate) mod tests {
             #[cfg(gdb)]
             dbg_mem_access_handler: dbg_mem_access_fn,
             seed: 1234567890,
-            page_size: 4096,
             peb_addr: RawPtr::from(0x230000),
             dispatch_function_addr: Arc::new(Mutex::new(None)),
             max_init_time: Duration::from_millis(

--- a/src/hyperlight_host/src/sandbox/uninitialized_evolve.rs
+++ b/src/hyperlight_host/src/sandbox/uninitialized_evolve.rs
@@ -119,14 +119,12 @@ fn hv_init(
         let peb_u64 = u64::try_from(gshm.layout.peb_address)?;
         RawPtr::from(peb_u64)
     };
-    let page_size = u32::try_from(page_size::get())?;
     let hv_handler_config = HvHandlerConfig {
         outb_handler: outb_hdl,
         mem_access_handler: mem_access_hdl,
         #[cfg(gdb)]
         dbg_mem_access_handler: dbg_mem_access_hdl,
         seed,
-        page_size,
         peb_addr,
         dispatch_function_addr: Arc::new(Mutex::new(None)),
         max_init_time,

--- a/src/tests/rust_guests/callbackguest/Cargo.lock
+++ b/src/tests/rust_guests/callbackguest/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "anyhow"
-version = "1.0.96"
+version = "1.0.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b964d184e89d9b6b67dd2715bc8e74cf3107fb2b529990c90cf517326150bf4"
+checksum = "dcfed56ad506cb2c684a14971b8861fdc3baaaae314b9e5f9bb532cbe3ba7a4f"
 
 [[package]]
 name = "autocfg"

--- a/src/tests/rust_guests/dummyguest/src/main.rs
+++ b/src/tests/rust_guests/dummyguest/src/main.rs
@@ -43,8 +43,8 @@ fn mmio_read() {
 
 #[allow(non_snake_case)]
 #[no_mangle]
-pub extern "win64" fn entrypoint(a: i64, b: i64, c: i32) -> i32 {
-    if a != 0x230000 || b != 1234567890 || c != 4096 {
+pub extern "win64" fn entrypoint(a: u64, b: u64) -> i32 {
+    if a != 0x230000 || b != 1234567890 {
         mmio_read();
     }
     halt();

--- a/src/tests/rust_guests/simpleguest/Cargo.lock
+++ b/src/tests/rust_guests/simpleguest/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "anyhow"
-version = "1.0.96"
+version = "1.0.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b964d184e89d9b6b67dd2715bc8e74cf3107fb2b529990c90cf517326150bf4"
+checksum = "dcfed56ad506cb2c684a14971b8861fdc3baaaae314b9e5f9bb532cbe3ba7a4f"
 
 [[package]]
 name = "autocfg"


### PR DESCRIPTION
The page_size is currently passed to the guest's entrypoint, but is unused.