### PR TITLE
Remove `host_print_writer` from the arguments to `UninitializedSandbox::new`

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,6 @@ fn main() -> hyperlight_host::Result<()> {
         hyperlight_host::GuestBinary::FilePath(hyperlight_testing::simple_guest_as_string().unwrap()),
         None, // default configuration
         None, // default run options
-        None, // default host print function
     )?;
 
     // Registering a host function makes it available to be called by the guest

--- a/fuzz/fuzz_targets/guest_call.rs
+++ b/fuzz/fuzz_targets/guest_call.rs
@@ -36,7 +36,6 @@ fuzz_target!(
             GuestBinary::FilePath(simple_guest_for_fuzzing_as_string().expect("Guest Binary Missing")),
             None,
             None,
-            None,
         )
         .unwrap();
 

--- a/fuzz/fuzz_targets/host_call.rs
+++ b/fuzz/fuzz_targets/host_call.rs
@@ -20,7 +20,6 @@ use std::sync::{Mutex, OnceLock};
 
 use hyperlight_host::func::{ParameterValue, ReturnType};
 use hyperlight_host::sandbox::uninitialized::GuestBinary;
-use hyperlight_host::sandbox::SandboxConfiguration;
 use hyperlight_host::sandbox_state::sandbox::EvolvableSandbox;
 use hyperlight_host::sandbox_state::transition::Noop;
 use hyperlight_host::{HyperlightError, MultiUseSandbox, UninitializedSandbox};
