### PR TITLE
Changes to remove build steps for PE formatted guests.

### DIFF
--- a/.github/workflows/Benchmarks.yml
+++ b/.github/workflows/Benchmarks.yml
@@ -43,9 +43,7 @@ jobs:
       - name: Copy Guest Binaries
         run: |
           cp ./downloaded-guest-binaries-release/callbackguest ./src/tests/rust_guests/bin/release/callbackguest
-          cp ./downloaded-guest-binaries-release/callbackguest.exe ./src/tests/rust_guests/bin/release/callbackguest.exe
           cp ./downloaded-guest-binaries-release/simpleguest ./src/tests/rust_guests/bin/release/simpleguest
-          cp ./downloaded-guest-binaries-release/simpleguest.exe ./src/tests/rust_guests/bin/release/simpleguest.exe
           cp ./downloaded-guest-binaries-release/dummyguest ./src/tests/rust_guests/bin/release/dummyguest
 
       ### Benchmarks ###

--- a/.github/workflows/CreateRelease.yml
+++ b/.github/workflows/CreateRelease.yml
@@ -166,7 +166,6 @@ jobs:
             benchmarks_Linux_mshv3_amd.tar.gz \
             benchmarks_Linux_mshv3_intel.tar.gz \
             hyperlight-guest-c-api-linux.tar.gz \
-            hyperlight-guest-c-api-windows.tar.gz \
             include.tar.gz
         env:
             GH_TOKEN: ${{ github.token }}
@@ -185,7 +184,6 @@ jobs:
             benchmarks_Linux_mshv3_amd.tar.gz \
             benchmarks_Linux_mshv3_intel.tar.gz \
             hyperlight-guest-c-api-linux.tar.gz \
-            hyperlight-guest-c-api-windows.tar.gz \
             include.tar.gz
         env:
             GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/dep_build_guest_binaries.yml
+++ b/.github/workflows/dep_build_guest_binaries.yml
@@ -46,8 +46,6 @@ jobs:
           name: guest-binaries-${{ matrix.config }}
           path: |
             src\tests\rust_guests\bin\${{ matrix.config }}\callbackguest
-            src\tests\rust_guests\bin\${{ matrix.config }}\callbackguest.exe
             src\tests\rust_guests\bin\${{ matrix.config }}\dummyguest
             src\tests\rust_guests\bin\${{ matrix.config }}\simpleguest
-            src\tests\rust_guests\bin\${{ matrix.config }}\simpleguest.exe
           if-no-files-found: error

--- a/.github/workflows/dep_rust.yml
+++ b/.github/workflows/dep_rust.yml
@@ -79,11 +79,16 @@ jobs:
         shell: pwsh
 
       - name: Build and move Rust guests
-        run: just build-and-move-rust-guests
+        run: |
+          # use these commands in favor of build-and-move-rust-guests to avoid building both configs
+          just build-rust-guests ${{ matrix.config }}
+          just move-rust-guests ${{ matrix.config }}
 
       - name: Build c guests
-        run: just build-and-move-c-guests
-
+        run: |
+          # use these commands in favor of build-and-move-c-guests to avoid building both configs
+          just build-c-guests ${{ matrix.config }}
+          just move-c-guests ${{ matrix.config }}
       - name: Build
         run: just build ${{ matrix.config }}
 

--- a/Justfile
+++ b/Justfile
@@ -10,10 +10,8 @@ root := justfile_directory()
 
 default-target := "debug"
 simpleguest_source := "src/tests/rust_guests/simpleguest/target/x86_64-unknown-none"
-simpleguest_msvc_source := "src/tests/rust_guests/simpleguest/target/x86_64-pc-windows-msvc"
 dummyguest_source := "src/tests/rust_guests/dummyguest/target/x86_64-unknown-none"
 callbackguest_source := "src/tests/rust_guests/callbackguest/target/x86_64-unknown-none"
-callbackguest_msvc_source := "src/tests/rust_guests/callbackguest/target/x86_64-pc-windows-msvc"
 rust_guests_bin_dir := "src/tests/rust_guests/bin"
 
 ################
@@ -32,16 +30,12 @@ guests: build-and-move-rust-guests build-and-move-c-guests
 
 build-rust-guests target=default-target:
     cd src/tests/rust_guests/callbackguest && cargo build --profile={{ if target == "debug" { "dev" } else { target } }}
-    cd src/tests/rust_guests/callbackguest && cargo build --profile={{ if target == "debug" { "dev" } else { target } }}  --target=x86_64-pc-windows-msvc
     cd src/tests/rust_guests/simpleguest && cargo build --profile={{ if target == "debug" { "dev" } else { target } }} 
