### PR TITLE
Adding code owners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Global Code Owners
+* @danbugs @ludfjig @dblnz @devigned @syntactically @marosset @jprendes @simongdavies


### PR DESCRIPTION
Adding a codeowners file to be referred to by CNCF project-maintainers list.

Once this merges will also add it to the branch protection rules so at least one of the people mentioned has to approve PRs