### PR TITLE
Guest error region refactor

### DIFF
--- a/src/hyperlight_common/src/mem/mod.rs
+++ b/src/hyperlight_common/src/mem/mod.rs
@@ -84,7 +84,6 @@ pub struct GuestPanicContextData {
 pub struct HyperlightPEB {
     pub security_cookie_seed: u64,
     pub guest_function_dispatch_ptr: u64,
-    pub guestErrorData: GuestErrorData,
     pub pCode: *mut c_char,
     pub pOutb: *mut c_void,
     pub pOutbContext: *mut c_void,

--- a/src/hyperlight_guest/src/entrypoint.rs
+++ b/src/hyperlight_guest/src/entrypoint.rs
@@ -23,7 +23,6 @@ use log::LevelFilter;
 use spin::Once;
 
 use crate::gdt::load_gdt;
-use crate::guest_error::reset_error;
 use crate::guest_function_call::dispatch_function;
 use crate::guest_logger::init_logger;
 use crate::host_function_call::{outb, OutBAction};
@@ -145,8 +144,6 @@ pub extern "win64" fn entrypoint(peb_address: u64, seed: u64, ops: u64, max_log_
             OS_PAGE_SIZE = ops as u32;
 
             (*peb_ptr).guest_function_dispatch_ptr = dispatch_function as usize as u64;
-
-            reset_error();
 
             hyperlight_main();
         }

--- a/src/hyperlight_guest/src/guest_error.rs
+++ b/src/hyperlight_guest/src/guest_error.rs
@@ -14,73 +14,27 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use alloc::string::{String, ToString};
+use alloc::string::ToString;
 use alloc::vec::Vec;
 use core::ffi::{c_char, CStr};
 
 use hyperlight_common::flatbuffer_wrappers::guest_error::{ErrorCode, GuestError};
-use log::error;
 
 use crate::entrypoint::halt;
 use crate::host_function_call::{outb, OutBAction};
-use crate::P_PEB;
+use crate::shared_output_data::push_shared_output_data;
 
 pub(crate) fn write_error(error_code: ErrorCode, message: Option<&str>) {
     let guest_error = GuestError::new(
         error_code.clone(),
         message.map_or("".to_string(), |m| m.to_string()),
     );
-    let mut guest_error_buffer: Vec<u8> = (&guest_error)
+    let guest_error_buffer: Vec<u8> = (&guest_error)
         .try_into()
         .expect("Invalid guest_error_buffer, could not be converted to a Vec<u8>");
 
-    unsafe {
-        assert!(!(*P_PEB.unwrap()).guestErrorData.guestErrorBuffer.is_null());
-        let len = guest_error_buffer.len();
-        if guest_error_buffer.len() > (*P_PEB.unwrap()).guestErrorData.guestErrorSize as usize {
-            error!(
-                "Guest error buffer is too small to hold the error message: size {} buffer size {} message may be truncated",
-                guest_error_buffer.len(),
-                (*P_PEB.unwrap()).guestErrorData.guestErrorSize as usize
-            );
-            // get the length of the message
-            let message_len = message.map_or("".to_string(), |m| m.to_string()).len();
-            // message is too long, truncate it
-            let truncate_len = message_len
-                - (guest_error_buffer.len()
-                    - (*P_PEB.unwrap()).guestErrorData.guestErrorSize as usize);
-            let truncated_message = message
-                .map_or("".to_string(), |m| m.to_string())
-                .chars()
-                .take(truncate_len)
-                .collect::<String>();
-            let guest_error = GuestError::new(error_code, truncated_message);
-            guest_error_buffer = (&guest_error)
-                .try_into()
-                .expect("Invalid guest_error_buffer, could not be converted to a Vec<u8>");
-        }
-
-        // Optimally, we'd use copy_from_slice here, but, because
-        // p_guest_error_buffer is a *mut c_void, we can't do that.
-        // Instead, we do the copying manually using pointer arithmetic.
-        // Plus; before, we'd do an assert w/ the result from copy_from_slice,
-        // but, because copy_nonoverlapping doesn't return anything, we can't do that.
-        // Instead, we do the prior asserts/checks to check the destination pointer isn't null
-        // and that there is enough space in the destination buffer for the copy.
-        let dest_ptr = (*P_PEB.unwrap()).guestErrorData.guestErrorBuffer as *mut u8;
-        core::ptr::copy_nonoverlapping(guest_error_buffer.as_ptr(), dest_ptr, len);
-    }
-}
-
-pub(crate) fn reset_error() {
-    unsafe {
-        let peb_ptr = P_PEB.unwrap();
-        core::ptr::write_bytes(
-            (*peb_ptr).guestErrorData.guestErrorBuffer,
-            0,
-            (*peb_ptr).guestErrorData.guestErrorSize as usize,
-        );
-    }
+    push_shared_output_data(guest_error_buffer)
+        .expect("Unable to push guest error to shared output data");
 }
 
 pub(crate) fn set_error(error_code: ErrorCode, message: &str) {

--- a/src/hyperlight_guest/src/guest_function_call.rs
+++ b/src/hyperlight_guest/src/guest_function_call.rs
@@ -23,7 +23,7 @@ use hyperlight_common::flatbuffer_wrappers::guest_error::ErrorCode;
 
 use crate::entrypoint::halt;
 use crate::error::{HyperlightGuestError, Result};
-use crate::guest_error::{reset_error, set_error};
+use crate::guest_error::set_error;
 use crate::shared_input_data::try_pop_shared_input_data_into;
 use crate::shared_output_data::push_shared_output_data;
 use crate::REGISTERED_GUEST_FUNCTIONS;
@@ -81,8 +81,6 @@ pub(crate) fn call_guest_function(function_call: FunctionCall) -> Result<Vec<u8>
 #[no_mangle]
 #[inline(never)]
 fn internal_dispatch_function() -> Result<()> {
-    reset_error();
-
     #[cfg(debug_assertions)]
     log::trace!("internal_dispatch_function");
 

--- a/src/hyperlight_host/src/mem/memory_region.rs
+++ b/src/hyperlight_host/src/mem/memory_region.rs
@@ -131,8 +131,6 @@ pub enum MemoryRegionType {
     Code,
     /// The region contains the PEB
     Peb,
-    /// The region contains the Guest Error Data
-    GuestErrorData,
     /// The region contains the Input Data
     InputData,
     /// The region contains the Output Data

--- a/src/hyperlight_host/src/mem/mgr.rs
+++ b/src/hyperlight_host/src/mem/mgr.rs
@@ -199,7 +199,6 @@ where
                             MemoryRegionType::OutputData => PAGE_PRESENT | PAGE_RW | PAGE_NX,
                             MemoryRegionType::Peb => PAGE_PRESENT | PAGE_RW | PAGE_NX,
                             MemoryRegionType::PanicContext => PAGE_PRESENT | PAGE_RW | PAGE_NX,
-                            MemoryRegionType::GuestErrorData => PAGE_PRESENT | PAGE_RW | PAGE_NX,
                             MemoryRegionType::PageTables => PAGE_PRESENT | PAGE_RW | PAGE_NX,
                         },
                         // If there is an error then the address isn't mapped so mark it as not present
@@ -591,22 +590,11 @@ impl SandboxMemoryManager<HostSharedMemory> {
 
     /// Get the guest error data
     #[instrument(err(Debug), skip_all, parent = Span::current(), level= "Trace")]
-    pub(crate) fn get_guest_error(&self) -> Result<GuestError> {
-        // get memory buffer max size
-        let err_buffer_size_offset = self.layout.get_guest_error_buffer_size_offset();
-        let max_err_buffer_size = self.shared_mem.read::<u64>(err_buffer_size_offset)?;
-
-        // get guest error from layout and shared mem
-        let mut guest_error_buffer = vec![b'0'; usize::try_from(max_err_buffer_size)?];
-        let err_msg_offset = self.layout.guest_error_buffer_offset;
-        self.shared_mem
-            .copy_to_slice(guest_error_buffer.as_mut_slice(), err_msg_offset)?;
-        GuestError::try_from(guest_error_buffer.as_slice()).map_err(|e| {
-            new_error!(
-                "get_guest_error: failed to convert buffer to GuestError: {}",
-                e
-            )
-        })
+    pub(crate) fn get_guest_error(&mut self) -> Result<GuestError> {
+        self.shared_mem.try_pop_buffer_into::<GuestError>(
+            self.layout.output_data_buffer_offset,
+            self.layout.sandbox_memory_config.get_output_data_size(),
+        )
     }
 
     /// Read guest panic data from the `SharedMemory` contained within `self`

--- a/src/hyperlight_host/src/sandbox/uninitialized.rs
+++ b/src/hyperlight_host/src/sandbox/uninitialized.rs
@@ -434,8 +434,6 @@ mod tests {
             let mut cfg = SandboxConfiguration::default();
             cfg.set_input_data_size(0x1000);
             cfg.set_output_data_size(0x1000);
-            cfg.set_host_function_definition_size(0x1000);
-            cfg.set_host_exception_size(0x1000);
             cfg.set_stack_size(0x1000);
             cfg.set_heap_size(0x1000);
             cfg.set_max_execution_time(Duration::from_millis(1001));

--- a/src/hyperlight_host/src/sandbox/uninitialized.rs
+++ b/src/hyperlight_host/src/sandbox/uninitialized.rs
@@ -436,7 +436,6 @@ mod tests {
             cfg.set_output_data_size(0x1000);
             cfg.set_host_function_definition_size(0x1000);
             cfg.set_host_exception_size(0x1000);
-            cfg.set_guest_error_buffer_size(0x1000);
             cfg.set_stack_size(0x1000);
             cfg.set_heap_size(0x1000);
             cfg.set_max_execution_time(Duration::from_millis(1001));


### PR DESCRIPTION
Removed the guest error region. Now, instead, we use the input/output data stacks to transmit guest errors.

> Note: Just like #457 , this PR is also part of the effort of breaking #297 into more digestible bits.