-    cd src/tests/rust_guests/simpleguest && cargo build --profile={{ if target == "debug" { "dev" } else { target } }} --target=x86_64-pc-windows-msvc
     cd src/tests/rust_guests/dummyguest && cargo build --profile={{ if target == "debug" { "dev" } else { target } }} 
 
 @move-rust-guests target=default-target:
     cp {{ callbackguest_source }}/{{ target }}/callbackguest* {{ rust_guests_bin_dir }}/{{ target }}/
-    cp {{ callbackguest_msvc_source }}/{{ target }}/callbackguest* {{ rust_guests_bin_dir }}/{{ target }}/
     cp {{ simpleguest_source }}/{{ target }}/simpleguest* {{ rust_guests_bin_dir }}/{{ target }}/
-    cp {{ simpleguest_msvc_source }}/{{ target }}/simpleguest* {{ rust_guests_bin_dir }}/{{ target }}/
     cp {{ dummyguest_source }}/{{ target }}/dummyguest* {{ rust_guests_bin_dir }}/{{ target }}/
 
 build-and-move-rust-guests: (build-rust-guests "debug") (move-rust-guests "debug") (build-rust-guests "release") (move-rust-guests "release")
@@ -184,7 +178,6 @@ tar-headers: (build-rust-capi) # build-rust-capi is a dependency because we need
     tar -zcvf include.tar.gz -C {{root}}/src/hyperlight_guest/third_party/ musl/include musl/arch/x86_64 printf/printf.h -C {{root}}/src/hyperlight_guest_capi include
 
 tar-static-lib: (build-rust-capi "release") (build-rust-capi "debug")
-    tar -zcvf hyperlight-guest-c-api-windows.tar.gz -C {{root}}/target/x86_64-pc-windows-msvc/ release/hyperlight_guest_capi.lib -C {{root}}/target/x86_64-pc-windows-msvc/ debug/hyperlight_guest_capi.lib
     tar -zcvf hyperlight-guest-c-api-linux.tar.gz -C {{root}}/target/x86_64-unknown-none/ release/libhyperlight_guest_capi.a -C {{root}}/target/x86_64-unknown-none/ debug/libhyperlight_guest_capi.a
 
 # Create release notes for the given tag. The expected format is a v-prefixed version number, e.g. v0.2.0

--- a/c.just
+++ b/c.just
@@ -1,16 +1,9 @@
 mkdir := if os() == "windows" { "mkdir -f -p" } else { "mkdir -p"} 
 
-# PE options
-c-compile-options-pe := '/GS /W3 /Zi /Od /fp:precise /WX- /std:c17  /showIncludes /MT /EHsc /nologo /diagnostics:column'
-c-linker-options-pe := '/MANIFEST:NO /NXCOMPAT /HEAP:131072,131072 /STACK:65536,65536 /DEBUG /RELEASE /ENTRY:"entrypoint" /ALIGN:4096 /FILEALIGN:4096 /NODEFAULTLIB /SAFESEH:NO /driver /SUBSYSTEM:NATIVE /MACHINE:x64 /DYNAMICBASE /TSAWARE:no /section:.text,ERP /section:.rdata,RP /section:.data,RWP /section:.pdata,RP'
-c-include-flags-pe := "/I " + root / "src/hyperlight_guest_capi/include/"  + " /I " + root / "src/hyperlight_guest/third_party/musl/include/" + " /I " + root / "src/hyperlight_guest/third_party/musl/arch/x86_64" + " /I " + root / "src/hyperlight_guest/third_party/printf"
-c-flags-debug-pe := '/Od /Ob0 /Z7'
-c-flags-release-pe := '/O2 /Gy'
-
 # Elf options
 # We don't support stack protectors at the moment, but Arch Linux clang auto-enables them for -linux platforms, so explicitly disable them.
 c-compile-options-elf := '-nobuiltininc -H --target=x86_64-unknown-linux-none -fno-stack-protector -fstack-clash-protection -mstack-probe-size=4096 -fPIC'
-c-include-flags-elf := replace(c-include-flags-pe, '/I ', '-I ')
+c-include-flags-elf := "-I " + root / "src/hyperlight_guest_capi/include/"  + " -I " + root / "src/hyperlight_guest/third_party/musl/include/" + " -I " + root / "src/hyperlight_guest/third_party/musl/arch/x86_64" + " -I " + root / "src/hyperlight_guest/third_party/printf"
 c-linker-options-elf := '--entry "entrypoint" --nostdlib -pie'
 c-flags-debug-elf := '-O0'
 c-flags-release-elf := '-O3'
