### PR TITLE
Change base address from 0x200_000 to 0x0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -468,3 +468,6 @@ hyperlight_guest.h
 .mono
 
 !.gitkeep
+
+# gdb
+.gdbinit

--- a/Justfile
+++ b/Justfile
@@ -62,6 +62,22 @@ clean-rust:
 
 # Note: most testing recipes take an optional "features" comma separated list argument. If provided, these will be passed to cargo as **THE ONLY FEATURES**, i.e. default features will be disabled.
 
+# convenience recipe to run all tests with the given target and features (similar to CI)
+test-like-ci config=default-target hypervisor="kvm":
+    @# with default features
+    just test {{config}} {{ if hypervisor == "mshv3" {"mshv3"} else {""} }}
+
+    @# with only one driver enabled + seccomp + inprocess
+    just test {{config}} inprocess,seccomp,{{ if hypervisor == "mshv" {"mshv2"} else if hypervisor == "mshv3" {"mshv3"} else {"kvm"} }}
+
+    @# make sure certain cargo features compile
+    cargo check -p hyperlight-host --features crashdump
+    cargo check -p hyperlight-host --features print_debug
+    cargo check -p hyperlight-host --features gdb
+
+    @# without any driver (should fail to compile)
+    just test-compilation-fail {{config}}
+
 # runs all tests
 test target=default-target features="": (test-unit target features) (test-isolated target features) (test-integration "rust" target features) (test-integration "c" target features) (test-seccomp target features)
 

--- a/docs/paging-development-notes.md
+++ b/docs/paging-development-notes.md
@@ -9,7 +9,7 @@ Hyperlight uses paging, which means the all addresses inside a Hyperlight VM are
 
 ## Host-to-Guest memory mapping
 
-Into each Hyperlight VM, memory from the host is mapped into the VM as physical memory. The physical memory inside the VM starts at address `0x200_000` and extends linearly to however much memory was mapped into the VM (depends on various parameters).
+Into each Hyperlight VM, memory from the host is mapped into the VM as physical memory. The physical memory inside the VM starts at address `0x0` and extends linearly to however much memory was mapped into the VM (depends on various parameters).
 
 ## Page table setup
 
@@ -17,27 +17,27 @@ The following page table structs are set up in memory before running a Hyperligh
 
 ### PML4 (Page Map Level 4) Table
 
-The PML4 table is located at physical address specified in CR3. In Hyperlight we set `CR3=0x200_000`, which means the PML4 table is located at physical address `0x200_000`. The PML4 table comprises 512 64-bit entries.
+The PML4 table is located at physical address specified in CR3. In Hyperlight we set `CR3=0x0`, which means the PML4 table is located at physical address `0x0`. The PML4 table comprises 512 64-bit entries.
 
-In Hyperlight, we only initialize the first entry (at address `0x200_000`), with value `0x201_000`, implying that we only have a single PDPT.
+In Hyperlight, we only initialize the first entry (at address `0x0`), with value `0x1_000`, implying that we only have a single PDPT.
 
 ### PDPT (Page-directory-pointer Table)
 
-The first and only PDPT is located at physical address `0x201_000`. The PDPT comprises 512 64-bit entries. In Hyperlight, we only initialize the first entry of the PDPT (at address `0x201_000`), with the value `0x202_000`, implying that we only have a single PD.
+The first and only PDPT is located at physical address `0x1_000`. The PDPT comprises 512 64-bit entries. In Hyperlight, we only initialize the first entry of the PDPT (at address `0x1_000`), with the value `0x2_000`, implying that we only have a single PD.
 
 ### PD (Page Directory)
 
-The first and only PD is located at physical address `0x202_000`. The PD comprises 512 64-bit entries, each entry `i` is set to the value `(i * 0x1000) + 0x203_000`. Thus, the first entry is `0x203_000`, the second entry is `0x204_000` and so on.
+The first and only PD is located at physical address `0x2_000`. The PD comprises 512 64-bit entries, each entry `i` is set to the value `(i * 0x1000) + 0x3_000`. Thus, the first entry is `0x3_000`, the second entry is `0x4_000` and so on.
 
 ### PT (Page Table)
 
