### PR TITLE
Update dependabot autocommit script and job

### DIFF
--- a/.github/workflows/auto-merge-dependabot.yml
+++ b/.github/workflows/auto-merge-dependabot.yml
@@ -10,12 +10,33 @@ permissions:
   contents: write
   pull-requests: write
 
+# This workflow uses a GitHub App token to approve and merge Dependabot PRs
+# The token is created using the `actions/create-github-app-token` action
+# The token is used so that the updates are made by the GitHub App instead of Github Actions 
+# and will show up as such in the PR comments and history
+# In addition, the token is scoped to only the permissions needed for this workflow
+# see https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/making-authenticated-api-requests-with-a-github-app-in-a-github-actions-workflow for details
+
 jobs:
   auto-merge-dependabot:
     runs-on: ubuntu-latest
     steps:
+
+      # Gets the GitHub App token
+      - uses: actions/create-github-app-token@v2
+        id: get-app-token
+        with:
+          # required
+          app-id: ${{ secrets.DEPENDABOT_APP_ID }}
+          private-key: ${{ secrets.DEPENDABOT_APP_KEY }}
+          permission-pull-requests: write
+          permission-contents: write
+
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          token: ${{ steps.get-app-token.outputs.token }}
+          persist-credentials: false
       
       - name: Setup GitHub CLI
         run: |
@@ -27,5 +48,5 @@ jobs:
       
       - name: Run auto approve script
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.get-app-token.outputs.token }}
         run: ./dev/auto-approve-dependabot.sh ${{ github.repository }}


### PR DESCRIPTION
The implementation of the script that automatically approves dependabot PRs relied on issuing commands to dependabot by using comments in the PR such as `@dependabot merge` , this result in a comment in the PR `Sorry, only users with push access can use that command.` 

I attempted to fix this by creating a GitHub App, giving it the correct permissions and then [using an app installation token in the workflow](https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/making-authenticated-api-requests-with-a-github-app-in-a-github-actions-workflow) , however this did not work either as it turns out that dependabot checks to see if the token belongs to a real user with push access to the repo when these commands are issued.

I resolved the issue by setting auto approve squash on the PR rather than use dependabot commands, I decided to leave the change that uses the app token for 2 reasons, firstly it means that the actions that the job takes are clear in the PR history (as they show up as [dependabot-pr-auto-approver](https://github.com/apps/dependabot-pr-auto-approver)) , second the token in limited to the permissions required by the job and cannot obtain any other permissions unless the app is updated.