### PR TITLE
Bring back panic info to abort

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -62,7 +62,7 @@ test-like-ci config=default-target hypervisor="kvm":
     just test {{config}} {{ if hypervisor == "mshv3" {"mshv3"} else {""} }}
 
     @# with only one driver enabled + seccomp
-    just test {{config}} seccomp,{{ if hypervisor == "mshv" {"mshv2"} else if hypervisor == "mshv3" {"mshv3"} else {"kvm"} }}
+    just test {{config}} seccomp,build-metadata,{{ if hypervisor == "mshv" {"mshv2"} else if hypervisor == "mshv3" {"mshv3"} else {"kvm"} }}
 
     @# make sure certain cargo features compile
     cargo check -p hyperlight-host --features crashdump

--- a/src/hyperlight_common/src/mem.rs
+++ b/src/hyperlight_common/src/mem.rs
@@ -22,18 +22,6 @@ pub const PAGE_SIZE_USIZE: usize = 1 << 12;
 
 use core::ffi::{c_char, c_void};
 
-#[repr(C)]
-pub struct HostFunctionDefinitions {
-    pub fbHostFunctionDetailsSize: u64,
-    pub fbHostFunctionDetails: *mut c_void,
-}
-
-#[repr(C)]
-pub struct GuestErrorData {
-    pub guestErrorSize: u64,
-    pub guestErrorBuffer: *mut c_void,
-}
-
 #[repr(u64)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum RunMode {