@@ -19,25 +12,18 @@ build-c-guests target=default-target: (build-rust-capi target) (compile-c-guest 
 
 build-rust-capi target=default-target:
     cd src/hyperlight_guest_capi && cargo build --profile {{ if target == "debug" { "dev" } else { target } }}
-    cd src/hyperlight_guest_capi && cargo build --profile {{ if target == "debug" { "dev" } else { target } }} --target x86_64-pc-windows-msvc
 
 compile-c-guest target=default-target:
-    cd src/tests/c_guests/c_simpleguest   && {{ mkdir }} "./out/{{target}}" && clang-cl /c main.c {{ c-compile-options-pe }} {{ if target == "debug" { c-flags-debug-pe } else { c-flags-release-pe } }} {{c-include-flags-pe}} /Fo"out/{{ target }}/main.obj"
-    cd src/tests/c_guests/c_callbackguest && {{ mkdir }} "./out/{{target}}" && clang-cl /c main.c {{ c-compile-options-pe }} {{ if target == "debug" { c-flags-debug-pe } else { c-flags-release-pe } }} {{c-include-flags-pe}} /Fo"out/{{ target }}/main.obj"
     # elf
-    cd src/tests/c_guests/c_simpleguest && clang -c {{ c-compile-options-elf }} {{ if target == "debug" { c-flags-debug-elf } else { c-flags-release-elf } }} main.c {{c-include-flags-elf}} -o "out/{{ target }}/main.o"
-    cd src/tests/c_guests/c_callbackguest && clang -c {{ c-compile-options-elf }} {{ if target == "debug" { c-flags-debug-elf } else { c-flags-release-elf } }} main.c {{c-include-flags-elf}} -o "out/{{ target }}/main.o"
+    cd src/tests/c_guests/c_simpleguest && {{ mkdir }} "./out/{{target}}" && clang -c {{ c-compile-options-elf }} {{ if target == "debug" { c-flags-debug-elf } else { c-flags-release-elf } }} main.c {{c-include-flags-elf}} -o "out/{{ target }}/main.o"
+    cd src/tests/c_guests/c_callbackguest && {{ mkdir }} "./out/{{target}}" && clang -c {{ c-compile-options-elf }} {{ if target == "debug" { c-flags-debug-elf } else { c-flags-release-elf } }} main.c {{c-include-flags-elf}} -o "out/{{ target }}/main.o"
 
 link-c-guest target=default-target:
-    cd src/tests/c_guests/c_simpleguest   && lld-link /OUT:./out/{{ target }}/simpleguest.exe   /PDB:./out/{{ target }}/simpleguest.pdb   {{c-linker-options-pe}} out/{{ target }}/main.obj {{justfile_directory()}}/target/x86_64-pc-windows-msvc/{{ target }}/hyperlight_guest_capi.lib
-    cd src/tests/c_guests/c_callbackguest && lld-link /OUT:./out/{{ target }}/callbackguest.exe /PDB:./out/{{ target }}/callbackguest.pdb {{c-linker-options-pe}} out/{{ target }}/main.obj {{justfile_directory()}}/target/x86_64-pc-windows-msvc/{{ target }}/hyperlight_guest_capi.lib
     # elf
     cd src/tests/c_guests/c_simpleguest && ld.lld -o out/{{target}}/simpleguest {{c-linker-options-elf}} out/{{target}}/main.o -l hyperlight_guest_capi -L "{{justfile_directory()}}/target/x86_64-unknown-none/{{target}}"
     cd src/tests/c_guests/c_callbackguest && ld.lld -o out/{{target}}/callbackguest {{c-linker-options-elf}} out/{{target}}/main.o -l hyperlight_guest_capi -L "{{justfile_directory()}}/target/x86_64-unknown-none/{{target}}"
 
 move-c-guests target=default-target:
-    cp src/tests/c_guests/c_simpleguest/out/{{target}}/simpleguest.exe src/tests/c_guests/bin/{{target}}/
-    cp src/tests/c_guests/c_callbackguest/out/{{target}}/callbackguest.exe src/tests/c_guests/bin/{{target}}/
     # elf
     cp src/tests/c_guests/c_simpleguest/out/{{target}}/simpleguest src/tests/c_guests/bin/{{target}}/
     cp src/tests/c_guests/c_callbackguest/out/{{target}}/callbackguest src/tests/c_guests/bin/{{target}}/


### PR DESCRIPTION
Now that we have removed support for PE formatted guests (#470), we no longer need to build/archive these guests.

This completes the work for issue #470 