### PR TITLE
Improve the ergonomics of registering host functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,16 +47,11 @@ fn main() -> hyperlight_host::Result<()> {
         None, // default host print function
     )?;
 
-    // Register a host function
-    fn sleep_5_secs() -> hyperlight_host::Result<()> {
+    // Registering a host function makes it available to be called by the guest
+    uninitialized_sandbox.register("Sleep5Secs", || {
         thread::sleep(std::time::Duration::from_secs(5));
         Ok(())
-    }
-
-    let host_function = Arc::new(Mutex::new(sleep_5_secs));
-
-    // Registering a host function makes it available to be called by the guest
-    host_function.register(&mut uninitialized_sandbox, "Sleep5Secs")?;
+    })?;
     // Note: This function is unused by the guest code below, it's just here for demonstration purposes
 
     // Initialize sandbox to be able to call host functions

--- a/src/hyperlight_host/benches/benchmarks.rs
+++ b/src/hyperlight_host/benches/benchmarks.rs
@@ -14,12 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use criterion::{criterion_group, criterion_main, Criterion};
 use hyperlight_common::flatbuffer_wrappers::function_types::{ParameterValue, ReturnType};
-use hyperlight_host::func::HostFunction;
 use hyperlight_host::sandbox::{MultiUseSandbox, SandboxConfiguration, UninitializedSandbox};
 use hyperlight_host::sandbox_state::sandbox::EvolvableSandbox;
 use hyperlight_host::sandbox_state::transition::Noop;
@@ -110,12 +108,8 @@ fn guest_call_benchmark(c: &mut Criterion) {
         let mut uninitialized_sandbox = create_uninit_sandbox();
 
         // Define a host function that adds two integers and register it.
-        fn add(a: i32, b: i32) -> hyperlight_host::Result<i32> {
-            Ok(a + b)
-        }
-        let host_function = Arc::new(Mutex::new(add));
-        host_function
-            .register(&mut uninitialized_sandbox, "HostAdd")
+        uninitialized_sandbox
+            .register("HostAdd", |a: i32, b: i32| Ok(a + b))
             .unwrap();
 
         let multiuse_sandbox: MultiUseSandbox =

--- a/src/hyperlight_host/examples/guest-debugging/main.rs
+++ b/src/hyperlight_host/examples/guest-debugging/main.rs
@@ -14,11 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use std::sync::{Arc, Mutex};
 use std::thread;
 
 use hyperlight_common::flatbuffer_wrappers::function_types::{ParameterValue, ReturnType};
-use hyperlight_host::func::HostFunction;
 #[cfg(gdb)]
 use hyperlight_host::sandbox::config::DebugInfo;
 use hyperlight_host::sandbox::SandboxConfiguration;
@@ -55,14 +53,10 @@ fn main() -> hyperlight_host::Result<()> {
     )?;
 
     // Register a host functions
-    fn sleep_5_secs() -> hyperlight_host::Result<()> {
+    uninitialized_sandbox.register("Sleep5Secs", || {
         thread::sleep(std::time::Duration::from_secs(5));
         Ok(())
-    }
-
-    let host_function = Arc::new(Mutex::new(sleep_5_secs));
-
-    host_function.register(&mut uninitialized_sandbox, "Sleep5Secs")?;
+    })?;
     // Note: This function is unused, it's just here for demonstration purposes
 
     // Initialize sandbox to be able to call host functions

--- a/src/hyperlight_host/examples/hello-world/main.rs
+++ b/src/hyperlight_host/examples/hello-world/main.rs
@@ -14,11 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use std::sync::{Arc, Mutex};
 use std::thread;
 
 use hyperlight_common::flatbuffer_wrappers::function_types::{ParameterValue, ReturnType};
-use hyperlight_host::func::HostFunction;
 use hyperlight_host::sandbox_state::sandbox::EvolvableSandbox;
 use hyperlight_host::sandbox_state::transition::Noop;
 use hyperlight_host::{MultiUseSandbox, UninitializedSandbox};
@@ -35,14 +33,10 @@ fn main() -> hyperlight_host::Result<()> {
     )?;
 
     // Register a host functions
-    fn sleep_5_secs() -> hyperlight_host::Result<()> {
+    uninitialized_sandbox.register("Sleep5Secs", || {
         thread::sleep(std::time::Duration::from_secs(5));
         Ok(())
-    }
-
-    let host_function = Arc::new(Mutex::new(sleep_5_secs));
-
-    host_function.register(&mut uninitialized_sandbox, "Sleep5Secs")?;
+    })?;
     // Note: This function is unused, it's just here for demonstration purposes
 
     // Initialize sandbox to be able to call host functions


### PR DESCRIPTION
This PR adds the `register` and `register_with_extra_allowed_syscalls` methods to the `UninitializedSandbox` to register host methods.
e.g.,
```rust
uninitialized_sandbox.register("add", |a: i32, b: i32| {
    Ok(a + b)
})?;
```

This method accepts either:
* `FnMut(..) -> Result<R>`
* `Arc<Mutex<FnMut(..) -> Result<R>>>`
* `&Arc<Mutex<FnMut(..) -> Result<R>>>`

This is controlled by the IntoHostFunction trait.

This is not a breaking change. It's an additive change, and the previous registration mechanism continues to works.