### PR TITLE
Remove kernel stack and boot stack memory regions

### DIFF
--- a/src/hyperlight_host/src/hypervisor/kvm.rs
+++ b/src/hyperlight_host/src/hypervisor/kvm.rs
@@ -569,8 +569,9 @@ impl Hypervisor for KVMDriver {
                 }
             },
             Ok(other) => {
-                crate::debug!("KVM Other Exit {:?}", other);
-                HyperlightExit::Unknown(format!("Unexpected KVM Exit {:?}", other))
+                let err_msg = format!("Unexpected KVM Exit {:?}", other);
+                crate::debug!("KVM Other Exit Details: {:#?}", &self);
+                HyperlightExit::Unknown(err_msg)
             }
         };
         Ok(result)

--- a/src/hyperlight_host/src/mem/memory_region.rs
+++ b/src/hyperlight_host/src/mem/memory_region.rs
@@ -149,10 +149,6 @@ pub enum MemoryRegionType {
     GuardPage,
     /// The region contains the Stack
     Stack,
-    /// The region contains the Kernel Stack
-    KernelStack,
-    /// The region contains the Boot Stack
-    BootStack,
 }
 
 /// represents a single memory region inside the guest. All memory within a region has

--- a/src/hyperlight_host/src/mem/mgr.rs
+++ b/src/hyperlight_host/src/mem/mgr.rs
@@ -58,7 +58,7 @@ const PAGE_USER: u64 = 1 << 2; // User/Supervisor (if this bit is set then the p
 const PAGE_NX: u64 = 1 << 63; // Execute Disable (if this bit is set then data in the page cannot be executed)
 
 // The amount of memory that can be mapped per page table
-pub(super) const AMOUNT_OF_MEMORY_PER_PT: usize = 0x200000;
+pub(super) const AMOUNT_OF_MEMORY_PER_PT: usize = 0x200_000;
 /// Read/write permissions flag for the 64-bit PDE
 /// The page size for the 64-bit PDE
 /// The size of stack guard cookies
@@ -213,8 +213,6 @@ where
                             // Host Exception Data are readonly in the guest
                             MemoryRegionType::HostExceptionData => PAGE_PRESENT | PAGE_NX,
                             MemoryRegionType::PageTables => PAGE_PRESENT | PAGE_RW | PAGE_NX,
-                            MemoryRegionType::KernelStack => PAGE_PRESENT | PAGE_RW | PAGE_NX,
-                            MemoryRegionType::BootStack => PAGE_PRESENT | PAGE_RW | PAGE_NX,
                         },
                         // If there is an error then the address isn't mapped so mark it as not present
                         Err(_) => 0,


### PR DESCRIPTION
These memory regions are unused and should be removed.

> Note: Just like #450 , this PR is also part of the effort of breaking #297 into more digestible bits.