### PR TITLE
Fixes label for GH action updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,8 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-    labels: []
+    labels:
+      - "kind/dependencies"
   - package-ecosystem: "cargo"
     directories: ["/", "src/tests/rust_guests/simpleguest","src/tests/rust_guests/callbackguest"]
     schedule:


### PR DESCRIPTION
Makes sure the correct label is applied to GH actions dependabot PRs