### PR TITLE
Fix benchmark artifact names in release job

### DIFF
--- a/.github/workflows/CreateRelease.yml
+++ b/.github/workflows/CreateRelease.yml
@@ -143,12 +143,18 @@ jobs:
 
       - name: Archive benchmarks
         run: |
+          # windows
           tar -zcvf benchmarks_Windows_hyperv_amd.tar.gz benchmarks_Windows_hyperv_amd
-          tar -zcvf benchmarks_Linux_hyperv_amd.tar.gz benchmarks_Linux_hyperv_amd
-          tar -zcvf benchmarks_Linux_kvm_amd.tar.gz benchmarks_Linux_kvm_amd
           tar -zcvf benchmarks_Windows_hyperv_intel.tar.gz benchmarks_Windows_hyperv_intel
-          tar -zcvf benchmarks_Linux_hyperv_intel.tar.gz benchmarks_Linux_hyperv_intel
+          # kvm
+          tar -zcvf benchmarks_Linux_kvm_amd.tar.gz benchmarks_Linux_kvm_amd
           tar -zcvf benchmarks_Linux_kvm_intel.tar.gz benchmarks_Linux_kvm_intel
+          # mshv2
+          tar -zcvf benchmarks_Linux_mshv_intel.tar.gz benchmarks_Linux_mshv_intel
+          tar -zcvf benchmarks_Linux_mshv_amd.tar.gz benchmarks_Linux_mshv_amd
+          # mshv3
+          tar -zcvf benchmarks_Linux_mshv3_amd.tar.gz benchmarks_Linux_mshv3_amd
+          tar -zcvf benchmarks_Linux_mshv3_intel.tar.gz benchmarks_Linux_mshv3_intel
 
       - name: Extract release notes from changelog
         if: ${{ contains(github.ref, 'refs/heads/release/') }}
@@ -168,11 +174,13 @@ jobs:
             src/tests/rust_guests/bin/${{ env.CONFIG }}/simpleguest.exe \
             src/tests/rust_guests/bin/${{ env.CONFIG }}/dummyguest \
             benchmarks_Windows_hyperv_amd.tar.gz \
-            benchmarks_Linux_hyperv_amd.tar.gz \
-            benchmarks_Linux_kvm_amd.tar.gz \
             benchmarks_Windows_hyperv_intel.tar.gz \
-            benchmarks_Linux_hyperv_intel.tar.gz \
+            benchmarks_Linux_kvm_amd.tar.gz \
             benchmarks_Linux_kvm_intel.tar.gz \
+            benchmarks_Linux_mshv_intel.tar.gz.tar.gz \
+            benchmarks_Linux_mshv_amd.tar.gz \
+            benchmarks_Linux_mshv3_amd.tar.gz \
+            benchmarks_Linux_mshv3_intel.tar.gz \
             hyperlight-guest-c-api-linux.tar.gz \
             hyperlight-guest-c-api-windows.tar.gz \
             include.tar.gz
@@ -190,11 +198,13 @@ jobs:
             src/tests/rust_guests/bin/${{ env.CONFIG }}/simpleguest.exe \
             src/tests/rust_guests/bin/${{ env.CONFIG }}/dummyguest \
             benchmarks_Windows_hyperv_amd.tar.gz \
-            benchmarks_Linux_hyperv_amd.tar.gz \
-            benchmarks_Linux_kvm_amd.tar.gz \
             benchmarks_Windows_hyperv_intel.tar.gz \
-            benchmarks_Linux_hyperv_intel.tar.gz \
+            benchmarks_Linux_kvm_amd.tar.gz \
             benchmarks_Linux_kvm_intel.tar.gz \
+            benchmarks_Linux_mshv_intel.tar.gz.tar.gz \
+            benchmarks_Linux_mshv_amd.tar.gz \
+            benchmarks_Linux_mshv3_amd.tar.gz \
+            benchmarks_Linux_mshv3_intel.tar.gz \
             hyperlight-guest-c-api-linux.tar.gz \
             hyperlight-guest-c-api-windows.tar.gz \
             include.tar.gz


### PR DESCRIPTION
Fixes the tarfiles of our benchmarking artifacts to match the ones that we create. When switching to linux runners in #370, this became a hard-errror: https://github.com/hyperlight-dev/hyperlight/actions/runs/13954211641/job/39062218141
