### PR TITLE
Fix issues in guest logging

### DIFF
--- a/docs/hyperlight-metrics-logs-and-traces.md
+++ b/docs/hyperlight-metrics-logs-and-traces.md
@@ -66,13 +66,13 @@ In the [examples/tracing](../src/hyperlight_host/examples/tracing) directory, th
 #### Linux
 
 ```bash
-RUST_LOG='none,hyperlight-host=info,tracing=info' cargo run --example tracing
+RUST_LOG='none,hyperlight_host=info,tracing=info' cargo run --example tracing
 ```
 
 #### Windows
 
 ```powershell
-$env:RUST_LOG='none,hyperlight-host=info,tracing=info'; cargo run --example tracing
+$env:RUST_LOG='none,hyperlight_host=info,tracing=info'; cargo run --example tracing
 ```
 
 ### Using OTLP exporter and Jaeger

--- a/src/hyperlight_host/src/hypervisor/hypervisor_handler.rs
+++ b/src/hyperlight_host/src/hypervisor/hypervisor_handler.rs
@@ -28,7 +28,7 @@ use crossbeam::atomic::AtomicCell;
 use crossbeam_channel::{Receiver, Sender};
 #[cfg(target_os = "linux")]
 use libc::{pthread_kill, pthread_self, ESRCH};
-use log::{error, info};
+use log::{error, info, LevelFilter};
 use tracing::{instrument, Span};
 #[cfg(target_os = "linux")]
 use vmm_sys_util::signal::SIGRTMIN;
@@ -191,6 +191,7 @@ pub(crate) struct HvHandlerConfig {
     pub(crate) outb_handler: OutBHandlerWrapper,
     pub(crate) mem_access_handler: MemAccessHandlerWrapper,
     pub(crate) max_wait_for_cancellation: Duration,
+    pub(crate) max_guest_log_level: Option<LevelFilter>,
     #[cfg(gdb)]
     pub(crate) dbg_mem_access_handler: DbgMemAccessHandlerWrapper,
 }
@@ -360,6 +361,7 @@ impl HypervisorHandler {
                                     configuration.outb_handler.clone(),
                                     configuration.mem_access_handler.clone(),
                                     Some(hv_handler_clone.clone()),
+                                    configuration.max_guest_log_level,
                                     #[cfg(gdb)]
                                     configuration.dbg_mem_access_handler.clone(),
                                 );

--- a/src/hyperlight_host/src/hypervisor/inprocess.rs
+++ b/src/hyperlight_host/src/hypervisor/inprocess.rs
@@ -17,6 +17,8 @@ limitations under the License.
 use std::fmt::Debug;
 use std::os::raw::c_void;
 
+use log::LevelFilter;
+
 #[cfg(gdb)]
 use super::handlers::DbgMemAccessHandlerWrapper;
 use super::{HyperlightExit, Hypervisor};
