### PR TITLE
Remove dependency on the paste crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1231,7 +1231,6 @@ dependencies = [
  "opentelemetry-semantic-conventions",
  "opentelemetry_sdk",
  "page_size",
- "paste",
  "proc-maps",
  "proptest",
  "rand 0.9.1",

--- a/src/hyperlight_host/Cargo.toml
+++ b/src/hyperlight_host/Cargo.toml
@@ -25,7 +25,6 @@ goblin = { version = "0.9" }
 rand = { version = "0.9" }
 cfg-if = { version = "1.0.0" }
 libc = { version = "0.2.172" }
-paste = "1.0"
 flatbuffers = "25.2.10"
 page_size = "0.6.0"
 termcolor = "1.2.0"


### PR DESCRIPTION
This PR removes the last usage of the `paste` crate.
Fixes #341