### PR TITLE
release: change crate version to v0.3.0 and update CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Prerelease] - Unreleased
 
 ### Added  
+-
+
+### Changed
+-
+
+### Removed
+-
+
+### Fixed
+-
+
+## [v.0.3.0] - 2025-03-27
+
+### Added
+- Gdb support for mshv guests #327 by @dblnz in [#327](https://github.com/hyperlight-dev/hyperlight/pull/327)
 - Add fuzzing targets for fuzzing guest and host call parameters and return value by @ludfjig in [#259](https://github.com/hyperlight-dev/hyperlight/pull/259)
 
 ### Changed
@@ -50,6 +65,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 The Initial Hyperlight Release 🎉 
 
 
-[Prerelease]: <https://github.com/hyperlight-dev/hyperlight/compare/v0.2.0..HEAD>
+[Prerelease]: <https://github.com/hyperlight-dev/hyperlight/compare/v0.3.0..HEAD>
+[v0.3.0]: <https://github.com/hyperlight-dev/hyperlight/compare/v0.2.0...v0.3.0>
 [v0.2.0]: <https://github.com/hyperlight-dev/hyperlight/compare/v0.1.0...v0.2.0>
 [v0.1.0]: <https://github.com/hyperlight-dev/hyperlight/releases/tag/v0.1.0>

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1083,7 +1083,7 @@ dependencies = [
 
 [[package]]
 name = "hyperlight-common"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -1105,7 +1105,7 @@ dependencies = [
 
 [[package]]
 name = "hyperlight-guest"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "buddy_system_allocator",
@@ -1120,7 +1120,7 @@ dependencies = [
 
 [[package]]
 name = "hyperlight-host"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "bitflags 2.9.0",
@@ -1204,7 +1204,7 @@ dependencies = [
 
 [[package]]
 name = "hyperlight_guest_capi"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "cbindgen",
  "hyperlight-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,9 +26,9 @@ repository = "https://github.com/hyperlight-dev/hyperlight"
 readme = "README.md"
 
 [workspace.dependencies]
-hyperlight-common = { path = "src/hyperlight_common", version = "0.2.0", default-features = false }
-hyperlight-host = { path = "src/hyperlight_host", version = "0.2.0", default-features = false }
-hyperlight-guest = { path = "src/hyperlight_guest", version = "0.2.0", default-features = false }
+hyperlight-common = { path = "src/hyperlight_common", version = "0.3.0", default-features = false }
+hyperlight-host = { path = "src/hyperlight_host", version = "0.3.0", default-features = false }
+hyperlight-guest = { path = "src/hyperlight_guest", version = "0.3.0", default-features = false }
 hyperlight-testing = { path = "src/hyperlight_testing", default-features = false }
 
 [workspace.lints.rust]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 rust-version = "1.81.0"
 license = "Apache-2.0"


### PR DESCRIPTION
Changes in preparation of v0.3.0 release of Hyperlight..
Includes:
- changes in `Cargo.toml` and `Cargo.lock`
- updates in `CHANGELOG.md` to specify major changes apart from the generated list of merged PRs.  