### PR TITLE
Remove generics from SupportedParameterType and SupportedReturnType traits

### DIFF
--- a/src/hyperlight_host/src/func/host_functions.rs
+++ b/src/hyperlight_host/src/func/host_functions.rs
@@ -87,8 +87,8 @@ macro_rules! impl_host_function {
             impl<R $(, $P)*, F> HostFunction<R, ($($P,)*)> for Arc<Mutex<F>>
             where
                 F: FnMut($($P),*) -> Result<R> + Send + 'static,
-                $($P: SupportedParameterType<$P> + Clone,)*
-                R: SupportedReturnType<R>,
+                $($P: SupportedParameterType + Clone,)*
+                R: SupportedReturnType,
             {
                 /// Register the host function with the given name in the sandbox.
                 #[instrument(
@@ -162,8 +162,8 @@ macro_rules! impl_host_function {
             ) -> Result<()>
             where
                 T: FnMut($($P),*) -> Result<R> + Send + 'static,
-                $($P: SupportedParameterType<$P> + Clone,)*
-                R: SupportedReturnType<R>,
+                $($P: SupportedParameterType + Clone,)*
+                R: SupportedReturnType,
             {
                 const N: usize = impl_host_function!(@count $($P),*);
                 let cloned = self_.clone();

--- a/src/hyperlight_host/src/func/param_type.rs
+++ b/src/hyperlight_host/src/func/param_type.rs
@@ -24,8 +24,8 @@ use crate::{log_then_return, Result};
 /// valid Hyperlight parameter type.
 ///
 /// For each parameter type Hyperlight supports in host functions, we
-/// provide an implementation for `SupportedParameterType<SupportedType>`
-pub trait SupportedParameterType<T> {
+/// provide an implementation for `SupportedParameterType`
+pub trait SupportedParameterType: Sized {
     /// Get the underlying Hyperlight parameter type representing this
     /// `SupportedParameterType`
     fn get_hyperlight_type() -> ParameterType;
@@ -33,11 +33,11 @@ pub trait SupportedParameterType<T> {
     /// `SupportedParameterType`
     fn get_hyperlight_value(&self) -> ParameterValue;
     /// Get the actual inner value of this `SupportedParameterType`
-    fn get_inner(a: ParameterValue) -> Result<T>;
+    fn get_inner(a: ParameterValue) -> Result<Self>;
 }
 
 // We can then implement these traits for each type that Hyperlight supports as a parameter or return type
-impl SupportedParameterType<String> for String {
+impl SupportedParameterType for String {
     #[instrument(skip_all, parent = Span::current(), level= "Trace")]
     fn get_hyperlight_type() -> ParameterType {
         ParameterType::String
@@ -59,7 +59,7 @@ impl SupportedParameterType<String> for String {
     }
 }
 
-impl SupportedParameterType<i32> for i32 {
+impl SupportedParameterType for i32 {
     #[instrument(skip_all, parent = Span::current(), level= "Trace")]
     fn get_hyperlight_type() -> ParameterType {
         ParameterType::Int
@@ -81,7 +81,7 @@ impl SupportedParameterType<i32> for i32 {
     }
 }
 
-impl SupportedParameterType<u32> for u32 {
+impl SupportedParameterType for u32 {
     #[instrument(skip_all, parent = Span::current(), level= "Trace")]
     fn get_hyperlight_type() -> ParameterType {
         ParameterType::UInt
@@ -103,7 +103,7 @@ impl SupportedParameterType<u32> for u32 {
     }
 }
 
-impl SupportedParameterType<i64> for i64 {
+impl SupportedParameterType for i64 {
     #[instrument(skip_all, parent = Span::current(), level= "Trace")]
     fn get_hyperlight_type() -> ParameterType {
         ParameterType::Long
@@ -125,7 +125,7 @@ impl SupportedParameterType<i64> for i64 {
     }
 }
 
-impl SupportedParameterType<u64> for u64 {
+impl SupportedParameterType for u64 {
     #[instrument(skip_all, parent = Span::current(), level= "Trace")]
     fn get_hyperlight_type() -> ParameterType {
         ParameterType::ULong
@@ -147,7 +147,7 @@ impl SupportedParameterType<u64> for u64 {
     }
 }
 
-impl SupportedParameterType<bool> for bool {
+impl SupportedParameterType for bool {
     #[instrument(skip_all, parent = Span::current(), level= "Trace")]
     fn get_hyperlight_type() -> ParameterType {
         ParameterType::Bool
@@ -169,7 +169,7 @@ impl SupportedParameterType<bool> for bool {
     }
 }
 
-impl SupportedParameterType<Vec<u8>> for Vec<u8> {
+impl SupportedParameterType for Vec<u8> {
     #[instrument(skip_all, parent = Span::current(), level= "Trace")]
     fn get_hyperlight_type() -> ParameterType {
         ParameterType::VecBytes

--- a/src/hyperlight_host/src/func/ret_type.rs
+++ b/src/hyperlight_host/src/func/ret_type.rs
@@ -21,7 +21,7 @@ use crate::HyperlightError::ReturnValueConversionFailure;
 use crate::{log_then_return, Result};
 
 /// This is a marker trait that is used to indicate that a type is a valid Hyperlight return type.
-pub trait SupportedReturnType<T> {
+pub trait SupportedReturnType: Sized {
     /// Gets the return type of the supported return value
     fn get_hyperlight_type() -> ReturnType;
 
@@ -29,10 +29,10 @@ pub trait SupportedReturnType<T> {
     fn get_hyperlight_value(&self) -> ReturnValue;
 
     /// Gets the inner value of the supported return type
-    fn get_inner(a: ReturnValue) -> Result<T>;
+    fn get_inner(a: ReturnValue) -> Result<Self>;
 }
 
-impl SupportedReturnType<()> for () {
+impl SupportedReturnType for () {
     #[instrument(skip_all, parent = Span::current(), level= "Trace")]
     fn get_hyperlight_type() -> ReturnType {
         ReturnType::Void
@@ -54,7 +54,7 @@ impl SupportedReturnType<()> for () {
     }
 }
 
-impl SupportedReturnType<String> for String {
+impl SupportedReturnType for String {
     #[instrument(skip_all, parent = Span::current(), level= "Trace")]
     fn get_hyperlight_type() -> ReturnType {
         ReturnType::String
@@ -76,7 +76,7 @@ impl SupportedReturnType<String> for String {
     }
 }
 
-impl SupportedReturnType<i32> for i32 {
+impl SupportedReturnType for i32 {
     #[instrument(skip_all, parent = Span::current(), level= "Trace")]
     fn get_hyperlight_type() -> ReturnType {
         ReturnType::Int
@@ -98,7 +98,7 @@ impl SupportedReturnType<i32> for i32 {
     }
 }
 
-impl SupportedReturnType<u32> for u32 {
+impl SupportedReturnType for u32 {
     #[instrument(skip_all, parent = Span::current(), level= "Trace")]
     fn get_hyperlight_type() -> ReturnType {
         ReturnType::UInt
@@ -120,7 +120,7 @@ impl SupportedReturnType<u32> for u32 {
     }
 }
 
-impl SupportedReturnType<i64> for i64 {
+impl SupportedReturnType for i64 {
     #[instrument(skip_all, parent = Span::current(), level= "Trace")]
     fn get_hyperlight_type() -> ReturnType {
         ReturnType::Long
@@ -142,7 +142,7 @@ impl SupportedReturnType<i64> for i64 {
     }
 }
 
-impl SupportedReturnType<u64> for u64 {
+impl SupportedReturnType for u64 {
     #[instrument(skip_all, parent = Span::current(), level= "Trace")]
     fn get_hyperlight_type() -> ReturnType {
         ReturnType::ULong
@@ -164,7 +164,7 @@ impl SupportedReturnType<u64> for u64 {
     }
 }
 
-impl SupportedReturnType<bool> for bool {
+impl SupportedReturnType for bool {
     #[instrument(skip_all, parent = Span::current(), level= "Trace")]
     fn get_hyperlight_type() -> ReturnType {
         ReturnType::Bool
@@ -186,7 +186,7 @@ impl SupportedReturnType<bool> for bool {
     }
 }
 
-impl SupportedReturnType<Vec<u8>> for Vec<u8> {
+impl SupportedReturnType for Vec<u8> {
     #[instrument(skip_all, parent = Span::current(), level= "Trace")]
     fn get_hyperlight_type() -> ReturnType {
         ReturnType::VecBytes


### PR DESCRIPTION
As far as I can tell those generics are not needed
They also mean that for each generic value it's actually a different trait, making it harder to use them as generics themselves.