### PR TITLE
Fix dependabot for issues with test guests and mshv crates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,10 +6,16 @@ updates:
       interval: "daily"
     labels:
       - "kind/dependencies"
-    open-pull-requests-limit: 40
   - package-ecosystem: "cargo"
-    directories: ["/", "src/tests/rust_guests/simpleguest","src/tests/rust_guests/callbackguest"]
+    directory: "/"
     schedule:
       interval: "daily"
     labels:
       - "kind/dependencies"
+    ignore:
+    # The way we are using 2 different versions of the mshv crates seems to break dependabot
+      - dependency-name: "mshv-ioctls"
+        versions: [ ">=0.2.1" ]
+      - dependency-name: "mshv-bindings"
+        versions: [ ">=0.2.1" ]
+    open-pull-requests-limit: 20


### PR DESCRIPTION
Additional updates to dependabot to exclude test guests and mshv crates which both cause errors with update job