### PR TITLE
release: update rust tests deps to latest hyperlight version

### DIFF
--- a/src/tests/rust_guests/callbackguest/Cargo.lock
+++ b/src/tests/rust_guests/callbackguest/Cargo.lock
@@ -76,7 +76,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hyperlight-common"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "flatbuffers",
@@ -86,7 +86,7 @@ dependencies = [
 
 [[package]]
 name = "hyperlight-guest"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "buddy_system_allocator",

--- a/src/tests/rust_guests/simpleguest/Cargo.lock
+++ b/src/tests/rust_guests/simpleguest/Cargo.lock
@@ -68,7 +68,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hyperlight-common"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "flatbuffers",
@@ -78,7 +78,7 @@ dependencies = [
 
 [[package]]
 name = "hyperlight-guest"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "buddy_system_allocator",


### PR DESCRIPTION
This PR updates the rust tests dependencies of the new Hyperlight crate version