### PR TITLE
Improve ergonomics of SupportedParameterType and SupportedReturnType

### DIFF
--- a/src/hyperlight_common/src/flatbuffer_wrappers/function_types.rs
+++ b/src/hyperlight_common/src/flatbuffer_wrappers/function_types.rs
@@ -99,7 +99,7 @@ pub enum ReturnValue {
     /// bool
     Bool(bool),
     /// ()
-    Void,
+    Void(()),
     /// Vec<u8>
     VecBytes(Vec<u8>),
 }
@@ -508,7 +508,7 @@ impl TryFrom<ReturnValue> for () {
     #[cfg_attr(feature = "tracing", instrument(err(Debug), skip_all, parent = Span::current(), level= "Trace"))]
     fn try_from(value: ReturnValue) -> Result<Self> {
         match value {
-            ReturnValue::Void => Ok(()),
+            ReturnValue::Void(()) => Ok(()),
             _ => {
                 bail!("Unexpected return value type: {:?}", value)
             }
@@ -570,7 +570,7 @@ impl TryFrom<FbFunctionCallResult<'_>> for ReturnValue {
                 };
                 Ok(ReturnValue::String(hlstring.unwrap_or("".to_string())))
             }
-            FbReturnValue::hlvoid => Ok(ReturnValue::Void),
+            FbReturnValue::hlvoid => Ok(ReturnValue::Void(())),
             FbReturnValue::hlsizeprefixedbuffer => {
                 let hlvecbytes =
                     match function_call_result_fb.return_value_as_hlsizeprefixedbuffer() {
@@ -724,7 +724,7 @@ impl TryFrom<&ReturnValue> for Vec<u8> {
                 builder.finish_size_prefixed(function_call_result, None);
                 builder.finished_data().to_vec()
             }
-            ReturnValue::Void => {
+            ReturnValue::Void(()) => {
                 let hlvoid = hlvoid::create(&mut builder, &hlvoidArgs {});
                 let function_call_result = FbFunctionCallResult::create(
                     &mut builder,

--- a/src/hyperlight_host/src/func/host_functions.rs
+++ b/src/hyperlight_host/src/func/host_functions.rs
@@ -169,7 +169,7 @@ macro_rules! impl_host_function {
                 let cloned = self_.clone();
                 let func = Box::new(move |args: Vec<ParameterValue>| {
                     let ($($P,)*) = match <[ParameterValue; N]>::try_from(args) {
-                        Ok([$($P,)*]) => ($($P::get_inner($P)?,)*),
+                        Ok([$($P,)*]) => ($($P::from_value($P)?,)*),
                         Err(args) => { log_then_return!(UnexpectedNoOfArguments(args.len(), N)); }
                     };
 
@@ -178,10 +178,10 @@ macro_rules! impl_host_function {
                         .map_err(|e| new_error!("Error locking at {}:{}: {}", file!(), line!(), e))?(
                             $($P),*
                         )?;
-                    Ok(result.get_hyperlight_value())
+                    Ok(result.into_value())
                 });
 
-                let parameter_types = Some(vec![$($P::get_hyperlight_type()),*]);
+                let parameter_types = Some(vec![$($P::TYPE),*]);
 
                 if let Some(_eas) = extra_allowed_syscalls {
                     if cfg!(all(feature = "seccomp", target_os = "linux")) {
@@ -196,7 +196,7 @@ macro_rules! impl_host_function {
                                     &HostFunctionDefinition::new(
                                         name.to_string(),
                                         parameter_types,
-                                        R::get_hyperlight_type(),
+                                        R::TYPE,
                                     ),
                                     HyperlightFunction::new(func),
                                     _eas,
@@ -216,7 +216,7 @@ macro_rules! impl_host_function {
                             &HostFunctionDefinition::new(
                                 name.to_string(),
                                 parameter_types,
-                                R::get_hyperlight_type(),
+                                R::TYPE,
                             ),
                             HyperlightFunction::new(func),
                         )?;


### PR DESCRIPTION
This PR:
* reduces code duplication using macros
* replaces `get_hyperlight_type` with a `TYPE` associated const
* replaces `get_hyperlight_value(&self)` with `into_value(self)`, for a better name and avoiding a copy.
* replaces `get_inner(v: XxxValue)` with `from_value(v: XxxValue)`, for a better name.