### PR TITLE
Fix dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,7 @@ updates:
       interval: "daily"
     labels:
       - "kind/dependencies"
+    open-pull-requests-limit: 40
   - package-ecosystem: "cargo"
     directories: ["/", "src/tests/rust_guests/simpleguest","src/tests/rust_guests/callbackguest"]
     schedule:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,11 @@ default-members = [
     "src/hyperlight_testing",
 ]
 members = [
+    "src/hyperlight_common",
+    "src/hyperlight_guest",
+    "src/hyperlight_host",
     "src/hyperlight_guest_capi",
+    "src/hyperlight_testing",
     "fuzz",
 ]
 # Guests have custom linker flags, so we need to exclude them from the workspace


### PR DESCRIPTION
Reverses a change that was made to the package level Cargo.toml in #360 which has caused dependabot to fail with `unknown_error`, see [here](https://github.com/hyperlight-dev/hyperlight/actions/runs/14299164915/job/40070585565) for an example. 

I do not know why this change caused the error but I have verified that it works locally using the dependabot cli.

Also updates the number of Open PRs allowed to 40, so we can catch up with the missing version updates in one go.