@@ -75,6 +77,7 @@ impl<'a> Hypervisor for InprocessDriver<'a> {
         _outb_handle_fn: super::handlers::OutBHandlerWrapper,
         _mem_access_fn: super::handlers::MemAccessHandlerWrapper,
         _hv_handler: Option<super::hypervisor_handler::HypervisorHandler>,
+        _guest_max_log_level: Option<LevelFilter>,
         #[cfg(gdb)] _dbg_mem_access_fn: DbgMemAccessHandlerWrapper,
     ) -> crate::Result<()> {
         let entrypoint_fn: extern "win64" fn(u64, u64, u64, u64) =

--- a/src/hyperlight_host/src/sandbox/outb.rs
+++ b/src/hyperlight_host/src/sandbox/outb.rs
@@ -88,7 +88,7 @@ pub(super) fn outb_log(mgr: &mut SandboxMemoryManager<HostSharedMemory>) -> Resu
             &Record::builder()
                 .args(format_args!("{}", log_data.message))
                 .level(record_level)
-                .target("hyperlight-guest")
+                .target("hyperlight_guest")
                 .file(source_file)
                 .line(line)
                 .module_path(source)
@@ -100,7 +100,7 @@ pub(super) fn outb_log(mgr: &mut SandboxMemoryManager<HostSharedMemory>) -> Resu
             &Record::builder()
                 .args(format_args!("{}", log_data.message))
                 .level(record_level)
-                .target("hyperlight-guest")
+                .target("hyperlight_guest")
                 .file(Some(&log_data.source_file))
                 .line(Some(log_data.line))
                 .module_path(Some(&log_data.source))
@@ -442,7 +442,7 @@ mod tests {
                         test_value_as_str(metadata_values_map, "level", expected_level);
                         test_value_as_str(event_values_map, "log.file", "test source file");
                         test_value_as_str(event_values_map, "log.module_path", "test source");
-                        test_value_as_str(event_values_map, "log.target", "hyperlight-guest");
+                        test_value_as_str(event_values_map, "log.target", "hyperlight_guest");
                         count_matching_events += 1;
                     }
                     assert!(

--- a/src/hyperlight_host/src/sandbox/uninitialized.rs
+++ b/src/hyperlight_host/src/sandbox/uninitialized.rs
@@ -20,6 +20,7 @@ use std::path::Path;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
+use log::LevelFilter;
 use tracing::{instrument, Span};
 
 #[cfg(gdb)]
@@ -54,6 +55,7 @@ pub struct UninitializedSandbox {
     pub(crate) max_initialization_time: Duration,
     pub(crate) max_execution_time: Duration,
     pub(crate) max_wait_for_cancellation: Duration,
+    pub(crate) max_guest_log_level: Option<LevelFilter>,
     #[cfg(gdb)]
     pub(crate) debug_info: Option<DebugInfo>,
 }
@@ -195,6 +197,7 @@ impl UninitializedSandbox {
             max_wait_for_cancellation: Duration::from_millis(
                 sandbox_cfg.get_max_wait_for_cancellation() as u64,
             ),
+            max_guest_log_level: None,
             #[cfg(gdb)]
             debug_info,
         };
@@ -298,6 +301,13 @@ impl UninitializedSandbox {
         } else {
             SandboxMemoryManager::load_guest_binary_into_memory(cfg, &mut exe_info, inprocess)
         }
+    }
+
+    /// Set the max log level to be used by the guest.
+    /// If this is not set then the log level will be determined by parsing the RUST_LOG environment variable.
+    /// If the RUST_LOG environment variable is not set then the max log level will be set to `LevelFilter::Error`.
+    pub fn set_max_guest_log_level(&mut self, log_level: LevelFilter) {
+        self.max_guest_log_level = Some(log_level);
     }
 }
 // Check to see if the current version of Windows is supported

--- a/src/hyperlight_host/src/sandbox/uninitialized_evolve.rs
+++ b/src/hyperlight_host/src/sandbox/uninitialized_evolve.rs
@@ -17,6 +17,7 @@ limitations under the License.
 use core::time::Duration;
 use std::sync::{Arc, Mutex};
 
+use log::LevelFilter;
 use rand::Rng;
 use tracing::{instrument, Span};
 
@@ -70,6 +71,7 @@ where
             u_sbox.max_initialization_time,
             u_sbox.max_execution_time,
             u_sbox.max_wait_for_cancellation,
+            u_sbox.max_guest_log_level,
             #[cfg(gdb)]
             u_sbox.debug_info,
         )?;
@@ -99,6 +101,7 @@ pub(super) fn evolve_impl_multi_use(u_sbox: UninitializedSandbox) -> Result<Mult
 }
 
 #[instrument(err(Debug), skip_all, parent = Span::current(), level = "Trace")]