@@ -34,7 +33,6 @@ fuzz_target!(
     init: {
         let u_sbox = UninitializedSandbox::new(
             GuestBinary::FilePath(simple_guest_for_fuzzing_as_string().expect("Guest Binary Missing")),
-            None,
             None,
             None,
         )

--- a/fuzz/fuzz_targets/host_print.rs
+++ b/fuzz/fuzz_targets/host_print.rs
@@ -22,7 +22,6 @@ fuzz_target!(
             GuestBinary::FilePath(simple_guest_for_fuzzing_as_string().expect("Guest Binary Missing")),
             None,
             None,
-            None,
         )
         .unwrap();
 

--- a/src/hyperlight_host/benches/benchmarks.rs
+++ b/src/hyperlight_host/benches/benchmarks.rs
@@ -26,7 +26,7 @@ use hyperlight_testing::simple_guest_as_string;
 
 fn create_uninit_sandbox() -> UninitializedSandbox {
     let path = simple_guest_as_string().unwrap();
-    UninitializedSandbox::new(GuestBinary::FilePath(path), None, None, None).unwrap()
+    UninitializedSandbox::new(GuestBinary::FilePath(path), None, None).unwrap()
 }
 
 fn create_multiuse_sandbox() -> MultiUseSandbox {
@@ -82,7 +82,6 @@ fn guest_call_benchmark(c: &mut Criterion) {
         let sandbox = UninitializedSandbox::new(
             GuestBinary::FilePath(simple_guest_as_string().unwrap()),
             Some(config),
-            None,
             None,
         )
         .unwrap();

--- a/src/hyperlight_host/examples/func_ctx/main.rs
+++ b/src/hyperlight_host/examples/func_ctx/main.rs
@@ -27,8 +27,7 @@ fn main() {
     // test guest binary
     let sbox1: MultiUseSandbox = {
         let path = simple_guest_as_string().unwrap();
-        let u_sbox =
-            UninitializedSandbox::new(GuestBinary::FilePath(path), None, None, None).unwrap();
+        let u_sbox = UninitializedSandbox::new(GuestBinary::FilePath(path), None, None).unwrap();
         u_sbox.evolve(Noop::default())
     }
     .unwrap();

--- a/src/hyperlight_host/examples/guest-debugging/main.rs
+++ b/src/hyperlight_host/examples/guest-debugging/main.rs
@@ -49,7 +49,6 @@ fn main() -> hyperlight_host::Result<()> {
         ),
         cfg,  // sandbox configuration
         None, // default run options
-        None, // default host print function
     )?;
 
     // Register a host functions

--- a/src/hyperlight_host/examples/hello-world/main.rs
+++ b/src/hyperlight_host/examples/hello-world/main.rs
@@ -29,7 +29,6 @@ fn main() -> hyperlight_host::Result<()> {
         ),
         None, // default configuration
         None, // default run options
-        None, // default host print function
     )?;
 
     // Register a host functions

--- a/src/hyperlight_host/examples/logging/main.rs
+++ b/src/hyperlight_host/examples/logging/main.rs
@@ -15,7 +15,6 @@ limitations under the License.
 */
 #![allow(clippy::disallowed_macros)]
 extern crate hyperlight_host;
-use std::sync::{Arc, Mutex};
 
 use hyperlight_common::flatbuffer_wrappers::function_types::{ParameterValue, ReturnType};
 use hyperlight_host::sandbox::uninitialized::UninitializedSandbox;
@@ -41,15 +40,10 @@ fn main() -> Result<()> {
 
     for _ in 0..20 {
         let path = hyperlight_guest_path.clone();
-        let writer_func = Arc::new(Mutex::new(fn_writer));
         let res: Result<()> = {
             // Create a new sandbox.
-            let usandbox = UninitializedSandbox::new(
-                GuestBinary::FilePath(path),
-                None,
-                None,
-                Some(&writer_func),
-            )?;
+            let mut usandbox = UninitializedSandbox::new(GuestBinary::FilePath(path), None, None)?;
+            usandbox.register_print(fn_writer)?;
 
             // Initialize the sandbox.
 
@@ -89,7 +83,6 @@ fn main() -> Result<()> {
     // Create a new sandbox.
     let usandbox = UninitializedSandbox::new(
         GuestBinary::FilePath(hyperlight_guest_path.clone()),
-        None,
         None,
         None,
     )?;

--- a/src/hyperlight_host/examples/metrics/main.rs
+++ b/src/hyperlight_host/examples/metrics/main.rs
@@ -15,7 +15,6 @@ limitations under the License.
 */
 #![allow(clippy::disallowed_macros)]
 extern crate hyperlight_host;
-use std::sync::{Arc, Mutex};
 use std::thread::{spawn, JoinHandle};
 
 use hyperlight_common::flatbuffer_wrappers::function_types::{ParameterValue, ReturnType};
@@ -53,15 +52,10 @@ fn do_hyperlight_stuff() {
 
     for _ in 0..20 {
         let path = hyperlight_guest_path.clone();
-        let writer_func = Arc::new(Mutex::new(fn_writer));
         let handle = spawn(move || -> Result<()> {
             // Create a new sandbox.
-            let usandbox = UninitializedSandbox::new(
-                GuestBinary::FilePath(path),
-                None,
-                None,
-                Some(&writer_func),
-            )?;
+            let mut usandbox = UninitializedSandbox::new(GuestBinary::FilePath(path), None, None)?;
+            usandbox.register_print(fn_writer)?;
 
             // Initialize the sandbox.
 
@@ -101,7 +95,6 @@ fn do_hyperlight_stuff() {
     // Create a new sandbox.
     let usandbox = UninitializedSandbox::new(
         GuestBinary::FilePath(hyperlight_guest_path.clone()),
-        None,
         None,
         None,
     )

--- a/src/hyperlight_host/examples/tracing-chrome/main.rs
+++ b/src/hyperlight_host/examples/tracing-chrome/main.rs
@@ -33,8 +33,7 @@ fn main() -> Result<()> {
         simple_guest_as_string().expect("Cannot find the guest binary at the expected location.");
 
     // Create a new sandbox.
-    let usandbox =
-        UninitializedSandbox::new(GuestBinary::FilePath(simple_guest_path), None, None, None)?;
+    let usandbox = UninitializedSandbox::new(GuestBinary::FilePath(simple_guest_path), None, None)?;
 
     let mut sbox = usandbox
         .evolve(Noop::<UninitializedSandbox, MultiUseSandbox>::default())

--- a/src/hyperlight_host/examples/tracing-otlp/main.rs
+++ b/src/hyperlight_host/examples/tracing-otlp/main.rs
@@ -116,7 +116,6 @@ fn run_example(wait_input: bool) -> HyperlightResult<()> {
     for i in 0..10 {
         let path = hyperlight_guest_path.clone();
         let exit = Arc::clone(&should_exit);
-        let writer_func = Arc::new(Mutex::new(fn_writer));
         let handle = spawn(move || -> HyperlightResult<()> {
             while !*exit.try_lock().unwrap() {
                 // Construct a new span named "hyperlight tracing example thread" with INFO  level.
@@ -130,12 +129,9 @@ fn run_example(wait_input: bool) -> HyperlightResult<()> {
                 let _entered = span.enter();
 
                 // Create a new sandbox.
-                let usandbox = UninitializedSandbox::new(
-                    GuestBinary::FilePath(path.clone()),
-                    None,
-                    None,
-                    Some(&writer_func),
-                )?;
+                let mut usandbox =
+                    UninitializedSandbox::new(GuestBinary::FilePath(path.clone()), None, None)?;
+                usandbox.register_print(fn_writer)?;
 
                 // Initialize the sandbox.
 

--- a/src/hyperlight_host/examples/tracing-tracy/main.rs
+++ b/src/hyperlight_host/examples/tracing-tracy/main.rs
@@ -39,8 +39,7 @@ fn main() -> Result<()> {
         simple_guest_as_string().expect("Cannot find the guest binary at the expected location.");
 
     // Create a new sandbox.
-    let usandbox =
-        UninitializedSandbox::new(GuestBinary::FilePath(simple_guest_path), None, None, None)?;
+    let usandbox = UninitializedSandbox::new(GuestBinary::FilePath(simple_guest_path), None, None)?;
 
     let mut sbox = usandbox
         .evolve(Noop::<UninitializedSandbox, MultiUseSandbox>::default())

--- a/src/hyperlight_host/examples/tracing/main.rs
+++ b/src/hyperlight_host/examples/tracing/main.rs
@@ -17,7 +17,6 @@ limitations under the License.
 use hyperlight_common::flatbuffer_wrappers::function_types::{ParameterValue, ReturnType};
 use tracing::{span, Level};
 extern crate hyperlight_host;
-use std::sync::{Arc, Mutex};
 use std::thread::{spawn, JoinHandle};
 
 use hyperlight_host::sandbox::uninitialized::UninitializedSandbox;
@@ -60,7 +59,6 @@ fn run_example() -> Result<()> {
 
     for i in 0..10 {
         let path = hyperlight_guest_path.clone();
-        let writer_func = Arc::new(Mutex::new(fn_writer));
         let handle = spawn(move || -> Result<()> {
             // Construct a new span named "hyperlight tracing example thread" with INFO  level.
             let id = Uuid::new_v4();
@@ -73,12 +71,8 @@ fn run_example() -> Result<()> {
             let _entered = span.enter();
 
             // Create a new sandbox.
-            let usandbox = UninitializedSandbox::new(
-                GuestBinary::FilePath(path),
-                None,
-                None,
-                Some(&writer_func),
-            )?;
+            let mut usandbox = UninitializedSandbox::new(GuestBinary::FilePath(path), None, None)?;
+            usandbox.register_print(fn_writer)?;
 
             // Initialize the sandbox.
 
@@ -117,7 +111,6 @@ fn run_example() -> Result<()> {
     // Create a new sandbox.
     let usandbox = UninitializedSandbox::new(
         GuestBinary::FilePath(hyperlight_guest_path.clone()),
-        None,
         None,
         None,
     )?;

--- a/src/hyperlight_host/src/func/call_ctx.rs
+++ b/src/hyperlight_host/src/func/call_ctx.rs
@@ -117,7 +117,7 @@ mod tests {
         let path = simple_guest_as_string().map_err(|e| {
             HyperlightError::Error(format!("failed to get simple guest path ({e:?})"))
         })?;
-        UninitializedSandbox::new(GuestBinary::FilePath(path), None, None, None)
+        UninitializedSandbox::new(GuestBinary::FilePath(path), None, None)
     }
 
     /// Test to create a `MultiUseSandbox`, then call several guest functions

--- a/src/hyperlight_host/src/func/guest_dispatch.rs
+++ b/src/hyperlight_host/src/func/guest_dispatch.rs
@@ -155,7 +155,6 @@ mod tests {
                 GuestBinary::FilePath(simple_guest_as_string().expect("Guest Binary Missing")),
                 None,
                 None,
-                None,
             )
             .unwrap();
 
@@ -189,7 +188,6 @@ mod tests {
                 GuestBinary::FilePath(simple_guest_as_string().expect("Guest Binary Missing")),
                 None,
                 None,
-                None,
             )
             .unwrap();
 
@@ -219,7 +217,6 @@ mod tests {
         let uninitialized_sandbox = || {
             UninitializedSandbox::new(
                 GuestBinary::FilePath(simple_guest_as_string().expect("Guest Binary Missing")),
-                None,
                 None,
                 None,
             )
@@ -337,8 +334,6 @@ mod tests {
             None,
             // by default, the below represents in-hypervisor mode
             None,
-            // just use the built-in host print function
-            None,
         )
         .unwrap();
         test_call_guest_function_by_name(u_sbox);
@@ -358,7 +353,6 @@ mod tests {
         }
         let usbox = UninitializedSandbox::new(
             GuestBinary::FilePath(simple_guest_as_string().expect("Guest Binary Missing")),
-            None,
             None,
             None,
         )?;
@@ -409,7 +403,6 @@ mod tests {
             GuestBinary::FilePath(callback_guest_as_string().expect("Guest Binary Missing")),
             None,
             None,
-            None,
         )
         .unwrap();
 
@@ -446,7 +439,6 @@ mod tests {
     fn test_trigger_exception_on_guest() {
         let usbox = UninitializedSandbox::new(
             GuestBinary::FilePath(simple_guest_as_string().expect("Guest Binary Missing")),
-            None,
             None,
             None,
         )

--- a/src/hyperlight_host/src/hypervisor/hypervisor_handler.rs
+++ b/src/hyperlight_host/src/hypervisor/hypervisor_handler.rs
@@ -976,7 +976,6 @@ mod tests {
             GuestBinary::FilePath(simple_guest_as_string().expect("Guest Binary Missing")),
             cfg,
             None,
-            None,
         )
         .unwrap();
 

--- a/src/hyperlight_host/src/hypervisor/mod.rs
+++ b/src/hyperlight_host/src/hypervisor/mod.rs
@@ -364,7 +364,7 @@ pub(crate) mod tests {
         }
 
         let sandbox =
-            UninitializedSandbox::new(GuestBinary::FilePath(filename.clone()), None, None, None)?;
+            UninitializedSandbox::new(GuestBinary::FilePath(filename.clone()), None, None)?;
         let (hshm, gshm) = sandbox.mgr.build();
         drop(hshm);
 

--- a/src/hyperlight_host/src/metrics/mod.rs
+++ b/src/hyperlight_host/src/metrics/mod.rs
@@ -111,7 +111,6 @@ mod tests {
                 GuestBinary::FilePath(simple_guest_as_string().unwrap()),
                 None,
                 None,
-                None,
             )
             .unwrap();
 

--- a/src/hyperlight_host/src/sandbox/initialized_multi_use.rs
+++ b/src/hyperlight_host/src/sandbox/initialized_multi_use.rs
@@ -113,7 +113,6 @@ impl MultiUseSandbox {
     ///     GuestBinary::FilePath("some_guest_binary".to_string()),
     ///     None,
     ///     None,
-    ///     None,
     /// ).unwrap();
     /// let sbox: MultiUseSandbox = u_sbox.evolve(Noop::default()).unwrap();
     /// // Next, create a new call context from the single-use sandbox.
@@ -279,8 +278,7 @@ mod tests {
         let sbox1: MultiUseSandbox = {
             let path = simple_guest_as_string().unwrap();
             let u_sbox =
-                UninitializedSandbox::new(GuestBinary::FilePath(path), Some(cfg), None, None)
-                    .unwrap();
+                UninitializedSandbox::new(GuestBinary::FilePath(path), Some(cfg), None).unwrap();
             u_sbox.evolve(Noop::default())
         }
         .unwrap();
@@ -299,8 +297,7 @@ mod tests {
         let sbox2: MultiUseSandbox = {
             let path = simple_guest_as_string().unwrap();
             let u_sbox =
-                UninitializedSandbox::new(GuestBinary::FilePath(path), Some(cfg), None, None)
-                    .unwrap();
+                UninitializedSandbox::new(GuestBinary::FilePath(path), Some(cfg), None).unwrap();
             u_sbox.evolve(Noop::default())
         }
         .unwrap();
@@ -326,7 +323,7 @@ mod tests {
         let sbox1: MultiUseSandbox = {
             let path = simple_guest_as_string().unwrap();
             let u_sbox =
-                UninitializedSandbox::new(GuestBinary::FilePath(path), None, None, None).unwrap();
+                UninitializedSandbox::new(GuestBinary::FilePath(path), None, None).unwrap();
             u_sbox.evolve(Noop::default())
         }
         .unwrap();

--- a/src/hyperlight_host/src/sandbox/mod.rs
+++ b/src/hyperlight_host/src/sandbox/mod.rs
@@ -134,13 +134,9 @@ mod tests {
 
         for i in 0..10 {
             let simple_guest_path = simple_guest_as_string().expect("Guest Binary Missing");
-            let unintializedsandbox = UninitializedSandbox::new(
-                GuestBinary::FilePath(simple_guest_path),
-                None,
-                None,
-                None,
-            )
-            .unwrap_or_else(|_| panic!("Failed to create UninitializedSandbox {}", i));
+            let unintializedsandbox =
+                UninitializedSandbox::new(GuestBinary::FilePath(simple_guest_path), None, None)
+                    .unwrap_or_else(|_| panic!("Failed to create UninitializedSandbox {}", i));
 
             unintializedsandbox_queue
                 .push(unintializedsandbox)

--- a/src/hyperlight_host/src/sandbox/uninitialized_evolve.rs
+++ b/src/hyperlight_host/src/sandbox/uninitialized_evolve.rs
@@ -180,7 +180,6 @@ mod tests {
                 GuestBinary::FilePath(guest_bin_path.clone()),
                 None,
                 None,
-                None,
             )
             .unwrap();
             evolve_impl_multi_use(u_sbox).unwrap();
@@ -201,7 +200,6 @@ mod tests {
                 GuestBinary::FilePath(guest_bin_path.clone()),
                 None,
                 Some(SandboxRunOptions::RunInHypervisor),
-                None,
             )
             .unwrap();
             let err = format!("error evolving sandbox with guest binary {guest_bin_path}");

--- a/src/hyperlight_host/tests/common/mod.rs
+++ b/src/hyperlight_host/tests/common/mod.rs
@@ -30,7 +30,6 @@ pub fn new_uninit() -> Result<UninitializedSandbox> {
         GuestBinary::FilePath(get_c_or_rust_simpleguest_path()),
         None,
         None,
-        None,
     )
 }
 
@@ -38,7 +37,6 @@ pub fn new_uninit() -> Result<UninitializedSandbox> {
 pub fn new_uninit_rust() -> Result<UninitializedSandbox> {
     UninitializedSandbox::new(
         GuestBinary::FilePath(simple_guest_as_string().unwrap()),
-        None,
         None,
         None,
     )
@@ -49,13 +47,20 @@ pub fn get_simpleguest_sandboxes(
 ) -> Vec<MultiUseSandbox> {
     let elf_path = get_c_or_rust_simpleguest_path();
 
-    vec![
+    let sandboxes = [
         // in hypervisor elf
-        UninitializedSandbox::new(GuestBinary::FilePath(elf_path.clone()), None, None, writer)
-            .unwrap()
-            .evolve(Noop::default())
-            .unwrap(),
-    ]
+        UninitializedSandbox::new(GuestBinary::FilePath(elf_path.clone()), None, None).unwrap(),
+    ];
+
+    sandboxes
+        .into_iter()
+        .map(|mut sandbox| {
+            if let Some(writer) = writer {
+                sandbox.register_print(writer).unwrap();
+            }
+            sandbox.evolve(Noop::default()).unwrap()
+        })
+        .collect()
 }
 
 pub fn get_callbackguest_uninit_sandboxes(
@@ -63,11 +68,20 @@ pub fn get_callbackguest_uninit_sandboxes(
 ) -> Vec<UninitializedSandbox> {
     let elf_path = get_c_or_rust_callbackguest_path();
 
-    vec![
+    let sandboxes = [
         // in hypervisor elf
-        UninitializedSandbox::new(GuestBinary::FilePath(elf_path.clone()), None, None, writer)
-            .unwrap(),
-    ]
+        UninitializedSandbox::new(GuestBinary::FilePath(elf_path.clone()), None, None).unwrap(),
+    ];
+
+    sandboxes
+        .into_iter()
+        .map(|mut sandbox| {
+            if let Some(writer) = writer {
+                sandbox.register_print(writer).unwrap();
+            }
+            sandbox
+        })
+        .collect()
 }
 
 // returns the the path of simpleguest binary. Picks rust/c version depending on environment variable GUEST (or rust by default if unset)

--- a/src/hyperlight_host/tests/integration_test.rs
+++ b/src/hyperlight_host/tests/integration_test.rs
@@ -32,7 +32,7 @@ use crate::common::{new_uninit, new_uninit_rust};
 fn print_four_args_c_guest() {
     let path = c_simple_guest_as_string().unwrap();
     let guest_path = GuestBinary::FilePath(path);
-    let uninit = UninitializedSandbox::new(guest_path, None, None, None);
+    let uninit = UninitializedSandbox::new(guest_path, None, None);
     let mut sbox1 = uninit.unwrap().evolve(Noop::default()).unwrap();
 
     let res = sbox1.call_guest_function_by_name(
@@ -146,7 +146,7 @@ fn guest_abort_with_context2() {
 fn guest_abort_c_guest() {
     let path = c_simple_guest_as_string().unwrap();
     let guest_path = GuestBinary::FilePath(path);
-    let uninit = UninitializedSandbox::new(guest_path, None, None, None);
+    let uninit = UninitializedSandbox::new(guest_path, None, None);
     let mut sbox1 = uninit.unwrap().evolve(Noop::default()).unwrap();
 
     let res = sbox1
@@ -248,7 +248,6 @@ fn guest_malloc_abort() {
         GuestBinary::FilePath(simple_guest_as_string().unwrap()),
         Some(cfg),
         None,
-        None,
     )
     .unwrap();
     let mut sbox2 = uninit.evolve(Noop::default()).unwrap();
@@ -271,7 +270,7 @@ fn guest_malloc_abort() {
 fn dynamic_stack_allocate_c_guest() {
     let path = c_simple_guest_as_string().unwrap();
     let guest_path = GuestBinary::FilePath(path);
-    let uninit = UninitializedSandbox::new(guest_path, None, None, None);
+    let uninit = UninitializedSandbox::new(guest_path, None, None);
     let mut sbox1: MultiUseSandbox = uninit.unwrap().evolve(Noop::default()).unwrap();
 
     let res2 = sbox1

--- a/src/hyperlight_host/tests/sandbox_host_tests.rs
+++ b/src/hyperlight_host/tests/sandbox_host_tests.rs
@@ -393,7 +393,6 @@ fn max_memory_sandbox() {
         GuestBinary::FilePath(simple_guest_as_string().unwrap()),
         Some(cfg),
         None,
-        None,
     );
 
     assert!(matches!(


### PR DESCRIPTION
With #480 merged, registering a host function with a name that is already in use, just replaces the previous registration.
This means that we can pre-emptively register the default `HostPrint` method, and replace it afterwards.

This PR removes `host_print_writer` from the arguments to `UninitializedSandbox::new`.
The default host print is pre-emptively registered, and a new `HostPrint` can be registered like any other host function.
Alternatively, the method `register_print` can be used, which uses the correct name and (compile-time-)checks the function signature.

This partly addresses the following comment (i.e., it still doesn't implement a builder pattern, but does allow adding extra syscalls to the writer method)
https://github.com/hyperlight-dev/hyperlight/blob/a862d4ad73c72ab89e4504f410ef6541d87472b9/src/hyperlight_host/src/sandbox/uninitialized.rs#L195-L197