### PR TITLE
Add GH_TOKEN env to release workflow

### DIFF
--- a/.github/workflows/CreateRelease.yml
+++ b/.github/workflows/CreateRelease.yml
@@ -159,10 +159,14 @@ jobs:
       - name: Extract release notes from changelog
         if: ${{ contains(github.ref, 'refs/heads/release/') }}
         run: just create-release-notes v${{ env.HYPERLIGHT_VERSION }} > RELEASE_NOTES.md
+        env:
+          GH_TOKEN: ${{ github.token }}
 
       - name: Extract prerelease notes from changelog
         if: ${{ github.ref=='refs/heads/main' }}
         run: just create-release-notes dev-latest > RELEASE_NOTES.md
+        env:
+          GH_TOKEN: ${{ github.token }}
 
       - name: Create release
         if: ${{ contains(github.ref, 'refs/heads/release/') }}


### PR DESCRIPTION
Without it, our release notes generation does not work properly, as seen here for v0.4.0 release https://github.com/hyperlight-dev/hyperlight/actions/runs/14764756314/job/41454523267#step:12:12, so I had to run it locally and update the release notes manually.