+#[allow(clippy::too_many_arguments)]
 fn hv_init(
     hshm: &MemMgrWrapper<HostSharedMemory>,
     gshm: SandboxMemoryManager<GuestSharedMemory>,
@@ -106,6 +109,7 @@ fn hv_init(
     max_init_time: Duration,
     max_exec_time: Duration,
     max_wait_for_cancellation: Duration,
+    max_guest_log_level: Option<LevelFilter>,
     #[cfg(gdb)] debug_info: Option<DebugInfo>,
 ) -> Result<HypervisorHandler> {
     let outb_hdl = outb_handler_wrapper(hshm.clone(), host_funcs);
@@ -134,6 +138,7 @@ fn hv_init(
         max_init_time,
         max_exec_time,
         max_wait_for_cancellation,
+        max_guest_log_level,
     };
     // Note: `dispatch_function_addr` is set by the Hyperlight guest library, and so it isn't in
     // shared memory at this point in time. We will set it after the execution of `hv_init`.

--- a/src/hyperlight_host/tests/integration_test.rs
+++ b/src/hyperlight_host/tests/integration_test.rs
@@ -485,8 +485,8 @@ fn log_message() {
     log_test_messages();
     assert_eq!(5 + num_fixed_trace_log, LOGGER.num_log_calls());
     // The number of enabled calls is the number of times that the enabled function is called
-    // with a target of "hyperlight-guest"
-    // This should be the same as the number of log calls as all the log calls for the "hyperlight-guest" target should be filtered in
+    // with a target of "hyperlight_guest"
+    // This should be the same as the number of log calls as all the log calls for the "hyperlight_guest" target should be filtered in
     // the guest
     assert_eq!(LOGGER.num_log_calls(), LOGGER.num_enabled_calls());
 

--- a/src/hyperlight_testing/src/logger.rs
+++ b/src/hyperlight_testing/src/logger.rs
@@ -90,7 +90,7 @@ impl Log for Logger {
         }
 
         LOGCALLS.with(|log_calls| {
-            if record.target().contains("hyperlight-guest") {
+            if record.target().contains("hyperlight_guest") {
                 println!("Thread {:?} {:?}", current().id(), record);
                 println!("Thread {:?} {:?}", current().id(), record.metadata());
             }

--- a/src/hyperlight_testing/src/simplelogger.rs
+++ b/src/hyperlight_testing/src/simplelogger.rs
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 // this is a non threadsafe logger for testing purposes, to test the log messages emitted by the guest.
-// it will only log messages from the hyperlight-guest target. It will not log messages from other targets.
+// it will only log messages from the hyperlight_guest target. It will not log messages from other targets.
 // this target is only used when handling an outb log request from the guest, so this logger will only capture those messages.
 
 use std::sync::Once;
@@ -80,13 +80,13 @@ impl Log for SimpleLogger {
     fn enabled(&self, metadata: &Metadata) -> bool {
         // This allows us to count the actual number of messages that have been logged by the guest
         // because the guest derives its log level from the host log level then the number times that enabled is called for
-        // the "hyperlight-guest" target will be the same as the number of messages logged by the guest.
-        // In other words this function should always return true for the "hyperlight-guest" target.
+        // the "hyperlight_guest" target will be the same as the number of messages logged by the guest.
+        // In other words this function should always return true for the "hyperlight_guest" target.
         unsafe {
-            if metadata.target() == "hyperlight-guest" {
+            if metadata.target() == "hyperlight_guest" {
                 NUMBER_OF_ENABLED_CALLS += 1;
             }
-            metadata.target() == "hyperlight-guest" && metadata.level() <= log::max_level()
+            metadata.target() == "hyperlight_guest" && metadata.level() <= log::max_level()
         }
     }
     fn log(&self, record: &Record) {


### PR DESCRIPTION
Allow explicit setting of max guest log level, , if this is not set check `RUST_LOG` environment variable.

The guest log level impacts the amount of logs produced by the guest, its presently set by examining the value of max_log_level in the host.

This may not be appropriate since logging in the guest is expensive and it may cause logs to be emitted from the guest but ignored in the host. This change introduces a function on an `UninitializedSandbox` to set the level explicitly, if this is not set the env var `RUST_LOG` is parsed to determine the log level so that logs  are only produced if they are going to be consumed.  If `RUST_LOG` is not set then the max guest log level is set to error.

Updates inconsistent crate name `hyperlight-guest` in guest logs to `hyperlight_guest`