### PR TITLE
Fix confusing log message when checking present hypervisor

### DIFF
--- a/src/hyperlight_host/src/hypervisor/hyperv_linux.rs
+++ b/src/hyperlight_host/src/hypervisor/hyperv_linux.rs
@@ -278,8 +278,8 @@ pub(crate) fn is_hypervisor_present() -> bool {
             } // must explicitly close fd to avoid a leak
             true
         }
-        Err(e) => {
-            log::info!("Error creating MSHV object: {:?}", e);
+        Err(_) => {
+            log::info!("MSHV is not available on this system");
             false
         }
     }

--- a/src/hyperlight_host/src/hypervisor/hyperv_linux.rs
+++ b/src/hyperlight_host/src/hypervisor/hyperv_linux.rs
@@ -271,13 +271,8 @@ mod debug {
 /// and functional.
 #[instrument(skip_all, parent = Span::current(), level = "Trace")]
 pub(crate) fn is_hypervisor_present() -> bool {
-    match Mshv::open_with_cloexec(true) {
-        Ok(fd) => {
-            unsafe {
-                libc::close(fd);
-            } // must explicitly close fd to avoid a leak
-            true
-        }
+    match Mshv::new() {
+        Ok(_) => true,
         Err(_) => {
             log::info!("MSHV is not available on this system");
             false

--- a/src/hyperlight_host/src/hypervisor/kvm.rs
+++ b/src/hyperlight_host/src/hypervisor/kvm.rs
@@ -59,7 +59,7 @@ pub(crate) fn is_hypervisor_present() -> bool {
             }
         }
     } else {
-        log::info!("Error creating KVM object");
+        log::info!("KVM is not available on this system");
         false
     }
 }

--- a/src/hyperlight_host/src/hypervisor/windows_hypervisor_platform.rs
+++ b/src/hyperlight_host/src/hypervisor/windows_hypervisor_platform.rs
@@ -53,7 +53,10 @@ pub(crate) fn is_hypervisor_present() -> bool {
         )
     } {
         Ok(_) => unsafe { capability.HypervisorPresent.as_bool() },
-        Err(_) => false,
+        Err(_) => {
+            log::info!("Windows Hypervisor Platform is not available on this system");
+            false
+        }
     }
 }
 

--- a/src/tests/rust_guests/callbackguest/Cargo.lock
+++ b/src/tests/rust_guests/callbackguest/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "anyhow"
-version = "1.0.97"
+version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcfed56ad506cb2c684a14971b8861fdc3baaaae314b9e5f9bb532cbe3ba7a4f"
+checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
 name = "autocfg"

--- a/src/tests/rust_guests/simpleguest/Cargo.lock
+++ b/src/tests/rust_guests/simpleguest/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "anyhow"
-version = "1.0.97"
+version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcfed56ad506cb2c684a14971b8861fdc3baaaae314b9e5f9bb532cbe3ba7a4f"
+checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
 name = "autocfg"


### PR DESCRIPTION
When checking if a specific hypervisor is present using for example `kvm::is_hypervisor_present`, and the hypervisor is not present, a log message is printed with the word 'Error' in it, which was confusing since it's not actually an error.

The second commit does a slight cleanup by switching to Mshv::new() to avoid having to manually close the fd with raw libc calls.

Closes #379 