### PR TITLE
Fix filename typo in release workflow

### DIFF
--- a/.github/workflows/CreateRelease.yml
+++ b/.github/workflows/CreateRelease.yml
@@ -177,7 +177,7 @@ jobs:
             benchmarks_Windows_hyperv_intel.tar.gz \
             benchmarks_Linux_kvm_amd.tar.gz \
             benchmarks_Linux_kvm_intel.tar.gz \
-            benchmarks_Linux_mshv_intel.tar.gz.tar.gz \
+            benchmarks_Linux_mshv_intel.tar.gz \
             benchmarks_Linux_mshv_amd.tar.gz \
             benchmarks_Linux_mshv3_amd.tar.gz \
             benchmarks_Linux_mshv3_intel.tar.gz \
@@ -201,7 +201,7 @@ jobs:
             benchmarks_Windows_hyperv_intel.tar.gz \
             benchmarks_Linux_kvm_amd.tar.gz \
             benchmarks_Linux_kvm_intel.tar.gz \
-            benchmarks_Linux_mshv_intel.tar.gz.tar.gz \
+            benchmarks_Linux_mshv_intel.tar.gz \
             benchmarks_Linux_mshv_amd.tar.gz \
             benchmarks_Linux_mshv3_amd.tar.gz \
             benchmarks_Linux_mshv3_intel.tar.gz \


### PR DESCRIPTION
I typoed in #371 unfortunately: https://github.com/hyperlight-dev/hyperlight/actions/runs/13956374020/job/39069810365