-The page tables start at physical address `0x203_000`. Each page table has 512 64-bit entries. Each entry is set to the value `p << 21|i << 12` where `p` is the page table number and `i` is the index of the entry in the page table. Thus, the first entry of the first page table is `0x000_000`, the second entry is `0x000_000 + 0x1000`, and so on. The first entry of the second page table is `0x200_000 + 0x1000`, the second entry is `0x200_000 + 0x2000`, and so on. Enough page tables are created to cover the size of memory mapped into the VM.
+The page tables start at physical address `0x3_000`. Each page table has 512 64-bit entries. Each entry is set to the value `p << 21|i << 12` where `p` is the page table number and `i` is the index of the entry in the page table. Thus, the first entry of the first page table is `0x000_000`, the second entry is `0x000_000 + 0x1000`, and so on. The first entry of the second page table is `0x200_000 + 0x1000`, the second entry is `0x200_000 + 0x2000`, and so on. Enough page tables are created to cover the size of memory mapped into the VM.
 
 ## Address Translation
 
 Given a 64-bit virtual address X, the corresponding physical address is obtained as follows:
 
-1. PML4 table's physical address is located using CR3 (CR3 is `0x200_000`).
+1. PML4 table's physical address is located using CR3 (CR3 is `0x0`).
 2. Bits 47:39 of X are used to index into PML4, giving us the address of the PDPT.
 3. Bits 38:30 of X are used to index into PDPT, giving us the address of the PD.
 4. Bits 29:21 of X are used to index into PD, giving us the address of the PT.
@@ -63,7 +63,7 @@ In addition to providing addresses, page table entries also contain access flags
 
 PML4E, PDPTE, and PD Entries have the present flag set to 1, and the rest of the flags are not set.
 
-PTE Entries all have the present flag set to 1, apart from those for the address range `0x000_000` to `0x1FF_000` which have the present flag set to 0 as we do not map memory below physical address `0x200_000`. 
+PTE Entries all have the present flag set to 1.
 
 In addition, the following flags are set according to the type of memory being mapped:
 

--- a/src/hyperlight_host/src/lib.rs
+++ b/src/hyperlight_host/src/lib.rs
@@ -57,13 +57,13 @@ pub mod hypervisor;
 ///
 /// Virtual Address
 ///
-/// 0x200000    PML4
-/// 0x201000    PDPT
-/// 0x202000    PD
-/// 0x203000    The guest PE code (When the code has been loaded using LoadLibrary to debug the guest this will not be
+/// 0x0000    PML4
+/// 0x1000    PDPT
+/// 0x2000    PD
+/// 0x3000    The guest PE code (When the code has been loaded using LoadLibrary to debug the guest this will not be
 /// present and code length will be zero;
 ///
-/// The pointer passed to the Entrypoint in the Guest application is the 0x200000 + size of page table + size of code,
+/// The pointer passed to the Entrypoint in the Guest application is the ize of page table + size of code,
 /// at this address structs below are laid out in this order
 pub mod mem;
 /// Metric definitions and helpers

--- a/src/hyperlight_host/src/mem/ptr.rs
+++ b/src/hyperlight_host/src/mem/ptr.rs
@@ -241,13 +241,4 @@ mod tests {
             );
         }
     }
-
-    #[test]
-    fn ptr_fail() {
-        {
-            let raw_guest_ptr = RawPtr(SandboxMemoryLayout::BASE_ADDRESS as u64 - 1);
-            let guest_ptr = GuestPtr::try_from(raw_guest_ptr);
-            assert!(guest_ptr.is_err());
-        }
-    }
 }


### PR DESCRIPTION
This PR is the start of an effort to break down #297 into more digestible pieces. 

In here, I changed the base address from our arbitrary 0x200_000 value start to 0x0, which is needed for custom guests (e.g., Nanvix) to execute properly. Aside from just changing the value, I also had to modify our `get_address` macro and the PT setup–see efecff4.

In addition, I also committed two small convenience things: (1) added the .gdbinit to our .gitignore, and (2) added a new Justfile recipe to more easily run a CI-like test suite locally. 