### PR TITLE
Support ELF core dump creation on guest crash

### DIFF
--- a/.github/workflows/dep_rust.yml
+++ b/.github/workflows/dep_rust.yml
@@ -136,6 +136,12 @@ jobs:
           RUST_LOG: debug
         run: just test-rust-gdb-debugging ${{ matrix.config }} ${{ matrix.hypervisor == 'mshv3' && 'mshv3' || ''}}
 
+      - name: Run Rust Crashdump tests
+        env:
+          CARGO_TERM_COLOR: always
+          RUST_LOG: debug
+        run: just test-rust-crashdump ${{ matrix.config }} ${{ matrix.hypervisor == 'mshv3' && 'mshv3' || ''}}
+
       ### Benchmarks ###
       - name: Install github-cli (Linux mariner)
         if: runner.os == 'Linux' && matrix.hypervisor == 'mshv'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -664,6 +664,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
+name = "elfcore"
+version = "1.1.5"
+source = "git+https://github.com/dblnz/elfcore.git?branch=split-linux-impl-from-elfcore#d3152cb3cbeee5f72b1b2ee8fd3b4c1ecf9ed5a7"
+dependencies = [
+ "libc",
+ "nix",
+ "smallvec",
+ "thiserror 1.0.69",
+ "tracing",
+ "zerocopy 0.7.35",
+]
+
+[[package]]
 name = "endian-type"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1222,6 +1235,7 @@ dependencies = [
  "crossbeam",
  "crossbeam-channel",
  "crossbeam-queue",
+ "elfcore",
  "env_logger",
  "flatbuffers",
  "gdbstub",
@@ -1895,6 +1909,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
 dependencies = [
  "smallvec",
+]
+
+[[package]]
+name = "nix"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
+dependencies = [
+ "bitflags 1.3.2",
+ "cfg-if",
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -665,8 +665,9 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "elfcore"
-version = "1.1.5"
-source = "git+https://github.com/hyperlight-dev/elfcore.git?rev=cef4c80e26bf4b2a5599e50d2d1730965f942c13#cef4c80e26bf4b2a5599e50d2d1730965f942c13"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824386967a6a98e7f99d5c15d40cd1534b0ebfc4193a7109689dcf5322e8d744"
 dependencies = [
  "libc",
  "nix",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -666,7 +666,7 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 [[package]]
 name = "elfcore"
 version = "1.1.5"
-source = "git+https://github.com/dblnz/elfcore.git?branch=split-linux-impl-from-elfcore#d3152cb3cbeee5f72b1b2ee8fd3b4c1ecf9ed5a7"
+source = "git+https://github.com/dblnz/elfcore.git?rev=1a57f04272dd54bc06df638f4027debe6d0f694f#1a57f04272dd54bc06df638f4027debe6d0f694f"
 dependencies = [
  "libc",
  "nix",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -666,7 +666,7 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 [[package]]
 name = "elfcore"
 version = "1.1.5"
-source = "git+https://github.com/dblnz/elfcore.git?rev=1a57f04272dd54bc06df638f4027debe6d0f694f#1a57f04272dd54bc06df638f4027debe6d0f694f"
+source = "git+https://github.com/hyperlight-dev/elfcore.git?rev=cef4c80e26bf4b2a5599e50d2d1730965f942c13#cef4c80e26bf4b2a5599e50d2d1730965f942c13"
 dependencies = [
  "libc",
  "nix",
@@ -1231,6 +1231,7 @@ dependencies = [
  "built",
  "cfg-if",
  "cfg_aliases",
+ "chrono",
  "criterion",
  "crossbeam",
  "crossbeam-channel",

--- a/Justfile
+++ b/Justfile
@@ -81,6 +81,9 @@ test-like-ci config=default-target hypervisor="kvm":
     @# without any driver (should fail to compile)
     just test-compilation-fail {{config}}
 
+    @# test the crashdump feature
+    just test-rust-crashdump {{config}}
+
 # runs all tests
 test target=default-target features="": (test-unit target features) (test-isolated target features) (test-integration "rust" target features) (test-integration "c" target features) (test-seccomp target features)
 
@@ -122,6 +125,10 @@ test-compilation-fail target=default-target:
 test-rust-gdb-debugging target=default-target features="":
     cargo test --profile={{ if target == "debug" { "dev" } else { target } }} --example guest-debugging {{ if features =="" {'--features gdb'} else { "--features gdb," + features } }}
     cargo test --profile={{ if target == "debug" { "dev" } else { target } }} {{ if features =="" {'--features gdb'} else { "--features gdb," + features } }} -- test_gdb
+
+# rust test for crashdump
+test-rust-crashdump target=default-target features="":
+    cargo test --profile={{ if target == "debug" { "dev" } else { target } }} {{ if features =="" {'--features crashdump'} else { "--features crashdump," + features } }} -- test_crashdump
 
 
 ################

--- a/docs/how-to-debug-a-hyperlight-guest.md
+++ b/docs/how-to-debug-a-hyperlight-guest.md
@@ -211,6 +211,13 @@ To make Hyperlight dump the state of the vCPU (general purpose registers, regist
 This will result in a dump file being created in the temporary directory.
 The name and location of the dump file will be printed to the console and logged as an error message.
 
+**NOTE**: By enabling the `crashdump` feature, you instruct Hyperlight to create core dump files for all sandboxes when an unhandled crash occurs.
+To selectively disable this feature for a specific sandbox, you can set the `guest_core_dump` field to `false` in the `SandboxConfiguration`.
+```rust
+    let mut cfg = SandboxConfiguration::default();
+    cfg.set_guest_core_dump(false); // Disable core dump for this sandbox
+```
+
 ### Inspecting the core dump
 
 After the core dump has been created, to inspect the state of the guest, load the core dump file using `gdb` or `lldb`.

--- a/docs/how-to-debug-a-hyperlight-guest.md
+++ b/docs/how-to-debug-a-hyperlight-guest.md
@@ -207,10 +207,14 @@ involved in the gdb debugging of a Hyperlight guest running inside a **KVM** or 
 When a guest crashes because of an unknown VmExit or unhandled exception, the vCPU state is dumped to an `ELF` core dump file.
 This can be used to inspect the state of the guest at the time of the crash.
 
-To make Hyperlight dump the state of the vCPU (general purpose registers, registers) to an `ELF` core dump file, set the feature `crashdump` and run a debug build.
-This will result in a dump file being created in the temporary directory.
+To make Hyperlight dump the state of the vCPU (general purpose registers, registers) to an `ELF` core dump file, enable the `crashdump`
+feature and run.
+The feature enables the creation of core dump files for both debug and release builds of Hyperlight hosts.
+By default, Hyperlight places the core dumps in the temporary directory (platform specific).
+To change this, use the `HYPERLIGHT_CORE_DUMP_DIR` environment variable to specify a directory.
 The name and location of the dump file will be printed to the console and logged as an error message.
 
+**NOTE**: If the directory provided by `HYPERLIGHT_CORE_DUMP_DIR` does not exist, Hyperlight places the file in the temporary directory.
 **NOTE**: By enabling the `crashdump` feature, you instruct Hyperlight to create core dump files for all sandboxes when an unhandled crash occurs.
 To selectively disable this feature for a specific sandbox, you can set the `guest_core_dump` field to `false` in the `SandboxConfiguration`.
 ```rust

--- a/docs/how-to-debug-a-hyperlight-guest.md
+++ b/docs/how-to-debug-a-hyperlight-guest.md
@@ -204,15 +204,17 @@ involved in the gdb debugging of a Hyperlight guest running inside a **KVM** or 
 
 ## Dumping the guest state to an ELF core dump when an unhandled crash occurs
 
-When a guest crashes, the vCPU state is dumped to an `ELF` core dump file. This can be used to inspect the state of the guest at the time of the crash.
+When a guest crashes because of an unknown VmExit or unhandled exception, the vCPU state is dumped to an `ELF` core dump file.
+This can be used to inspect the state of the guest at the time of the crash.
 
-To dump the state of the vCPU (general purpose registers, registers) to an `ELF` core dump file set the feature `crashdump` and run a debug build. This will result in a dump file being created in the temporary directory.
+To make Hyperlight dump the state of the vCPU (general purpose registers, registers) to an `ELF` core dump file, set the feature `crashdump` and run a debug build.
+This will result in a dump file being created in the temporary directory.
 The name and location of the dump file will be printed to the console and logged as an error message.
 
 ### Inspecting the core dump
 
 After the core dump has been created, to inspect the state of the guest, load the core dump file using `gdb` or `lldb`.
-A `gdb` version later than `15.0` and `lldb` version later than `17` have been used to test this feature.
+**NOTE: This feature has been tested with version `15.0` of `gdb` and version `17` of `lldb`, earlier versions may not work, it is recommended to use these versions or later.**
 
 To do this in vscode, the following configuration can be used to add debug configurations:
 
@@ -268,7 +270,7 @@ To do this in vscode, the following configuration can be used to add debug confi
     ]
 }
 ```
-NOTE: The `CodeLldb` debug session does not stop after launching. To see the code, stack frames and registers you need to
+**NOTE: The `CodeLldb` debug session does not stop after launching. To see the code, stack frames and registers you need to
 press the `pause` button. This is a known issue with the `CodeLldb` extension [#1245](https://github.com/vadimcn/codelldb/issues/1245).
-The `cppdbg` extension works as expected and stops at the entry point of the program.
+The `cppdbg` extension works as expected and stops at the entry point of the program.**
 

--- a/src/hyperlight_host/Cargo.toml
+++ b/src/hyperlight_host/Cargo.toml
@@ -38,11 +38,11 @@ vmm-sys-util = "0.14.0"
 crossbeam = "0.8.0"
 crossbeam-channel = "0.5.15"
 thiserror = "2.0.12"
-tempfile = { version = "3.20", optional = true }
+chrono = { version = "0.4", optional = true }
 anyhow = "1.0"
 metrics = "0.24.2"
 serde_json = "1.0"
-elfcore = { git = "https://github.com/dblnz/elfcore.git", rev = "1a57f04272dd54bc06df638f4027debe6d0f694f" }
+elfcore = { git = "https://github.com/hyperlight-dev/elfcore.git", rev = "cef4c80e26bf4b2a5599e50d2d1730965f942c13" }
 
 [target.'cfg(windows)'.dependencies]
 windows = { version = "0.61", features = [
@@ -125,7 +125,8 @@ function_call_metrics = []
 executable_heap = []
 # This feature enables printing of debug information to stdout in debug builds
 print_debug = []
-crashdump = ["dep:tempfile"] # Dumps the VM state to a file on unexpected errors or crashes. The path of the file will be printed on stdout and logged. This feature can only be used in debug builds.
+# Dumps the VM state to a file on unexpected errors or crashes. The path of the file will be printed on stdout and logged.
+crashdump = ["dep:chrono"]
 kvm = ["dep:kvm-bindings", "dep:kvm-ioctls"]
 mshv2 = ["dep:mshv-bindings2", "dep:mshv-ioctls2"]
 mshv3 = ["dep:mshv-bindings3", "dep:mshv-ioctls3"]

--- a/src/hyperlight_host/Cargo.toml
+++ b/src/hyperlight_host/Cargo.toml
@@ -42,7 +42,7 @@ chrono = { version = "0.4", optional = true }
 anyhow = "1.0"
 metrics = "0.24.2"
 serde_json = "1.0"
-elfcore = { git = "https://github.com/hyperlight-dev/elfcore.git", rev = "cef4c80e26bf4b2a5599e50d2d1730965f942c13" }
+elfcore = "2.0"
 
 [target.'cfg(windows)'.dependencies]
 windows = { version = "0.61", features = [

--- a/src/hyperlight_host/Cargo.toml
+++ b/src/hyperlight_host/Cargo.toml
@@ -42,6 +42,7 @@ tempfile = { version = "3.20", optional = true }
 anyhow = "1.0"
 metrics = "0.24.2"
 serde_json = "1.0"
+elfcore = { git = "https://github.com/dblnz/elfcore.git", branch = "split-linux-impl-from-elfcore" }
 
 [target.'cfg(windows)'.dependencies]
 windows = { version = "0.61", features = [

--- a/src/hyperlight_host/Cargo.toml
+++ b/src/hyperlight_host/Cargo.toml
@@ -42,7 +42,7 @@ tempfile = { version = "3.20", optional = true }
 anyhow = "1.0"
 metrics = "0.24.2"
 serde_json = "1.0"
-elfcore = { git = "https://github.com/dblnz/elfcore.git", branch = "split-linux-impl-from-elfcore" }
+elfcore = { git = "https://github.com/dblnz/elfcore.git", rev = "1a57f04272dd54bc06df638f4027debe6d0f694f" }
 
 [target.'cfg(windows)'.dependencies]
 windows = { version = "0.61", features = [

--- a/src/hyperlight_host/build.rs
+++ b/src/hyperlight_host/build.rs
@@ -93,8 +93,7 @@ fn main() -> Result<()> {
         gdb: { all(feature = "gdb", debug_assertions, any(feature = "kvm", feature = "mshv2", feature = "mshv3"), target_os = "linux") },
         kvm: { all(feature = "kvm", target_os = "linux") },
         mshv: { all(any(feature = "mshv2", feature = "mshv3"), target_os = "linux") },
-        // crashdump feature is aliased with debug_assertions to make it only available in debug-builds.
-        crashdump: { all(feature = "crashdump", debug_assertions) },
+        crashdump: { all(feature = "crashdump") },
         // print_debug feature is aliased with debug_assertions to make it only available in debug-builds.
         print_debug: { all(feature = "print_debug", debug_assertions) },
         // the following features are mutually exclusive but rather than enforcing that here we are enabling mshv3 to override mshv2 when both are enabled

--- a/src/hyperlight_host/src/hypervisor/crashdump.rs
+++ b/src/hyperlight_host/src/hypervisor/crashdump.rs
@@ -276,10 +276,7 @@ pub(crate) fn crashdump_to_tempfile(hv: &dyn Hypervisor) -> Result<()> {
     let memory_reader = GuestMemReader::new(&ctx);
 
     // Create and write core dump
-    let core_builder = CoreDumpBuilder::from_source(
-        Box::new(guest_view) as Box<dyn ProcessInfoSource>,
-        Box::new(memory_reader) as Box<dyn ReadProcessMemory>,
-    );
+    let core_builder = CoreDumpBuilder::from_source(guest_view, memory_reader);
 
     core_builder
         .write(&temp_file)

--- a/src/hyperlight_host/src/hypervisor/crashdump.rs
+++ b/src/hyperlight_host/src/hypervisor/crashdump.rs
@@ -14,47 +14,260 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use std::io::Write;
+use std::cmp::min;
 
+use elfcore::{
+    ArchComponentState, ArchState, CoreDumpBuilder, CoreError, Elf64_Auxv, ProcessInfoSource,
+    ReadProcessMemory, ThreadView, VaProtection, VaRegion,
+};
 use tempfile::NamedTempFile;
 
 use super::Hypervisor;
+use crate::mem::memory_region::{MemoryRegion, MemoryRegionFlags};
 use crate::{Result, new_error};
 
-/// Dump registers + memory regions + raw memory to a tempfile
-#[cfg(crashdump)]
-pub(crate) fn crashdump_to_tempfile(hv: &dyn Hypervisor) -> Result<()> {
-    let mut temp_file = NamedTempFile::with_prefix("mem")?;
-    let hv_details = format!("{:#x?}", hv);
+const NT_X86_XSTATE: u32 = 0x202;
+const AT_ENTRY: u64 = 9;
+const AT_NULL: u64 = 0;
 
-    // write hypervisor details such as registers, info about mapped memory regions, etc.
-    temp_file.write_all(hv_details.as_bytes())?;
-    temp_file.write_all(b"================ MEMORY DUMP =================\n")?;
+/// Structure to hold the crash dump context
+/// This structure contains the information needed to create a core dump
+#[derive(Debug)]
+pub(crate) struct CrashDumpContext<'a> {
+    regions: &'a [MemoryRegion],
+    regs: [u64; 27],
+    xsave: Vec<u8>,
+    entry: u64,
+}
 
-    // write the raw memory dump for each memory region
-    for region in hv.get_memory_regions() {
-        if region.host_region.start == 0 || region.host_region.is_empty() {
-            continue;
+impl<'a> CrashDumpContext<'a> {
+    pub(crate) fn new(
+        regions: &'a [MemoryRegion],
+        regs: [u64; 27],
+        xsave: Vec<u8>,
+        entry: u64,
+    ) -> Self {
+        Self {
+            regions,
+            regs,
+            xsave,
+            entry,
         }
-        // SAFETY: we got this memory region from the hypervisor so should never be invalid
-        let region_slice = unsafe {
-            std::slice::from_raw_parts(
-                region.host_region.start as *const u8,
-                region.host_region.len(),
-            )
-        };
-        temp_file.write_all(region_slice)?;
     }
-    temp_file.flush()?;
+}
 
-    // persist the tempfile to disk
-    let persist_path = temp_file.path().with_extension("dmp");
+/// Structure that contains the process information for the core dump
+/// This serves as a source of information for `elfcore`'s [`CoreDumpBuilder`]
+struct GuestView {
+    regions: Vec<VaRegion>,
+    threads: Vec<ThreadView>,
+    aux_vector: Vec<elfcore::Elf64_Auxv>,
+}
+
+impl GuestView {
+    fn new(ctx: &CrashDumpContext) -> Self {
+        // Map the regions to the format `CoreDumpBuilder` expects
+        let regions = ctx
+            .regions
+            .iter()
+            .filter(|r| !r.host_region.is_empty())
+            .map(|r| VaRegion {
+                begin: r.guest_region.start as u64,
+                end: r.guest_region.end as u64,
+                offset: r.host_region.start as u64,
+                protection: VaProtection {
+                    is_private: false,
+                    read: r.flags.contains(MemoryRegionFlags::READ),
+                    write: r.flags.contains(MemoryRegionFlags::WRITE),
+                    execute: r.flags.contains(MemoryRegionFlags::EXECUTE),
+                },
+                mapped_file_name: None,
+            })
+            .collect();
+
+        // The xsave state is checked as it can be empty
+        let mut components = vec![];
+        if !ctx.xsave.is_empty() {
+            components.push(ArchComponentState {
+                name: "XSAVE",
+                note_type: NT_X86_XSTATE,
+                note_name: b"LINUX",
+                data: ctx.xsave.clone(),
+            });
+        }
+
+        // Create the thread view
+        // The thread view contains the information about the thread
+        // NOTE: Some of these fields are not used in the current implementation
+        let thread = ThreadView {
+            flags: 0, // Kernel flags for the process
+            tid: 1,
+            uid: 0, // User ID
+            gid: 0, // Group ID
+            comm: "\0".to_string(),
+            ppid: 0,    // Parent PID
+            pgrp: 0,    // Process group ID
+            nice: 0,    // Nice value
+            state: 0,   // Process state
+            utime: 0,   // User time
+            stime: 0,   // System time
+            cutime: 0,  // Children User time
+            cstime: 0,  // Children User time
+            cursig: 0,  // Current signal
+            session: 0, // Session ID of the process
+            sighold: 0, // Blocked signal
+            sigpend: 0, // Pending signal
+            cmd_line: "\0".to_string(),
+
+            arch_state: Box::new(ArchState {
+                gpr_state: ctx.regs.to_vec(),
+                components,
+            }),
+        };
+
+        // Create the auxv vector
+        // The first entry is AT_ENTRY, which is the entry point of the program
+        // The entry point is the address where the program starts executing
+        // This helps the debugger to know that the entry is changed by an offset
+        // so the symbols can be loaded correctly.
+        // The second entry is AT_NULL, which marks the end of the vector
+        let auxv = vec![
+            Elf64_Auxv {
+                a_type: AT_ENTRY,
+                a_val: ctx.entry,
+            },
+            Elf64_Auxv {
+                a_type: AT_NULL,
+                a_val: 0,
+            },
+        ];
+
+        Self {
+            regions,
+            threads: vec![thread],
+            aux_vector: auxv,
+        }
+    }
+}
+
+impl ProcessInfoSource for GuestView {
+    fn pid(&self) -> i32 {
+        1
+    }
+    fn threads(&self) -> &[elfcore::ThreadView] {
+        &self.threads
+    }
+    fn page_size(&self) -> usize {
+        0x1000
+    }
+    fn aux_vector(&self) -> Option<&[elfcore::Elf64_Auxv]> {
+        Some(&self.aux_vector)
+    }
+    fn va_regions(&self) -> &[elfcore::VaRegion] {
+        &self.regions
+    }
+    fn mapped_files(&self) -> Option<&[elfcore::MappedFile]> {
+        None
+    }
+}
+
+/// Structure that reads the guest memory
+/// This structure serves as a custom memory reader for `elfcore`'s
+/// [`CoreDumpBuilder`]
+struct GuestMemReader {
+    regions: Vec<MemoryRegion>,
+}
+
+impl GuestMemReader {
+    fn new(ctx: &CrashDumpContext) -> Self {
+        Self {
+            regions: ctx.regions.to_vec(),
+        }
+    }
+}
+
+impl ReadProcessMemory for GuestMemReader {
+    fn read_process_memory(
+        &mut self,
+        base: usize,
+        buf: &mut [u8],
+    ) -> std::result::Result<usize, CoreError> {
+        for r in self.regions.iter() {
+            // Check if the base address is within the guest region
+            if base >= r.guest_region.start && base < r.guest_region.end {
+                let offset = base - r.guest_region.start;
+                let region_slice = unsafe {
+                    std::slice::from_raw_parts(
+                        r.host_region.start as *const u8,
+                        r.host_region.len(),
+                    )
+                };
+
+                // Calculate how much we can copy
+                let copy_size = min(buf.len(), region_slice.len() - offset);
+                if copy_size == 0 {
+                    return std::result::Result::Ok(0);
+                }
+
+                // Only copy the amount that fits in both buffers
+                buf[..copy_size].copy_from_slice(&region_slice[offset..offset + copy_size]);
+
+                // Return the number of bytes copied
+                return std::result::Result::Ok(copy_size);
+            }
+        }
+
+        // If we reach here, we didn't find a matching region
+        std::result::Result::Ok(0)
+    }
+}
+
+/// Create core dump file from the hypervisor information
+///
+/// This function generates an ELF core dump file capturing the hypervisor's state,
+/// which can be used for debugging when crashes occur. The file is created in the
+/// system's temporary directory with extension '.elf' and the path is printed to stdout and logs.
+///
+/// # Arguments
+/// * `hv`: Reference to the hypervisor implementation
+///
+/// # Returns
+/// * `Result<()>`: Success or error
+pub(crate) fn crashdump_to_tempfile(hv: &dyn Hypervisor) -> Result<()> {
+    log::info!("Creating core dump file...");
+
+    // Create a temporary file with a recognizable prefix
+    let temp_file = NamedTempFile::with_prefix("hl_core_")
+        .map_err(|e| new_error!("Failed to create temporary file: {:?}", e))?;
+
+    // Get crash context from hypervisor
+    let ctx = hv
+        .crashdump_context()
+        .map_err(|e| new_error!("Failed to get crashdump context: {:?}", e))?;
+
+    // Set up data sources for the core dump
+    let guest_view = GuestView::new(&ctx);
+    let memory_reader = GuestMemReader::new(&ctx);
+
+    // Create and write core dump
+    let core_builder = CoreDumpBuilder::from_source(
+        Box::new(guest_view) as Box<dyn ProcessInfoSource>,
+        Box::new(memory_reader) as Box<dyn ReadProcessMemory>,
+    );
+
+    core_builder
+        .write(&temp_file)
+        .map_err(|e| new_error!("Failed to write core dump: {:?}", e))?;
+
+    let persist_path = temp_file.path().with_extension("elf");
     temp_file
         .persist(&persist_path)
-        .map_err(|e| new_error!("Failed to persist crashdump file: {:?}", e))?;
+        .map_err(|e| new_error!("Failed to persist core dump file: {:?}", e))?;
 
-    println!("Memory dumped to file: {:?}", persist_path);
-    log::error!("Memory dumped to file: {:?}", persist_path);
+    let path_string = persist_path.to_string_lossy().to_string();
+
+    println!("Core dump created successfully: {}", path_string);
+    log::error!("Core dump file: {}", path_string);
 
     Ok(())
 }

--- a/src/hyperlight_host/src/hypervisor/crashdump.rs
+++ b/src/hyperlight_host/src/hypervisor/crashdump.rs
@@ -26,9 +26,18 @@ use super::Hypervisor;
 use crate::mem::memory_region::{MemoryRegion, MemoryRegionFlags};
 use crate::{Result, new_error};
 
+/// This constant is used to identify the XSAVE state in the core dump
 const NT_X86_XSTATE: u32 = 0x202;
+/// This constant identifies the entry point of the program in an Auxiliary Vector
+/// note of ELF. This tells a debugger whether the entry point of the program changed
+/// so it can load the symbols correctly.
 const AT_ENTRY: u64 = 9;
+/// This constant is used to mark the end of the Auxiliary Vector note
 const AT_NULL: u64 = 0;
+/// The PID of the core dump process - this is a placeholder value
+const CORE_DUMP_PID: i32 = 1;
+/// The page size of the core dump
+const CORE_DUMP_PAGE_SIZE: usize = 0x1000;
 
 /// Structure to hold the crash dump context
 /// This structure contains the information needed to create a core dump
@@ -152,13 +161,13 @@ impl GuestView {
 
 impl ProcessInfoSource for GuestView {
     fn pid(&self) -> i32 {
-        1
+        CORE_DUMP_PID
     }
     fn threads(&self) -> &[elfcore::ThreadView] {
         &self.threads
     }
     fn page_size(&self) -> usize {
-        0x1000
+        CORE_DUMP_PAGE_SIZE
     }
     fn aux_vector(&self) -> Option<&[elfcore::Elf64_Auxv]> {
         Some(&self.aux_vector)
@@ -167,6 +176,7 @@ impl ProcessInfoSource for GuestView {
         &self.regions
     }
     fn mapped_files(&self) -> Option<&[elfcore::MappedFile]> {
+        // We don't have mapped files
         None
     }
 }

--- a/src/hyperlight_host/src/hypervisor/crashdump.rs
+++ b/src/hyperlight_host/src/hypervisor/crashdump.rs
@@ -103,12 +103,12 @@ impl GuestView {
         let filename = ctx
             .filename
             .as_ref()
-            .map_or_else(|| "<unknown>".to_string(), |s| s.to_string());
+            .map_or(|| "<unknown>".to_string(), |s| s.to_string());
 
         let cmd = ctx
             .binary
             .as_ref()
-            .map_or_else(|| "<unknown>".to_string(), |s| s.to_string());
+            .map_or(|| "<unknown>".to_string(), |s| s.to_string());
 
         // The xsave state is checked as it can be empty
         let mut components = vec![];

--- a/src/hyperlight_host/src/hypervisor/crashdump.rs
+++ b/src/hyperlight_host/src/hypervisor/crashdump.rs
@@ -100,16 +100,15 @@ impl GuestView {
             })
             .collect();
 
-        // The filename and command line are set to null-terminated strings
         let filename = ctx
             .filename
-            .clone()
-            .map_or_else(|| "\0".to_string(), |s| format!("{}\0", s));
+            .as_ref()
+            .map_or_else(|| "<unknown>".to_string(), |s| s.to_string());
 
         let cmd = ctx
             .binary
-            .clone()
-            .map_or_else(|| "\0".to_string(), |s| format!("{}\0", s));
+            .as_ref()
+            .map_or_else(|| "<unknown>".to_string(), |s| s.to_string());
 
         // The xsave state is checked as it can be empty
         let mut components = vec![];

--- a/src/hyperlight_host/src/hypervisor/hyperv_linux.rs
+++ b/src/hyperlight_host/src/hypervisor/hyperv_linux.rs
@@ -51,6 +51,8 @@ use mshv_bindings::{
 use mshv_ioctls::{Mshv, MshvError, VcpuFd, VmFd};
 use tracing::{Span, instrument};
 
+#[cfg(crashdump)]
+use super::crashdump;
 use super::fpu::{FP_CONTROL_WORD_DEFAULT, FP_TAG_WORD_DEFAULT, MXCSR_DEFAULT};
 #[cfg(gdb)]
 use super::gdb::{DebugCommChannel, DebugMsg, DebugResponse, GuestDebug, MshvDebug};
@@ -750,8 +752,48 @@ impl Hypervisor for HypervLinuxDriver {
     }
 
     #[cfg(crashdump)]
-    fn get_memory_regions(&self) -> &[MemoryRegion] {
-        &self.mem_regions
+    fn crashdump_context(&self) -> Result<super::crashdump::CrashDumpContext> {
+        let mut regs = [0; 27];
+
+        let vcpu_regs = self.vcpu_fd.get_regs()?;
+        let sregs = self.vcpu_fd.get_sregs()?;
+        let xsave = self.vcpu_fd.get_xsave()?;
+
+        // Set up the registers for the crash dump
+        regs[0] = vcpu_regs.r15; // r15
+        regs[1] = vcpu_regs.r14; // r14
+        regs[2] = vcpu_regs.r13; // r13
+        regs[3] = vcpu_regs.r12; // r12
+        regs[4] = vcpu_regs.rbp; // rbp
+        regs[5] = vcpu_regs.rbx; // rbx
+        regs[6] = vcpu_regs.r11; // r11
+        regs[7] = vcpu_regs.r10; // r10
+        regs[8] = vcpu_regs.r9; // r9
+        regs[9] = vcpu_regs.r8; // r8
+        regs[10] = vcpu_regs.rax; // rax
+        regs[11] = vcpu_regs.rcx; // rcx
+        regs[12] = vcpu_regs.rdx; // rdx
+        regs[13] = vcpu_regs.rsi; // rsi
+        regs[14] = vcpu_regs.rdi; // rdi
+        regs[15] = 0; // orig rax
+        regs[16] = vcpu_regs.rip; // rip
+        regs[17] = sregs.cs.selector as u64; // cs
+        regs[18] = vcpu_regs.rflags; // eflags
+        regs[19] = vcpu_regs.rsp; // rsp
+        regs[20] = sregs.ss.selector as u64; // ss
+        regs[21] = sregs.fs.base; // fs_base
+        regs[22] = sregs.gs.base; // gs_base
+        regs[23] = sregs.ds.selector as u64; // ds
+        regs[24] = sregs.es.selector as u64; // es
+        regs[25] = sregs.fs.selector as u64; // fs
+        regs[26] = sregs.gs.selector as u64; // gs
+
+        Ok(crashdump::CrashDumpContext::new(
+            &self.mem_regions,
+            regs,
+            xsave.buffer.to_vec(),
+            self.entrypoint,
+        ))
     }
 
     #[cfg(gdb)]

--- a/src/hyperlight_host/src/hypervisor/hyperv_linux.rs
+++ b/src/hyperlight_host/src/hypervisor/hyperv_linux.rs
@@ -51,7 +51,7 @@ use mshv_bindings::{
 use mshv_ioctls::{Mshv, MshvError, VcpuFd, VmFd};
 use tracing::{Span, instrument};
 #[cfg(crashdump)]
-use {super::crashdump, crate::sandbox::uninitialized::SandboxMetadata, std::path::Path};
+use {super::crashdump, std::path::Path};
 
 use super::fpu::{FP_CONTROL_WORD_DEFAULT, FP_TAG_WORD_DEFAULT, MXCSR_DEFAULT};
 #[cfg(gdb)]
@@ -70,6 +70,8 @@ use crate::hypervisor::HyperlightExit;
 use crate::mem::memory_region::{MemoryRegion, MemoryRegionFlags};
 use crate::mem::ptr::{GuestPtr, RawPtr};
 use crate::sandbox::SandboxConfiguration;
+#[cfg(crashdump)]
+use crate::sandbox::uninitialized::SandboxRuntimeConfig;
 use crate::{Result, log_then_return, new_error};
 
 #[cfg(gdb)]
@@ -305,7 +307,7 @@ pub(crate) struct HypervLinuxDriver {
     #[cfg(gdb)]
     gdb_conn: Option<DebugCommChannel<DebugResponse, DebugMsg>>,
     #[cfg(crashdump)]
-    metadata: SandboxMetadata,
+    rt_cfg: SandboxRuntimeConfig,
 }
 
 impl HypervLinuxDriver {
@@ -325,7 +327,7 @@ impl HypervLinuxDriver {
         pml4_ptr: GuestPtr,
         config: &SandboxConfiguration,
         #[cfg(gdb)] gdb_conn: Option<DebugCommChannel<DebugResponse, DebugMsg>>,
-        #[cfg(crashdump)] metadata: SandboxMetadata,
+        #[cfg(crashdump)] rt_cfg: SandboxRuntimeConfig,
     ) -> Result<Self> {
         let mshv = Mshv::new()?;
         let pr = Default::default();
@@ -414,7 +416,7 @@ impl HypervLinuxDriver {
             #[cfg(gdb)]
             gdb_conn,
             #[cfg(crashdump)]
-            metadata,
+            rt_cfg,
         })
     }
 
@@ -757,57 +759,61 @@ impl Hypervisor for HypervLinuxDriver {
     }
 
     #[cfg(crashdump)]
-    fn crashdump_context(&self) -> Result<super::crashdump::CrashDumpContext> {
-        let mut regs = [0; 27];
+    fn crashdump_context(&self) -> Result<Option<super::crashdump::CrashDumpContext>> {
+        if self.rt_cfg.guest_core_dump {
+            let mut regs = [0; 27];
 
-        let vcpu_regs = self.vcpu_fd.get_regs()?;
-        let sregs = self.vcpu_fd.get_sregs()?;
-        let xsave = self.vcpu_fd.get_xsave()?;
+            let vcpu_regs = self.vcpu_fd.get_regs()?;
+            let sregs = self.vcpu_fd.get_sregs()?;
+            let xsave = self.vcpu_fd.get_xsave()?;
 
-        // Set up the registers for the crash dump
-        regs[0] = vcpu_regs.r15; // r15
-        regs[1] = vcpu_regs.r14; // r14
-        regs[2] = vcpu_regs.r13; // r13
-        regs[3] = vcpu_regs.r12; // r12
-        regs[4] = vcpu_regs.rbp; // rbp
-        regs[5] = vcpu_regs.rbx; // rbx
-        regs[6] = vcpu_regs.r11; // r11
-        regs[7] = vcpu_regs.r10; // r10
-        regs[8] = vcpu_regs.r9; // r9
-        regs[9] = vcpu_regs.r8; // r8
-        regs[10] = vcpu_regs.rax; // rax
-        regs[11] = vcpu_regs.rcx; // rcx
-        regs[12] = vcpu_regs.rdx; // rdx
-        regs[13] = vcpu_regs.rsi; // rsi
-        regs[14] = vcpu_regs.rdi; // rdi
-        regs[15] = 0; // orig rax
-        regs[16] = vcpu_regs.rip; // rip
-        regs[17] = sregs.cs.selector as u64; // cs
-        regs[18] = vcpu_regs.rflags; // eflags
-        regs[19] = vcpu_regs.rsp; // rsp
-        regs[20] = sregs.ss.selector as u64; // ss
-        regs[21] = sregs.fs.base; // fs_base
-        regs[22] = sregs.gs.base; // gs_base
-        regs[23] = sregs.ds.selector as u64; // ds
-        regs[24] = sregs.es.selector as u64; // es
-        regs[25] = sregs.fs.selector as u64; // fs
-        regs[26] = sregs.gs.selector as u64; // gs
+            // Set up the registers for the crash dump
+            regs[0] = vcpu_regs.r15; // r15
+            regs[1] = vcpu_regs.r14; // r14
+            regs[2] = vcpu_regs.r13; // r13
+            regs[3] = vcpu_regs.r12; // r12
+            regs[4] = vcpu_regs.rbp; // rbp
+            regs[5] = vcpu_regs.rbx; // rbx
+            regs[6] = vcpu_regs.r11; // r11
+            regs[7] = vcpu_regs.r10; // r10
+            regs[8] = vcpu_regs.r9; // r9
+            regs[9] = vcpu_regs.r8; // r8
+            regs[10] = vcpu_regs.rax; // rax
+            regs[11] = vcpu_regs.rcx; // rcx
+            regs[12] = vcpu_regs.rdx; // rdx
+            regs[13] = vcpu_regs.rsi; // rsi
+            regs[14] = vcpu_regs.rdi; // rdi
+            regs[15] = 0; // orig rax
+            regs[16] = vcpu_regs.rip; // rip
+            regs[17] = sregs.cs.selector as u64; // cs
+            regs[18] = vcpu_regs.rflags; // eflags
+            regs[19] = vcpu_regs.rsp; // rsp
+            regs[20] = sregs.ss.selector as u64; // ss
+            regs[21] = sregs.fs.base; // fs_base
+            regs[22] = sregs.gs.base; // gs_base
+            regs[23] = sregs.ds.selector as u64; // ds
+            regs[24] = sregs.es.selector as u64; // es
+            regs[25] = sregs.fs.selector as u64; // fs
+            regs[26] = sregs.gs.selector as u64; // gs
 
-        // Get the filename from the binary path
-        let filename = self.metadata.binary_path.clone().and_then(|path| {
-            Path::new(&path)
-                .file_name()
-                .and_then(|name| name.to_os_string().into_string().ok())
-        });
+            // Get the filename from the binary path
+            let filename = self.rt_cfg.binary_path.clone().and_then(|path| {
+                Path::new(&path)
+                    .file_name()
+                    .and_then(|name| name.to_os_string().into_string().ok())
+            });
 
-        Ok(crashdump::CrashDumpContext::new(
-            &self.mem_regions,
-            regs,
-            xsave.buffer.to_vec(),
-            self.entrypoint,
-            self.metadata.binary_path.clone(),
-            filename,
-        ))
+            Ok(Some(crashdump::CrashDumpContext::new(
+                &self.mem_regions,
+                regs,
+                xsave.buffer.to_vec(),
+                self.entrypoint,
+                self.rt_cfg.binary_path.clone(),
+                filename,
+            )))
+        } else {
+            Ok(None)
+        }
     }
 
     #[cfg(gdb)]
@@ -932,7 +938,14 @@ mod tests {
             #[cfg(gdb)]
             None,
             #[cfg(crashdump)]
-            SandboxMetadata { binary_path: None },
+            SandboxRuntimeConfig {
+                #[cfg(crashdump)]
+                binary_path: None,
+                #[cfg(gdb)]
+                debug_info: None,
+                #[cfg(crashdump)]
+                guest_core_dump: true,
+            },
         )
         .unwrap();
     }

--- a/src/hyperlight_host/src/hypervisor/hyperv_windows.rs
+++ b/src/hyperlight_host/src/hypervisor/hyperv_windows.rs
@@ -31,7 +31,7 @@ use windows::Win32::System::Hypervisor::{
     WHvX64RegisterCs, WHvX64RegisterEfer,
 };
 #[cfg(crashdump)]
-use {super::crashdump, crate::sandbox::uninitialized::SandboxMetadata, std::path::Path};
+use {super::crashdump, std::path::Path};
 
 use super::fpu::{FP_TAG_WORD_DEFAULT, MXCSR_DEFAULT};
 #[cfg(gdb)]
@@ -49,6 +49,8 @@ use crate::hypervisor::fpu::FP_CONTROL_WORD_DEFAULT;
 use crate::hypervisor::wrappers::WHvGeneralRegisters;
 use crate::mem::memory_region::{MemoryRegion, MemoryRegionFlags};
 use crate::mem::ptr::{GuestPtr, RawPtr};
+#[cfg(crashdump)]
+use crate::sandbox::uninitialized::SandboxRuntimeConfig;
 use crate::{Result, debug, new_error};
 
 /// A Hypervisor driver for HyperV-on-Windows.
@@ -62,7 +64,7 @@ pub(crate) struct HypervWindowsDriver {
     mem_regions: Vec<MemoryRegion>,
     interrupt_handle: Arc<WindowsInterruptHandle>,
     #[cfg(crashdump)]
-    metadata: SandboxMetadata,
+    rt_cfg: SandboxRuntimeConfig,
 }
 /* This does not automatically impl Send/Sync because the host
  * address of the shared memory region is a raw pointer, which are
@@ -83,7 +85,7 @@ impl HypervWindowsDriver {
         entrypoint: u64,
         rsp: u64,
         mmap_file_handle: HandleWrapper,
-        #[cfg(crashdump)] metadata: SandboxMetadata,
+        #[cfg(crashdump)] rt_cfg: SandboxRuntimeConfig,
     ) -> Result<Self> {
         // create and setup hypervisor partition
         let mut partition = VMPartition::new(1)?;
@@ -119,7 +121,7 @@ impl HypervWindowsDriver {
                 dropped: AtomicBool::new(false),
             }),
             #[cfg(crashdump)]
-            metadata,
+            rt_cfg,
         })
     }
 
@@ -522,57 +524,61 @@ impl Hypervisor for HypervWindowsDriver {
     }
 
     #[cfg(crashdump)]
-    fn crashdump_context(&self) -> Result<crashdump::CrashDumpContext> {
-        let mut regs = [0; 27];
+    fn crashdump_context(&self) -> Result<Option<crashdump::CrashDumpContext>> {
+        if self.rt_cfg.guest_core_dump {
+            let mut regs = [0; 27];
 
-        let vcpu_regs = self.processor.get_regs()?;
-        let sregs = self.processor.get_sregs()?;
-        let xsave = self.processor.get_xsave()?;
+            let vcpu_regs = self.processor.get_regs()?;
+            let sregs = self.processor.get_sregs()?;
+            let xsave = self.processor.get_xsave()?;
 
-        // Set the registers in the order expected by the crashdump context
-        regs[0] = vcpu_regs.r15; // r15
-        regs[1] = vcpu_regs.r14; // r14
-        regs[2] = vcpu_regs.r13; // r13
-        regs[3] = vcpu_regs.r12; // r12
-        regs[4] = vcpu_regs.rbp; // rbp
-        regs[5] = vcpu_regs.rbx; // rbx
-        regs[6] = vcpu_regs.r11; // r11
-        regs[7] = vcpu_regs.r10; // r10
-        regs[8] = vcpu_regs.r9; // r9
-        regs[9] = vcpu_regs.r8; // r8
-        regs[10] = vcpu_regs.rax; // rax
-        regs[11] = vcpu_regs.rcx; // rcx
-        regs[12] = vcpu_regs.rdx; // rdx
-        regs[13] = vcpu_regs.rsi; // rsi
-        regs[14] = vcpu_regs.rdi; // rdi
-        regs[15] = 0; // orig rax
-        regs[16] = vcpu_regs.rip; // rip
-        regs[17] = unsafe { sregs.cs.Segment.Selector } as u64; // cs
-        regs[18] = vcpu_regs.rflags; // eflags
-        regs[19] = vcpu_regs.rsp; // rsp
-        regs[20] = unsafe { sregs.ss.Segment.Selector } as u64; // ss
-        regs[21] = unsafe { sregs.fs.Segment.Base }; // fs_base
-        regs[22] = unsafe { sregs.gs.Segment.Base }; // gs_base
-        regs[23] = unsafe { sregs.ds.Segment.Selector } as u64; // ds
-        regs[24] = unsafe { sregs.es.Segment.Selector } as u64; // es
-        regs[25] = unsafe { sregs.fs.Segment.Selector } as u64; // fs
-        regs[26] = unsafe { sregs.gs.Segment.Selector } as u64; // gs
+            // Set the registers in the order expected by the crashdump context
+            regs[0] = vcpu_regs.r15; // r15
+            regs[1] = vcpu_regs.r14; // r14
+            regs[2] = vcpu_regs.r13; // r13
+            regs[3] = vcpu_regs.r12; // r12
+            regs[4] = vcpu_regs.rbp; // rbp
+            regs[5] = vcpu_regs.rbx; // rbx
+            regs[6] = vcpu_regs.r11; // r11
+            regs[7] = vcpu_regs.r10; // r10
+            regs[8] = vcpu_regs.r9; // r9
+            regs[9] = vcpu_regs.r8; // r8
+            regs[10] = vcpu_regs.rax; // rax
+            regs[11] = vcpu_regs.rcx; // rcx
+            regs[12] = vcpu_regs.rdx; // rdx
+            regs[13] = vcpu_regs.rsi; // rsi
+            regs[14] = vcpu_regs.rdi; // rdi
+            regs[15] = 0; // orig rax
+            regs[16] = vcpu_regs.rip; // rip
+            regs[17] = unsafe { sregs.cs.Segment.Selector } as u64; // cs
+            regs[18] = vcpu_regs.rflags; // eflags
+            regs[19] = vcpu_regs.rsp; // rsp
+            regs[20] = unsafe { sregs.ss.Segment.Selector } as u64; // ss
+            regs[21] = unsafe { sregs.fs.Segment.Base }; // fs_base
+            regs[22] = unsafe { sregs.gs.Segment.Base }; // gs_base
+            regs[23] = unsafe { sregs.ds.Segment.Selector } as u64; // ds
+            regs[24] = unsafe { sregs.es.Segment.Selector } as u64; // es
+            regs[25] = unsafe { sregs.fs.Segment.Selector } as u64; // fs
+            regs[26] = unsafe { sregs.gs.Segment.Selector } as u64; // gs
 
-        // Get the filename from the metadata
-        let filename = self.metadata.binary_path.clone().and_then(|path| {
-            Path::new(&path)
-                .file_name()
-                .and_then(|name| name.to_os_string().into_string().ok())
-        });
+            // Get the filename from the config
+            let filename = self.rt_cfg.binary_path.clone().and_then(|path| {
+                Path::new(&path)
+                    .file_name()
+                    .and_then(|name| name.to_os_string().into_string().ok())
+            });
 
-        Ok(crashdump::CrashDumpContext::new(
-            &self.mem_regions,
-            regs,
-            xsave,
-            self.entrypoint,
-            self.metadata.binary_path.clone(),
-            filename,
-        ))
+            Ok(Some(crashdump::CrashDumpContext::new(
+                &self.mem_regions,
+                regs,
+                xsave,
+                self.entrypoint,
+                self.rt_cfg.binary_path.clone(),
+                filename,
+            )))
+        } else {
+            Ok(None)
+        }
     }
 }
 

--- a/src/hyperlight_host/src/hypervisor/hyperv_windows.rs
+++ b/src/hyperlight_host/src/hypervisor/hyperv_windows.rs
@@ -31,6 +31,8 @@ use windows::Win32::System::Hypervisor::{
     WHvX64RegisterCs, WHvX64RegisterEfer,
 };
 
+#[cfg(crashdump)]
+use super::crashdump;
 use super::fpu::{FP_TAG_WORD_DEFAULT, MXCSR_DEFAULT};
 #[cfg(gdb)]
 use super::handlers::DbgMemAccessHandlerWrapper;
@@ -514,8 +516,48 @@ impl Hypervisor for HypervWindowsDriver {
     }
 
     #[cfg(crashdump)]
-    fn get_memory_regions(&self) -> &[MemoryRegion] {
-        &self.mem_regions
+    fn crashdump_context(&self) -> Result<crashdump::CrashDumpContext> {
+        let mut regs = [0; 27];
+
+        let vcpu_regs = self.processor.get_regs()?;
+        let sregs = self.processor.get_sregs()?;
+        let xsave = self.processor.get_xsave()?;
+
+        // Set the registers in the order expected by the crashdump context
+        regs[0] = vcpu_regs.r15; // r15
+        regs[1] = vcpu_regs.r14; // r14
+        regs[2] = vcpu_regs.r13; // r13
+        regs[3] = vcpu_regs.r12; // r12
+        regs[4] = vcpu_regs.rbp; // rbp
+        regs[5] = vcpu_regs.rbx; // rbx
+        regs[6] = vcpu_regs.r11; // r11
+        regs[7] = vcpu_regs.r10; // r10
+        regs[8] = vcpu_regs.r9; // r9
+        regs[9] = vcpu_regs.r8; // r8
+        regs[10] = vcpu_regs.rax; // rax
+        regs[11] = vcpu_regs.rcx; // rcx
+        regs[12] = vcpu_regs.rdx; // rdx
+        regs[13] = vcpu_regs.rsi; // rsi
+        regs[14] = vcpu_regs.rdi; // rdi
+        regs[15] = 0; // orig rax
+        regs[16] = vcpu_regs.rip; // rip
+        regs[17] = unsafe { sregs.cs.Segment.Selector } as u64; // cs
+        regs[18] = vcpu_regs.rflags; // eflags
+        regs[19] = vcpu_regs.rsp; // rsp
+        regs[20] = unsafe { sregs.ss.Segment.Selector } as u64; // ss
+        regs[21] = unsafe { sregs.fs.Segment.Base }; // fs_base
+        regs[22] = unsafe { sregs.gs.Segment.Base }; // gs_base
+        regs[23] = unsafe { sregs.ds.Segment.Selector } as u64; // ds
+        regs[24] = unsafe { sregs.es.Segment.Selector } as u64; // es
+        regs[25] = unsafe { sregs.fs.Segment.Selector } as u64; // fs
+        regs[26] = unsafe { sregs.gs.Segment.Selector } as u64; // gs
+
+        Ok(crashdump::CrashDumpContext::new(
+            &self.mem_regions,
+            regs,
+            xsave,
+            self.entrypoint,
+        ))
     }
 }
 

--- a/src/hyperlight_host/src/hypervisor/kvm.rs
+++ b/src/hyperlight_host/src/hypervisor/kvm.rs
@@ -27,7 +27,7 @@ use kvm_ioctls::{Kvm, VcpuExit, VcpuFd, VmFd};
 use log::LevelFilter;
 use tracing::{Span, instrument};
 #[cfg(crashdump)]
-use {super::crashdump, crate::sandbox::uninitialized::SandboxMetadata, std::path::Path};
+use {super::crashdump, std::path::Path};
 
 use super::fpu::{FP_CONTROL_WORD_DEFAULT, FP_TAG_WORD_DEFAULT, MXCSR_DEFAULT};
 #[cfg(gdb)]
@@ -45,6 +45,8 @@ use crate::HyperlightError;
 use crate::mem::memory_region::{MemoryRegion, MemoryRegionFlags};
 use crate::mem::ptr::{GuestPtr, RawPtr};
 use crate::sandbox::SandboxConfiguration;
+#[cfg(crashdump)]
+use crate::sandbox::uninitialized::SandboxRuntimeConfig;
 use crate::{Result, log_then_return, new_error};
 
 /// Return `true` if the KVM API is available, version 12, and has UserMemory capability, or `false` otherwise
@@ -293,7 +295,7 @@ pub(crate) struct KVMDriver {
     #[cfg(gdb)]
     gdb_conn: Option<DebugCommChannel<DebugResponse, DebugMsg>>,
     #[cfg(crashdump)]
-    metadata: SandboxMetadata,
+    rt_cfg: SandboxRuntimeConfig,
 }
 
 impl KVMDriver {
@@ -308,7 +310,7 @@ impl KVMDriver {
         rsp: u64,
         config: &SandboxConfiguration,
         #[cfg(gdb)] gdb_conn: Option<DebugCommChannel<DebugResponse, DebugMsg>>,
-        #[cfg(crashdump)] metadata: SandboxMetadata,
+        #[cfg(crashdump)] rt_cfg: SandboxRuntimeConfig,
     ) -> Result<Self> {
         let kvm = Kvm::new()?;
 
@@ -369,7 +371,7 @@ impl KVMDriver {
             #[cfg(gdb)]
             gdb_conn,
             #[cfg(crashdump)]
-            metadata,
+            rt_cfg,
         };
         Ok(ret)
     }
@@ -665,64 +667,67 @@ impl Hypervisor for KVMDriver {
     }
 
     #[cfg(crashdump)]
-    fn crashdump_context(&self) -> Result<crashdump::CrashDumpContext> {
-        let mut regs = [0; 27];
+    fn crashdump_context(&self) -> Result<Option<crashdump::CrashDumpContext>> {
+        if self.rt_cfg.guest_core_dump {
+            let mut regs = [0; 27];
 
-        let vcpu_regs = self.vcpu_fd.get_regs()?;
-        let sregs = self.vcpu_fd.get_sregs()?;
-        let xsave = self.vcpu_fd.get_xsave()?;
+            let vcpu_regs = self.vcpu_fd.get_regs()?;
+            let sregs = self.vcpu_fd.get_sregs()?;
+            let xsave = self.vcpu_fd.get_xsave()?;
 
-        // Set the registers in the order expected by the crashdump context
-        regs[0] = vcpu_regs.r15; // r15
-        regs[1] = vcpu_regs.r14; // r14
-        regs[2] = vcpu_regs.r13; // r13
-        regs[3] = vcpu_regs.r12; // r12
-        regs[4] = vcpu_regs.rbp; // rbp
-        regs[5] = vcpu_regs.rbx; // rbx
-        regs[6] = vcpu_regs.r11; // r11
-        regs[7] = vcpu_regs.r10; // r10
-        regs[8] = vcpu_regs.r9; // r9
-        regs[9] = vcpu_regs.r8; // r8
-        regs[10] = vcpu_regs.rax; // rax
-        regs[11] = vcpu_regs.rcx; // rcx
-        regs[12] = vcpu_regs.rdx; // rdx
-        regs[13] = vcpu_regs.rsi; // rsi
-        regs[14] = vcpu_regs.rdi; // rdi
-        regs[15] = 0; // orig rax
-        regs[16] = vcpu_regs.rip; // rip
-        regs[17] = sregs.cs.selector as u64; // cs
-        regs[18] = vcpu_regs.rflags; // eflags
-        regs[19] = vcpu_regs.rsp; // rsp
-        regs[20] = sregs.ss.selector as u64; // ss
-        regs[21] = sregs.fs.base; // fs_base
-        regs[22] = sregs.gs.base; // gs_base
-        regs[23] = sregs.ds.selector as u64; // ds
-        regs[24] = sregs.es.selector as u64; // es
-        regs[25] = sregs.fs.selector as u64; // fs
-        regs[26] = sregs.gs.selector as u64; // gs
+            // Set the registers in the order expected by the crashdump context
+            regs[0] = vcpu_regs.r15; // r15
+            regs[1] = vcpu_regs.r14; // r14
+            regs[2] = vcpu_regs.r13; // r13
+            regs[3] = vcpu_regs.r12; // r12
+            regs[4] = vcpu_regs.rbp; // rbp
+            regs[5] = vcpu_regs.rbx; // rbx
+            regs[6] = vcpu_regs.r11; // r11
+            regs[7] = vcpu_regs.r10; // r10
+            regs[8] = vcpu_regs.r9; // r9
+            regs[9] = vcpu_regs.r8; // r8
+            regs[10] = vcpu_regs.rax; // rax
+            regs[11] = vcpu_regs.rcx; // rcx
+            regs[12] = vcpu_regs.rdx; // rdx
+            regs[13] = vcpu_regs.rsi; // rsi
+            regs[14] = vcpu_regs.rdi; // rdi
+            regs[15] = 0; // orig rax
+            regs[16] = vcpu_regs.rip; // rip
+            regs[17] = sregs.cs.selector as u64; // cs
+            regs[18] = vcpu_regs.rflags; // eflags
+            regs[19] = vcpu_regs.rsp; // rsp
+            regs[20] = sregs.ss.selector as u64; // ss
+            regs[21] = sregs.fs.base; // fs_base
+            regs[22] = sregs.gs.base; // gs_base
+            regs[23] = sregs.ds.selector as u64; // ds
+            regs[24] = sregs.es.selector as u64; // es
+            regs[25] = sregs.fs.selector as u64; // fs
+            regs[26] = sregs.gs.selector as u64; // gs
 
-        // Get the filename from the metadata
-        let filename = self.metadata.binary_path.clone().and_then(|path| {
-            Path::new(&path)
-                .file_name()
-                .and_then(|name| name.to_os_string().into_string().ok())
-        });
+            // Get the filename from the runtime config
+            let filename = self.rt_cfg.binary_path.clone().and_then(|path| {
+                Path::new(&path)
+                    .file_name()
+                    .and_then(|name| name.to_os_string().into_string().ok())
+            });
 
-        // The [`CrashDumpContext`] accepts xsave as a vector of u8, so we need to convert the
-        // xsave region to a vector of u8
-        Ok(crashdump::CrashDumpContext::new(
-            &self.mem_regions,
-            regs,
-            xsave.region.into_iter().fold(vec![], |mut acc, item| {
-                let bytes = item.to_le_bytes();
-                acc.append(&mut bytes.to_vec());
-
-                acc
-            }),
-            self.entrypoint,
-            self.metadata.binary_path.clone(),
-            filename,
-        ))
+            // The [`CrashDumpContext`] accepts xsave as a vector of u8, so we need to convert the
+            // xsave region to a vector of u8
+            Ok(Some(crashdump::CrashDumpContext::new(
+                &self.mem_regions,
+                regs,
+                xsave
+                    .region
+                    .iter()
+                    .flat_map(|item| item.to_le_bytes())
+                    .collect::<Vec<u8>>(),
+                self.entrypoint,
+                self.rt_cfg.binary_path.clone(),
+                filename,
+            )))
+        } else {
+            Ok(None)
+        }
     }
 
     #[cfg(gdb)]

--- a/src/hyperlight_host/src/hypervisor/kvm.rs
+++ b/src/hyperlight_host/src/hypervisor/kvm.rs
@@ -27,6 +27,8 @@ use kvm_ioctls::{Kvm, VcpuExit, VcpuFd, VmFd};
 use log::LevelFilter;
 use tracing::{Span, instrument};
 
+#[cfg(crashdump)]
+use super::crashdump;
 use super::fpu::{FP_CONTROL_WORD_DEFAULT, FP_TAG_WORD_DEFAULT, MXCSR_DEFAULT};
 #[cfg(gdb)]
 use super::gdb::{DebugCommChannel, DebugMsg, DebugResponse, GuestDebug, KvmDebug, VcpuStopReason};
@@ -658,8 +660,55 @@ impl Hypervisor for KVMDriver {
     }
 
     #[cfg(crashdump)]
-    fn get_memory_regions(&self) -> &[MemoryRegion] {
-        &self.mem_regions
+    fn crashdump_context(&self) -> Result<crashdump::CrashDumpContext> {
+        let mut regs = [0; 27];
+
+        let vcpu_regs = self.vcpu_fd.get_regs()?;
+        let sregs = self.vcpu_fd.get_sregs()?;
+        let xsave = self.vcpu_fd.get_xsave()?;
+
+        // Set the registers in the order expected by the crashdump context
+        regs[0] = vcpu_regs.r15; // r15
+        regs[1] = vcpu_regs.r14; // r14
+        regs[2] = vcpu_regs.r13; // r13
+        regs[3] = vcpu_regs.r12; // r12
+        regs[4] = vcpu_regs.rbp; // rbp
+        regs[5] = vcpu_regs.rbx; // rbx
+        regs[6] = vcpu_regs.r11; // r11
+        regs[7] = vcpu_regs.r10; // r10
+        regs[8] = vcpu_regs.r9; // r9
+        regs[9] = vcpu_regs.r8; // r8
+        regs[10] = vcpu_regs.rax; // rax
+        regs[11] = vcpu_regs.rcx; // rcx
+        regs[12] = vcpu_regs.rdx; // rdx
+        regs[13] = vcpu_regs.rsi; // rsi
+        regs[14] = vcpu_regs.rdi; // rdi
+        regs[15] = 0; // orig rax
+        regs[16] = vcpu_regs.rip; // rip
+        regs[17] = sregs.cs.selector as u64; // cs
+        regs[18] = vcpu_regs.rflags; // eflags
+        regs[19] = vcpu_regs.rsp; // rsp
+        regs[20] = sregs.ss.selector as u64; // ss
+        regs[21] = sregs.fs.base; // fs_base
+        regs[22] = sregs.gs.base; // gs_base
+        regs[23] = sregs.ds.selector as u64; // ds
+        regs[24] = sregs.es.selector as u64; // es
+        regs[25] = sregs.fs.selector as u64; // fs
+        regs[26] = sregs.gs.selector as u64; // gs
+
+        // The [`CrashDumpContext`] accepts xsave as a vector of u8, so we need to convert the
+        // xsave region to a vector of u8
+        Ok(crashdump::CrashDumpContext::new(
+            &self.mem_regions,
+            regs,
+            xsave.region.into_iter().fold(vec![], |mut acc, item| {
+                let bytes = item.to_le_bytes();
+                acc.append(&mut bytes.to_vec());
+
+                acc
+            }),
+            self.entrypoint,
+        ))
     }
 
     #[cfg(gdb)]

--- a/src/hyperlight_host/src/hypervisor/mod.rs
+++ b/src/hyperlight_host/src/hypervisor/mod.rs
@@ -227,7 +227,7 @@ pub(crate) trait Hypervisor: Debug + Sync + Send {
     fn as_mut_hypervisor(&mut self) -> &mut dyn Hypervisor;
 
     #[cfg(crashdump)]
-    fn get_memory_regions(&self) -> &[MemoryRegion];
+    fn crashdump_context(&self) -> Result<crashdump::CrashDumpContext>;
 
     #[cfg(gdb)]
     /// handles the cases when the vCPU stops due to a Debug event

--- a/src/hyperlight_host/src/hypervisor/mod.rs
+++ b/src/hyperlight_host/src/hypervisor/mod.rs
@@ -227,7 +227,7 @@ pub(crate) trait Hypervisor: Debug + Sync + Send {
     fn as_mut_hypervisor(&mut self) -> &mut dyn Hypervisor;
 
     #[cfg(crashdump)]
-    fn crashdump_context(&self) -> Result<crashdump::CrashDumpContext>;
+    fn crashdump_context(&self) -> Result<Option<crashdump::CrashDumpContext>>;
 
     #[cfg(gdb)]
     /// handles the cases when the vCPU stops due to a Debug event
@@ -269,7 +269,7 @@ impl VirtualCPU {
                 }
                 Ok(HyperlightExit::Mmio(addr)) => {
                     #[cfg(crashdump)]
-                    crashdump::crashdump_to_tempfile(hv)?;
+                    crashdump::generate_crashdump(hv)?;
 
                     mem_access_fn
                         .clone()
@@ -281,7 +281,7 @@ impl VirtualCPU {
                 }
                 Ok(HyperlightExit::AccessViolation(addr, tried, region_permission)) => {
                     #[cfg(crashdump)]
-                    crashdump::crashdump_to_tempfile(hv)?;
+                    crashdump::generate_crashdump(hv)?;
 
                     if region_permission.intersects(MemoryRegionFlags::STACK_GUARD) {
                         return Err(HyperlightError::StackOverflow());
@@ -300,14 +300,14 @@ impl VirtualCPU {
                 }
                 Ok(HyperlightExit::Unknown(reason)) => {
                     #[cfg(crashdump)]
-                    crashdump::crashdump_to_tempfile(hv)?;
+                    crashdump::generate_crashdump(hv)?;
 
                     log_then_return!("Unexpected VM Exit {:?}", reason);
                 }
                 Ok(HyperlightExit::Retry()) => continue,
                 Err(e) => {
                     #[cfg(crashdump)]
-                    crashdump::crashdump_to_tempfile(hv)?;
+                    crashdump::generate_crashdump(hv)?;
 
                     return Err(e);
                 }
@@ -455,8 +455,8 @@ pub(crate) mod tests {
     use crate::hypervisor::DbgMemAccessHandlerCaller;
     use crate::mem::ptr::RawPtr;
     use crate::sandbox::uninitialized::GuestBinary;
-    #[cfg(crashdump)]
-    use crate::sandbox::uninitialized::SandboxMetadata;
+    #[cfg(any(crashdump, gdb))]
+    use crate::sandbox::uninitialized::SandboxRuntimeConfig;
     use crate::sandbox::uninitialized_evolve::set_up_hypervisor_partition;
     use crate::sandbox::{SandboxConfiguration, UninitializedSandbox};
     use crate::{Result, is_hypervisor_present, new_error};
@@ -500,16 +500,16 @@ pub(crate) mod tests {
         let filename = dummy_guest_as_string().map_err(|e| new_error!("{}", e))?;
 
         let config: SandboxConfiguration = Default::default();
+        #[cfg(any(crashdump, gdb))]
+        let rt_cfg: SandboxRuntimeConfig = Default::default();
         let sandbox =
             UninitializedSandbox::new(GuestBinary::FilePath(filename.clone()), Some(config))?;
         let (_hshm, mut gshm) = sandbox.mgr.build();
-        #[cfg(crashdump)]
-        let metadata = SandboxMetadata { binary_path: None };
         let mut vm = set_up_hypervisor_partition(
             &mut gshm,
             &config,
-            #[cfg(crashdump)]
-            &metadata,
+            #[cfg(any(crashdump, gdb))]
+            &rt_cfg,
         )?;
         vm.initialise(
             RawPtr::from(0x230000),

--- a/src/hyperlight_host/src/hypervisor/mod.rs
+++ b/src/hyperlight_host/src/hypervisor/mod.rs
@@ -455,6 +455,8 @@ pub(crate) mod tests {
     use crate::hypervisor::DbgMemAccessHandlerCaller;
     use crate::mem::ptr::RawPtr;
     use crate::sandbox::uninitialized::GuestBinary;
+    #[cfg(crashdump)]
+    use crate::sandbox::uninitialized::SandboxMetadata;
     use crate::sandbox::uninitialized_evolve::set_up_hypervisor_partition;
     use crate::sandbox::{SandboxConfiguration, UninitializedSandbox};
     use crate::{Result, is_hypervisor_present, new_error};
@@ -501,7 +503,14 @@ pub(crate) mod tests {
         let sandbox =
             UninitializedSandbox::new(GuestBinary::FilePath(filename.clone()), Some(config))?;
         let (_hshm, mut gshm) = sandbox.mgr.build();
-        let mut vm = set_up_hypervisor_partition(&mut gshm, &config)?;
+        #[cfg(crashdump)]
+        let metadata = SandboxMetadata { binary_path: None };
+        let mut vm = set_up_hypervisor_partition(
+            &mut gshm,
+            &config,
+            #[cfg(crashdump)]
+            &metadata,
+        )?;
         vm.initialise(
             RawPtr::from(0x230000),
             1234567890,

--- a/src/hyperlight_host/src/hypervisor/windows_hypervisor_platform.rs
+++ b/src/hyperlight_host/src/hypervisor/windows_hypervisor_platform.rs
@@ -24,6 +24,7 @@ use windows::core::s;
 use windows_result::HRESULT;
 
 use super::wrappers::HandleWrapper;
+use crate::HyperlightError;
 use crate::hypervisor::wrappers::{WHvFPURegisters, WHvGeneralRegisters, WHvSpecialRegisters};
 use crate::mem::memory_region::{MemoryRegion, MemoryRegionFlags};
 use crate::{Result, new_error};
@@ -407,6 +408,59 @@ impl VMProcessor {
                 rflags: out[17].Reg64,
             })
         }
+    }
+
+    #[cfg(crashdump)]
+    #[instrument(err(Debug), skip_all, parent = Span::current(), level= "Trace")]
+    pub(super) fn get_xsave(&self) -> Result<Vec<u8>> {
+        // Get the required buffer size by calling with NULL buffer
+        let mut buffer_size_needed: u32 = 0;
+
+        unsafe {
+            // First call with NULL buffer to get required size
+            // If the buffer is not large enough, the return value is WHV_E_INSUFFICIENT_BUFFER.
+            // In this case, BytesWritten receives the required buffer size.
+            let result = WHvGetVirtualProcessorXsaveState(
+                self.get_partition_hdl(),
+                0,
+                std::ptr::null_mut(),
+                0,
+                &mut buffer_size_needed,
+            );
+
+            // If it failed for reasons other than insufficient buffer, return error
+            if let Err(e) = result {
+                if e.code() != windows::Win32::Foundation::WHV_E_INSUFFICIENT_BUFFER {
+                    return Err(HyperlightError::WindowsAPIError(e));
+                }
+            }
+        }
+
+        // Create a buffer with the appropriate size
+        let mut xsave_buffer = vec![0; buffer_size_needed as usize];
+
+        // Get the Xsave state
+        let mut written_bytes = 0;
+        unsafe {
+            WHvGetVirtualProcessorXsaveState(
+                self.get_partition_hdl(),
+                0,
+                xsave_buffer.as_mut_ptr() as *mut std::ffi::c_void,
+                buffer_size_needed,
+                &mut written_bytes,
+            )
+        }?;
+
+        // Check if the number of written bytes matches the expected size
+        if written_bytes != buffer_size_needed {
+            return Err(new_error!(
+                "Failed to get Xsave state: expected {} bytes, got {}",
+                buffer_size_needed,
+                written_bytes
+            ));
+        }
+
+        Ok(xsave_buffer)
     }
 
     pub(super) fn set_fpu(&mut self, regs: &WHvFPURegisters) -> Result<()> {

--- a/src/hyperlight_host/src/hypervisor/windows_hypervisor_platform.rs
+++ b/src/hyperlight_host/src/hypervisor/windows_hypervisor_platform.rs
@@ -24,10 +24,9 @@ use windows::core::s;
 use windows_result::HRESULT;
 
 use super::wrappers::HandleWrapper;
-use crate::HyperlightError;
 use crate::hypervisor::wrappers::{WHvFPURegisters, WHvGeneralRegisters, WHvSpecialRegisters};
 use crate::mem::memory_region::{MemoryRegion, MemoryRegionFlags};
-use crate::{Result, new_error};
+use crate::{HyperlightError, Result, new_error};
 
 /// Interop calls for Windows Hypervisor Platform APIs
 ///

--- a/src/hyperlight_host/src/sandbox/uninitialized.rs
+++ b/src/hyperlight_host/src/sandbox/uninitialized.rs
@@ -153,8 +153,7 @@ impl UninitializedSandbox {
             GuestBinary::FilePath(binary_path) => {
                 let path = Path::new(&binary_path)
                     .canonicalize()
-                    .map_err(|e| new_error!("GuestBinary not found: '{}': {}", binary_path, e))?;
-                let path = path
+                    .map_err(|e| new_error!("GuestBinary not found: '{}': {}", binary_path, e))?
                     .into_os_string()
                     .into_string()
                     .map_err(|e| new_error!("Error converting OsString to String: {:?}", e))?;

--- a/src/tests/rust_guests/witguest/Cargo.lock
+++ b/src/tests/rust_guests/witguest/Cargo.lock
@@ -347,9 +347,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.94"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
+checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
 dependencies = [
  "unicode-ident",
 ]
@@ -477,9 +477,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.100"
+version = "2.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
+checksum = "f6397daf94fa90f058bd0fd88429dd9e5738999cca8d701813c80723add80462"
 dependencies = [
  "proc-macro2",
  "quote",


### PR DESCRIPTION
## Purpose
- Add support for core dump file generation when a guest crashes #310 

## Description
This depends on [PR](https://github.com/microsoft/elfcore/pull/34).
This closes #310 

- The `crashdump` feature toggles the logic of the creation of core dumps for Hyperlight Sandboxes.
Additionally, core dumps can be configured at the Sandbox level. By default, all the Sandboxes have core dump generation enabled. The user can set the `guest_core_dump = false` in the `SandboxConfiguration` to disable core dumps for specific Sandboxes.
- By default, Hyperlight places the core dumps in the temporary directory (platform specific).
To change this, use the `HYPERLIGHT_CORE_DUMP_DIR` to specify a directory. If the directory does not exist, it will be created.