### PR TITLE
Remove unused FunctionDefinition and redundant FunctionsMap

### DIFF
--- a/src/hyperlight_host/src/sandbox/mod.rs
+++ b/src/hyperlight_host/src/sandbox/mod.rs
@@ -45,8 +45,6 @@ pub mod uninitialized;
 /// initialized `Sandbox`es.
 pub(crate) mod uninitialized_evolve;
 
-use std::collections::HashMap;
-
 /// Re-export for `SandboxConfiguration` type
 pub use config::SandboxConfiguration;
 /// Re-export for the `MultiUseSandbox` type
@@ -60,7 +58,6 @@ pub use uninitialized::GuestBinary;
 pub use uninitialized::UninitializedSandbox;
 
 use self::mem_mgr::MemMgrWrapper;
-use crate::func::HyperlightFunction;
 use crate::hypervisor::hypervisor_handler::HypervisorHandler;
 #[cfg(target_os = "windows")]
 use crate::hypervisor::windows_hypervisor_platform;
@@ -85,49 +82,6 @@ pub fn is_supported_platform() -> bool {
 
 /// Alias for the type of extra allowed syscalls.
 pub type ExtraAllowedSyscall = i64;
-
-/// A `HashMap` to map function names to `HyperlightFunction`s and their extra allowed syscalls.
-///
-/// Note: you cannot add extra syscalls on Windows, but the field is still present to avoid a funky
-/// conditional compilation setup. This isn't a big deal as this struct isn't public facing.
-#[derive(Clone, Default)]
-pub(super) struct FunctionsMap(
-    HashMap<String, (HyperlightFunction, Option<Vec<ExtraAllowedSyscall>>)>,
-);
-
-impl FunctionsMap {
-    /// Insert a new entry into the map
-    pub(super) fn insert(
-        &mut self,
-        key: String,
-        value: HyperlightFunction,
-        extra_syscalls: Option<Vec<ExtraAllowedSyscall>>,
-    ) {
-        self.0.insert(key, (value, extra_syscalls));
-    }
-
-    /// Get the value associated with the given key, if it exists.
-    pub(super) fn get(
-        &self,
-        key: &str,
-    ) -> Option<&(HyperlightFunction, Option<Vec<ExtraAllowedSyscall>>)> {
-        self.0.get(key)
-    }
-
-    /// Get the length of the map.
-    fn len(&self) -> usize {
-        self.0.len()
-    }
-}
-
-impl PartialEq for FunctionsMap {
-    #[instrument(skip_all, parent = Span::current(), level= "Trace")]
-    fn eq(&self, other: &Self) -> bool {
-        self.len() == other.len() && self.0.keys().all(|k| other.0.contains_key(k))
-    }
-}
-
-impl Eq for FunctionsMap {}
 
 /// Determine whether a suitable hypervisor is available to run
 /// this sandbox.


### PR DESCRIPTION
The `FunctionDefinition` struct is unused and can be simple removed.
The `FunctionsMap` struct is just a thin wrapper around a `HashMap` that re-exposes the same API, so it can also be removed.