### PR TITLE
Remove unused cargo dependency and cleanup workspace cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,17 +6,10 @@ default-members = [
     "src/hyperlight_testing",
 ]
 members = [
-    "src/hyperlight_common",
-    "src/hyperlight_guest",
-    "src/hyperlight_host",
     "src/hyperlight_guest_capi",
-    "src/hyperlight_testing",
     "fuzz",
 ]
-# Because hyperlight-guest has custom linker flags,
-# we exclude it from the default-members list
-# to avoid cargo test failing on it.
-# Same for the simpleguest and dummyguest tests below.
+# Guests have custom linker flags, so we need to exclude them from the workspace
 exclude = [
     "src/tests/rust_guests/callbackguest",
     "src/tests/rust_guests/dummyguest",
@@ -33,7 +26,6 @@ repository = "https://github.com/hyperlight-dev/hyperlight"
 readme = "README.md"
 
 [workspace.dependencies]
-
 hyperlight-common = { path = "src/hyperlight_common", version = "0.2.0", default-features = false }
 hyperlight-host = { path = "src/hyperlight_host", version = "0.2.0", default-features = false }
 hyperlight-guest = { path = "src/hyperlight_guest", version = "0.2.0", default-features = false }

--- a/src/hyperlight_host/Cargo.toml
+++ b/src/hyperlight_host/Cargo.toml
@@ -84,7 +84,6 @@ mshv-ioctls3 = { package="mshv-ioctls",  version = "=0.3.2", optional = true}
 [dev-dependencies]
 uuid = { version = "1.15.1", features = ["v4"] }
 signal-hook-registry = "1.4.1"
-envy = { version = "0.4.2" }
 serde = "1.0"
 proptest = "1.6.0"
 tempfile = "3.18.0"


### PR DESCRIPTION
Removes unused dependecy, and cleans up workspace cargo.toml slightly.

For the Cargo.toml changes, common, guest,host, testing are already included as workspace path dependencies, making them members already.

No crates depend on hyperlight_guest_capi nor fuzz, so they stay regular members