### PR TITLE
Remove envy from Cargo.lock to sync it with Cargo.toml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -676,15 +676,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "envy"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f47e0157f2cb54f5ae1bd371b30a2ae4311e1c028f575cd4e81de7353215965"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1141,7 +1132,6 @@ dependencies = [
  "crossbeam-channel",
  "crossbeam-queue",
  "env_logger",
- "envy",
  "flatbuffers",
  "gdbstub",
  "gdbstub_arch",


### PR DESCRIPTION
A fresh checkout of the latest `main` shows `Cargo.lock` as modified due to the removal of `envy` crate from dev-dependencies of `Cargo.toml`.