--- a/src/hyperlight_guest/src/interrupt_handlers.rs
+++ b/src/hyperlight_guest/src/interrupt_handlers.rs
@@ -31,10 +31,9 @@ pub extern "sysv64" fn hl_exception_handler(
 ) {
     let exception = Exception::try_from(exception_number as u8).expect("Invalid exception number");
     let msg = format!(
-        "EXCEPTION: {:#?}\n\
-            Page Fault Address: {:#x}\n\
+        "Page Fault Address: {:#x}\n\
             Stack Pointer: {:#x}",
-        exception, page_fault_address, stack_pointer
+        page_fault_address, stack_pointer
     );
 
     unsafe {

--- a/src/hyperlight_host/Cargo.toml
+++ b/src/hyperlight_host/Cargo.toml
@@ -113,10 +113,10 @@ proc-maps = "0.4.0"
 [build-dependencies]
 anyhow = { version = "1.0.98" }
 cfg_aliases = "0.2.1"
-built = { version = "0.8.0", features = ["chrono", "git2"] }
+built = { version = "0.8.0", optional = true, features = ["chrono", "git2"] }
 
 [features]
-default = ["kvm", "mshv2", "seccomp"]
+default = ["kvm", "mshv2", "seccomp", "build-metadata"]
 seccomp = ["dep:seccompiler"]
 function_call_metrics = []
 executable_heap = []
@@ -129,6 +129,7 @@ mshv3 = ["dep:mshv-bindings3", "dep:mshv-ioctls3"]
 # This enables easy debug in the guest
 gdb = ["dep:gdbstub", "dep:gdbstub_arch"]
 fuzzing = ["hyperlight-common/fuzzing"]
+build-metadata = ["dep:built"]
 
 [[bench]]
 name = "benchmarks"

--- a/src/hyperlight_host/build.rs
+++ b/src/hyperlight_host/build.rs
@@ -15,6 +15,7 @@ limitations under the License.
 */
 
 use anyhow::Result;
+#[cfg(feature = "build-metadata")]
 use built::write_built_file;
 
 fn main() -> Result<()> {
@@ -103,6 +104,7 @@ fn main() -> Result<()> {
         mshv3: { all(feature = "mshv3", target_os = "linux") },
     }
 
+    #[cfg(feature = "build-metadata")]
     write_built_file()?;
 
     Ok(())

--- a/src/hyperlight_host/src/hypervisor/handlers.rs
+++ b/src/hyperlight_host/src/hypervisor/handlers.rs
@@ -25,7 +25,7 @@ use crate::{new_error, Result};
 /// has initiated an outb operation.
 pub trait OutBHandlerCaller: Sync + Send {
     /// Function that gets called when an outb operation has occurred.
-    fn call(&mut self, port: u16, payload: Vec<u8>) -> Result<()>;
+    fn call(&mut self, port: u16, payload: u32) -> Result<()>;
 }
 
 /// A convenient type representing a common way `OutBHandler` implementations
@@ -36,7 +36,7 @@ pub trait OutBHandlerCaller: Sync + Send {
 /// a &mut self).
 pub type OutBHandlerWrapper = Arc<Mutex<dyn OutBHandlerCaller>>;
 
-pub(crate) type OutBHandlerFunction = Box<dyn FnMut(u16, Vec<u8>) -> Result<()> + Send>;
+pub(crate) type OutBHandlerFunction = Box<dyn FnMut(u16, u32) -> Result<()> + Send>;
 
 /// A `OutBHandler` implementation using a `OutBHandlerFunction`
 ///
@@ -52,7 +52,7 @@ impl From<OutBHandlerFunction> for OutBHandler {
 
 impl OutBHandlerCaller for OutBHandler {
     #[instrument(err(Debug), skip_all, parent = Span::current(), level= "Trace")]
-    fn call(&mut self, port: u16, payload: Vec<u8>) -> Result<()> {
+    fn call(&mut self, port: u16, payload: u32) -> Result<()> {
         let mut func = self
             .0
             .try_lock()

--- a/src/hyperlight_host/src/hypervisor/hyperv_linux.rs
+++ b/src/hyperlight_host/src/hypervisor/hyperv_linux.rs
@@ -546,10 +546,15 @@ impl Hypervisor for HypervLinuxDriver {
         instruction_length: u64,
         outb_handle_fn: OutBHandlerWrapper,
     ) -> Result<()> {
+        let mut padded = [0u8; 4];
+        let copy_len = data.len().min(4);
+        padded[..copy_len].copy_from_slice(&data[..copy_len]);
+        let val = u32::from_le_bytes(padded);
+
         outb_handle_fn
             .try_lock()
             .map_err(|e| new_error!("Error locking at {}:{}: {}", file!(), line!(), e))?
-            .call(port, data)?;
+            .call(port, val)?;
 
         // update rip
         self.vcpu_fd.set_reg(&[hv_register_assoc {

--- a/src/hyperlight_host/src/lib.rs
+++ b/src/hyperlight_host/src/lib.rs
@@ -22,9 +22,10 @@ limitations under the License.
 #![cfg_attr(not(any(test, debug_assertions)), warn(clippy::unwrap_used))]
 #![cfg_attr(any(test, debug_assertions), allow(clippy::disallowed_macros))]
 
+#[cfg(feature = "build-metadata")]
 use std::sync::Once;
 
-use log::info;
+#[cfg(feature = "build-metadata")]
 /// The `built` crate is used to generate a `built.rs` file that contains
 /// information about the build environment. This information is used to
 /// populate the `built_info` module, which is re-exported here.
@@ -149,9 +150,12 @@ macro_rules! debug {
 }
 
 // LOG_ONCE is used to log information about the crate version once
+#[cfg(feature = "build-metadata")]
 static LOG_ONCE: Once = Once::new();
 
+#[cfg(feature = "build-metadata")]
 pub(crate) fn log_build_details() {
+    use log::info;
     LOG_ONCE.call_once(|| {
         info!("Package name: {}", built_info::PKG_NAME);
         info!("Package version: {}", built_info::PKG_VERSION);

--- a/src/hyperlight_host/src/sandbox/mem_mgr.rs
+++ b/src/hyperlight_host/src/sandbox/mem_mgr.rs
@@ -29,27 +29,39 @@ pub type StackCookie = [u8; STACK_COOKIE_LEN];
 /// A container with methods for accessing `SandboxMemoryManager` and other
 /// related objects
 #[derive(Clone)]
-pub(crate) struct MemMgrWrapper<S>(SandboxMemoryManager<S>, StackCookie);
+pub(crate) struct MemMgrWrapper<S> {
+    mgr: SandboxMemoryManager<S>,
+    stack_cookie: StackCookie,
+    abort_buffer: Vec<u8>,
+}
 
 impl<S: SharedMemory> MemMgrWrapper<S> {
     #[instrument(skip_all, parent = Span::current(), level= "Trace")]
     pub(super) fn new(mgr: SandboxMemoryManager<S>, stack_cookie: StackCookie) -> Self {
-        Self(mgr, stack_cookie)
+        Self {
+            mgr,
+            stack_cookie,
+            abort_buffer: Vec::new(),
+        }
     }
 
     #[instrument(skip_all, parent = Span::current(), level= "Trace")]
     pub(crate) fn unwrap_mgr(&self) -> &SandboxMemoryManager<S> {
-        &self.0
+        &self.mgr
     }
 
     #[instrument(skip_all, parent = Span::current(), level= "Trace")]
     pub(crate) fn unwrap_mgr_mut(&mut self) -> &mut SandboxMemoryManager<S> {
-        &mut self.0
+        &mut self.mgr
     }
 
     #[instrument(skip_all, parent = Span::current(), level= "Trace")]
     pub(super) fn get_stack_cookie(&self) -> &StackCookie {
-        &self.1
+        &self.stack_cookie
+    }
+
+    pub fn get_abort_buffer_mut(&mut self) -> &mut Vec<u8> {
+        &mut self.abort_buffer
     }
 }
 
@@ -74,8 +86,8 @@ impl MemMgrWrapper<ExclusiveSharedMemory> {
         MemMgrWrapper<HostSharedMemory>,
         SandboxMemoryManager<GuestSharedMemory>,
     ) {
-        let (hshm, gshm) = self.0.build();
-        (MemMgrWrapper(hshm, self.1), gshm)
+        let (hshm, gshm) = self.mgr.build();
+        (MemMgrWrapper::new(hshm, self.stack_cookie), gshm)
     }
 
     #[instrument(err(Debug), skip_all, parent = Span::current(), level= "Trace")]

--- a/src/hyperlight_host/src/sandbox/uninitialized.rs
+++ b/src/hyperlight_host/src/sandbox/uninitialized.rs
@@ -339,9 +339,8 @@ fn check_windows_version() -> Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use std::path::PathBuf;
     use std::sync::mpsc::channel;
-    use std::sync::{Arc, Mutex};
+    use std::sync::Arc;
     use std::time::Duration;
     use std::{fs, thread};
 

--- a/src/hyperlight_host/src/testing/log_values.rs
+++ b/src/hyperlight_host/src/testing/log_values.rs
@@ -61,61 +61,66 @@ fn try_to_string<'a>(values: &'a Map<String, Value>, key: &'a str) -> Result<&'a
     }
 }
 
-/// A single value in the parameter list for the `try_to_strings`
-/// function.
-pub(crate) type MapLookup<'a> = (&'a Map<String, Value>, &'a str);
+#[cfg(feature = "build-metadata")]
+pub(crate) mod build_metadata_testing {
+    use super::*;
 
-/// Given a constant-size slice of `MapLookup`s, attempt to look up the
-/// string value in each `MapLookup`'s map (the first tuple element) for
-/// that `MapLookup`'s key (the second tuple element). If the lookup
-/// succeeded, attempt to convert the resulting value to a string. Return
-/// `Ok` with all the successfully looked-up string values, or `Err`
-/// if any one or more lookups or string conversions failed.
-pub(crate) fn try_to_strings<'a, const NUM: usize>(
-    lookups: [MapLookup<'a>; NUM],
-) -> Result<[&'a str; NUM]> {
-    // Note (from arschles) about this code:
-    //
-    // In theory, there's a way to write this function in the functional
-    // programming (FP) style -- e.g. with a fold, map, flat_map, or
-    // something similar -- and without any mutability.
-    //
-    // In practice, however, since we're taking in a statically-sized slice,
-    // and we are expected to return a statically-sized slice of the same
-    // size, we are more limited in what we can do. There is a way to design
-    // a fold or flat_map to iterate over the lookups parameter and attempt to
-    // transform each MapLookup into the string value at that key.
-    //
-    // I wrote that code, which I'll called the "FP code" hereafter, and
-    // noticed two things:
-    //
-    // - It required several places where I had to explicitly deal with long
-    // and complex (in my opinion) types
-    // - It wasn't much more succinct or shorter than the code herein
-    //
-    // The FP code is functionally "pure" and maybe fun to write (if you like
-    // Rust or you love FP), but not fun to read. In fact, because of all the
-    // explicit type ceremony, I bet it'd make even the most hardcore Haskell
-    // programmer blush.
-    //
-    // So, I've decided to use a little bit of mutability to implement this
-    // function in a way I think most programmers would agree is easier to
-    // reason about and understand quickly.
-    //
-    // Final performance note:
-    //
-    // It's likely, but not certain, that the FP code is probably not
-    // significantly more memory efficient than this, since the compiler knows
-    // the size of both the input and output slices. Plus, this is test code,
-    // so even if this were 2x slower, I'd still argue the ease of
-    // understanding is more valuable than the (relatively small) memory
-    // savings.
-    let mut ret_slc: [&'a str; NUM] = [""; NUM];
-    for (idx, lookup) in lookups.iter().enumerate() {
-        let map = lookup.0;
-        let key = lookup.1;
-        let val = try_to_string(map, key)?;
-        ret_slc[idx] = val
+    /// A single value in the parameter list for the `try_to_strings`
+    /// function.
+    pub(crate) type MapLookup<'a> = (&'a Map<String, Value>, &'a str);
+
+    /// Given a constant-size slice of `MapLookup`s, attempt to look up the
+    /// string value in each `MapLookup`'s map (the first tuple element) for
+    /// that `MapLookup`'s key (the second tuple element). If the lookup
+    /// succeeded, attempt to convert the resulting value to a string. Return
+    /// `Ok` with all the successfully looked-up string values, or `Err`
+    /// if any one or more lookups or string conversions failed.
+    pub(crate) fn try_to_strings<'a, const NUM: usize>(
+        lookups: [MapLookup<'a>; NUM],
+    ) -> Result<[&'a str; NUM]> {
+        // Note (from arschles) about this code:
+        //
+        // In theory, there's a way to write this function in the functional
+        // programming (FP) style -- e.g. with a fold, map, flat_map, or
+        // something similar -- and without any mutability.
+        //
+        // In practice, however, since we're taking in a statically-sized slice,
+        // and we are expected to return a statically-sized slice of the same
+        // size, we are more limited in what we can do. There is a way to design
+        // a fold or flat_map to iterate over the lookups parameter and attempt to
+        // transform each MapLookup into the string value at that key.
+        //
+        // I wrote that code, which I'll called the "FP code" hereafter, and
+        // noticed two things:
+        //
+        // - It required several places where I had to explicitly deal with long
+        // and complex (in my opinion) types
+        // - It wasn't much more succinct or shorter than the code herein
+        //
+        // The FP code is functionally "pure" and maybe fun to write (if you like
+        // Rust or you love FP), but not fun to read. In fact, because of all the
+        // explicit type ceremony, I bet it'd make even the most hardcore Haskell
+        // programmer blush.
+        //
+        // So, I've decided to use a little bit of mutability to implement this
+        // function in a way I think most programmers would agree is easier to
+        // reason about and understand quickly.
+        //
+        // Final performance note:
+        //
+        // It's likely, but not certain, that the FP code is probably not
+        // significantly more memory efficient than this, since the compiler knows
+        // the size of both the input and output slices. Plus, this is test code,
+        // so even if this were 2x slower, I'd still argue the ease of
+        // understanding is more valuable than the (relatively small) memory
+        // savings.
+        let mut ret_slc: [&'a str; NUM] = [""; NUM];
+        for (idx, lookup) in lookups.iter().enumerate() {
+            let map = lookup.0;
+            let key = lookup.1;
+            let val = try_to_string(map, key)?;
+            ret_slc[idx] = val
+        }
+        Ok(ret_slc)
     }
-    Ok(ret_slc)
 }

--- a/src/hyperlight_host/tests/integration_test.rs
+++ b/src/hyperlight_host/tests/integration_test.rs
@@ -63,7 +63,7 @@ fn guest_abort() {
         .unwrap_err();
     println!("{:?}", res);
     assert!(
-        matches!(res, HyperlightError::GuestAborted(code, message) if (code == error_code && message.contains("NoException")) )
+        matches!(res, HyperlightError::GuestAborted(code, message) if (code == error_code && message.is_empty()))
     );
 }
 
@@ -83,7 +83,7 @@ fn guest_abort_with_context1() {
         .unwrap_err();
     println!("{:?}", res);
     assert!(
-        matches!(res, HyperlightError::GuestAborted(code, context) if (code == 25 && context.contains("NoException")))
+        matches!(res, HyperlightError::GuestAborted(code, context) if (code == 25 && context == "Oh no"))
     );
 }
 
@@ -135,7 +135,7 @@ fn guest_abort_with_context2() {
         .unwrap_err();
     println!("{:?}", res);
     assert!(
-        matches!(res, HyperlightError::GuestAborted(_, context) if context.contains("NoException"))
+        matches!(res, HyperlightError::GuestAborted(_, context) if context.contains("Guest abort buffer overflowed"))
     );
 }
 
@@ -161,7 +161,7 @@ fn guest_abort_c_guest() {
         .unwrap_err();
     println!("{:?}", res);
     assert!(
-        matches!(res, HyperlightError::GuestAborted(code, message) if (code == 75 && message.contains("NoException")) )
+        matches!(res, HyperlightError::GuestAborted(code, message) if (code == 75 && message == "This is a test error message") )
     );
 }
 
@@ -181,7 +181,7 @@ fn guest_panic() {
         .unwrap_err();
     println!("{:?}", res);
     assert!(
-        matches!(res, HyperlightError::GuestAborted(code, context) if code == ErrorCode::UnknownError as u8 && context.contains("NoException"))
+        matches!(res, HyperlightError::GuestAborted(code, context) if code == ErrorCode::UnknownError as u8 && context.contains("\nError... error..."))
     )
 }
 
@@ -261,7 +261,7 @@ fn guest_malloc_abort() {
     assert!(matches!(
         res.unwrap_err(),
         // OOM memory errors in rust allocator are panics. Our panic handler returns ErrorCode::UnknownError on panic
-        HyperlightError::GuestAborted(code, msg) if code == ErrorCode::UnknownError as u8 && msg.contains("NoException")
+        HyperlightError::GuestAborted(code, msg) if code == ErrorCode::UnknownError as u8 && msg.contains("memory allocation of ")
     ));
 }
 

--- a/src/tests/rust_guests/callbackguest/src/main.rs
+++ b/src/tests/rust_guests/callbackguest/src/main.rs
@@ -35,7 +35,7 @@ use hyperlight_guest::error::{HyperlightGuestError, Result};
 use hyperlight_guest::guest_function_definition::GuestFunctionDefinition;
 use hyperlight_guest::guest_function_register::register_function;
 use hyperlight_guest::host_function_call::{
-    call_host_function, get_host_return_value, print_output_as_guest_function,
+    call_host_function, get_host_return_value, print_output_with_host_print,
 };
 use hyperlight_guest::logging::log_message;
 
@@ -167,7 +167,7 @@ pub extern "C" fn hyperlight_main() {
         "PrintOutput".to_string(),
         Vec::from(&[ParameterType::String]),
         ReturnType::Int,
-        print_output_as_guest_function as usize,
+        print_output_with_host_print as usize,
     );
     register_function(print_output_def);
 


### PR DESCRIPTION
In #474, I removed the guest panic context region. With that, aborting was split into two steps:
    (1) printing panic info w/ debug_print, and
    (2) exiting w/ abort and codes.
    
This PR addresses feedback I got in #474 to join the operations by buffering string output when aborting.
    
This PR also cleans up our manual chunking logic w/ outb and leverages out8, out16, and out32 to minimize VM exits. Abort detects it should finishing buffering by a terminator code (0xFF).
    
Edited tests to check for panic message in aborts as they were prior to #474 merged.

This PR can be reviewed commit by commit. I also made some other minor changes like:
- removing some legacy unused structs, and
-  adding a feature flag to logging some of our build metadata, which uses a git2 dependency that is not available on every target.