### PR TITLE
Add error logging when MapViewOfFileNuma2 fails

### DIFF
--- a/src/hyperlight_host/src/hypervisor/surrogate_process_manager.rs
+++ b/src/hyperlight_host/src/hypervisor/surrogate_process_manager.rs
@@ -169,8 +169,11 @@ impl SurrogateProcessManager {
         };
 
         if allocated_address.Value.is_null() {
+            // Safety: `MapViewOfFileNuma2` will set the last error code if it fails.
+            let error = unsafe { windows::Win32::Foundation::GetLastError() };
             log_then_return!(
-                "MapViewOfFileNuma2 failed for mem address {:?}",
+                "MapViewOfFileNuma2 failed with error code: {:?} for mem address {:?} ",
+                error,
                 raw_source_address
             );
         }


### PR DESCRIPTION
MapViewOfFileNuma2  has started failing sometimes in CI. This PR adds some more information to the error message to help us debug the issue.