### PR TITLE
Refactor HostFunction

### DIFF
--- a/src/hyperlight_host/src/func/param_type.rs
+++ b/src/hyperlight_host/src/func/param_type.rs
@@ -17,7 +17,8 @@ limitations under the License.
 use hyperlight_common::flatbuffer_wrappers::function_types::{ParameterType, ParameterValue};
 use tracing::{instrument, Span};
 
-use crate::HyperlightError::ParameterValueConversionFailure;
+use super::utils::for_each_tuple;
+use crate::HyperlightError::{ParameterValueConversionFailure, UnexpectedNoOfArguments};
 use crate::{log_then_return, Result};
 
 /// This is a marker trait that is used to indicate that a type is a
@@ -25,7 +26,7 @@ use crate::{log_then_return, Result};
 ///
 /// For each parameter type Hyperlight supports in host functions, we
 /// provide an implementation for `SupportedParameterType`
-pub trait SupportedParameterType: Sized {
+pub trait SupportedParameterType: Sized + Clone + Send + Sync + 'static {
     /// The underlying Hyperlight parameter type representing this `SupportedParameterType`
     const TYPE: ParameterType;
 
@@ -76,3 +77,47 @@ macro_rules! impl_supported_param_type {
 }
 
 for_each_param_type!(impl_supported_param_type);
+
+/// A trait to describe the tuple of parameters that a host function can take.
+pub trait ParameterTuple: Sized + Clone + Send + Sync + 'static {
+    /// The number of parameters in the tuple
+    const SIZE: usize;
+
+    /// The underlying Hyperlight parameter types representing this tuple of `SupportedParameterType`
+    const TYPE: &[ParameterType];
+
+    /// Get the underling Hyperlight parameter value representing this
+    /// `SupportedParameterType`
+    fn into_value(self) -> Vec<ParameterValue>;
+
+    /// Get the actual inner value of this `SupportedParameterType`
+    fn from_value(value: Vec<ParameterValue>) -> Result<Self>;
+}
+
+macro_rules! impl_param_tuple {
+    ([$N:expr] ($($name:ident: $param:ident),*)) => {
+        impl<$($param: SupportedParameterType),*> ParameterTuple for ($($param,)*) {
+            const SIZE: usize = $N;
+
+            const TYPE: &[ParameterType] = &[
+                $($param::TYPE),*
+            ];
+
+            #[instrument(skip_all, parent = Span::current(), level= "Trace")]
+            fn into_value(self) -> Vec<ParameterValue> {
+                let ($($name,)*) = self;
+                vec![$($name.into_value()),*]
+            }
+
+            #[instrument(err(Debug), skip_all, parent = Span::current(), level= "Trace")]
+            fn from_value(value: Vec<ParameterValue>) -> Result<Self> {
+                match <[ParameterValue; $N]>::try_from(value) {
+                    Ok([$($name,)*]) => Ok(($($param::from_value($name)?,)*)),
+                    Err(value) => { log_then_return!(UnexpectedNoOfArguments(value.len(), $N)); }
+                }
+            }
+        }
+    };
+}
+
+for_each_tuple!(impl_param_tuple);

--- a/src/hyperlight_host/src/func/utils.rs
+++ b/src/hyperlight_host/src/func/utils.rs
@@ -1,0 +1,63 @@
+/// An utility macro to execute a macro for each tuple of parameters
+/// up to 32 parameters. This is useful to implement traits on functions
+/// for may parameter tuples.
+///
+/// Usage:
+/// ```rust
+/// macro_rules! my_macro {
+///     ([$count:expr] ($($name:ident: $type:ident),*)) => {
+///         // $count is the arity of the tuple
+///         // $name is the name of the parameter: p1, p2, ..., p$count
+///         // $type is the type of the parameter: P1, P2, ..., P$count
+///     };
+/// }
+///
+/// for_each_tuple!(impl_host_function);
+/// ```
+macro_rules! for_each_tuple {
+    (@
+        $macro:ident
+        [$count:expr]
+        [
+            $($param_id:ident: $param_ty:ident),*
+        ]
+        []
+    ) => {
+        $macro!([$count] ($($param_id: $param_ty),*));
+    };
+    (@
+        $macro:ident
+        [$count:expr]
+        [
+            $($param_id:ident: $param_ty:ident),*
+        ]
+        [
+            $first_ident:ident: $first_type:ident
+            $(, $rest_ident:ident: $rest_type:ident)*
+            $(,)?
+        ]
+    ) => {
+        $macro!([$count] ($($param_id: $param_ty),*));
+        for_each_tuple!(@
+            $macro
+            [$count + 1]
+            [
+                $($param_id: $param_ty, )*
+                $first_ident: $first_type
+            ]
+            [
+                $($rest_ident: $rest_type),*
+            ]
+        );
+    };
+    ($macro:ident) => {
+        for_each_tuple!(@ $macro [0] [] [
+            p1:  P1,  p2:  P2,  p3:  P3,  p4:  P4,  p5:  P5,  p6:  P6,  p7:  P7,  p8:  P8,
+            p9:  P9,  p10: P10, p11: P11, p12: P12, p13: P13, p14: P14, p15: P15, p16: P16,
+            p17: P17, p18: P18, p19: P19, p20: P20, p21: P21, p22: P22, p23: P23, p24: P24,
+            p25: P25, p26: P26, p27: P27, p28: P28, p29: P29, p30: P30, p31: P31, p32: P32,
+        ]);
+    };
+}
+
+pub(super) use for_each_tuple;

--- a/src/hyperlight_host/src/sandbox/uninitialized.rs
+++ b/src/hyperlight_host/src/sandbox/uninitialized.rs
@@ -29,7 +29,8 @@ use super::host_funcs::{default_writer_func, FunctionRegistry};
 use super::mem_mgr::MemMgrWrapper;
 use super::run_options::SandboxRunOptions;
 use super::uninitialized_evolve::evolve_impl_multi_use;
-use crate::func::host_functions::{HostFunction, IntoHostFunction};
+use crate::func::host_functions::{register_host_function, HostFunction};
+use crate::func::{ParameterTuple, SupportedReturnType};
 #[cfg(feature = "build-metadata")]
 use crate::log_build_details;
 use crate::mem::exe::ExeInfo;
@@ -240,30 +241,29 @@ impl UninitializedSandbox {
     }
 
     /// Register a host function with the given name in the sandbox.
-    pub fn register<F, R, Args>(&mut self, name: impl AsRef<str>, host_func: F) -> Result<()>
-    where
-        F: IntoHostFunction<R, Args>,
-    {
-        host_func.into_host_function().register(self, name.as_ref())
+    pub fn register<Args: ParameterTuple, Output: SupportedReturnType>(
+        &mut self,
+        name: impl AsRef<str>,
+        host_func: impl Into<HostFunction<Output, Args>>,
+    ) -> Result<()> {
+        register_host_function(host_func, self, name.as_ref(), None)
     }
 
     /// Register the host function with the given name in the sandbox.
     /// Unlike `register`, this variant takes a list of extra syscalls that will
     /// allowed during the execution of the function handler.
     #[cfg(all(feature = "seccomp", target_os = "linux"))]
-    pub fn register_with_extra_allowed_syscalls<F, R, Args>(
+    pub fn register_with_extra_allowed_syscalls<
+        Args: ParameterTuple,
+        Output: SupportedReturnType,
+    >(
         &mut self,
         name: impl AsRef<str>,
-        host_func: F,
+        host_func: impl Into<HostFunction<Output, Args>>,
         extra_allowed_syscalls: impl IntoIterator<Item = crate::sandbox::ExtraAllowedSyscall>,
-    ) -> Result<()>
-    where
-        F: IntoHostFunction<R, Args>,
-    {
+    ) -> Result<()> {
         let extra_allowed_syscalls: Vec<_> = extra_allowed_syscalls.into_iter().collect();
-        host_func
-            .into_host_function()
-            .register_with_extra_allowed_syscalls(self, name.as_ref(), extra_allowed_syscalls)
+        register_host_function(host_func, self, name.as_ref(), Some(extra_allowed_syscalls))
     }
 
     /// Register a host function named "HostPrint" that will be called by the guest
@@ -272,7 +272,7 @@ impl UninitializedSandbox {
     /// `FnMut(String) -> i32` signature.
     pub fn register_print(
         &mut self,
-        print_func: impl IntoHostFunction<i32, (String,)>,
+        print_func: impl Into<HostFunction<i32, (String,)>>,
     ) -> Result<()> {
         #[cfg(not(all(target_os = "linux", feature = "seccomp")))]
         self.register("HostPrint", print_func)?;
@@ -296,7 +296,7 @@ impl UninitializedSandbox {
     #[cfg(all(feature = "seccomp", target_os = "linux"))]
     pub fn register_print_with_extra_allowed_syscalls(
         &mut self,
-        print_func: impl IntoHostFunction<i32, (String,)>,
+        print_func: impl Into<HostFunction<i32, (String,)>>,
         extra_allowed_syscalls: impl IntoIterator<Item = crate::sandbox::ExtraAllowedSyscall>,
     ) -> Result<()> {
         #[cfg(all(target_os = "linux", feature = "seccomp"))]

--- a/src/hyperlight_host/tests/common/mod.rs
+++ b/src/hyperlight_host/tests/common/mod.rs
@@ -43,7 +43,7 @@ pub fn new_uninit_rust() -> Result<UninitializedSandbox> {
 }
 
 pub fn get_simpleguest_sandboxes(
-    writer: Option<&dyn HostFunction<i32, (String,)>>, // An optional writer to make sure correct info is passed to the host printer
+    writer: Option<HostFunction<i32, (String,)>>, // An optional writer to make sure correct info is passed to the host printer
 ) -> Vec<MultiUseSandbox> {
     let elf_path = get_c_or_rust_simpleguest_path();
 
@@ -55,7 +55,7 @@ pub fn get_simpleguest_sandboxes(
     sandboxes
         .into_iter()
         .map(|mut sandbox| {
-            if let Some(writer) = writer {
+            if let Some(writer) = writer.clone() {
                 sandbox.register_print(writer).unwrap();
             }
             sandbox.evolve(Noop::default()).unwrap()
@@ -64,7 +64,7 @@ pub fn get_simpleguest_sandboxes(
 }
 
 pub fn get_callbackguest_uninit_sandboxes(
-    writer: Option<&dyn HostFunction<i32, (String,)>>, // An optional writer to make sure correct info is passed to the host printer
+    writer: Option<HostFunction<i32, (String,)>>, // An optional writer to make sure correct info is passed to the host printer
 ) -> Vec<UninitializedSandbox> {
     let elf_path = get_c_or_rust_callbackguest_path();
 
@@ -76,7 +76,7 @@ pub fn get_callbackguest_uninit_sandboxes(
     sandboxes
         .into_iter()
         .map(|mut sandbox| {
-            if let Some(writer) = writer {
+            if let Some(writer) = writer.clone() {
                 sandbox.register_print(writer).unwrap();
             }
             sandbox

--- a/src/hyperlight_host/tests/sandbox_host_tests.rs
+++ b/src/hyperlight_host/tests/sandbox_host_tests.rs
@@ -160,16 +160,14 @@ fn set_static() {
 fn multiple_parameters() {
     let messages = Arc::new(Mutex::new(Vec::new()));
     let messages_clone = messages.clone();
-    let writer = move |msg| {
+    let writer = move |msg: String| {
         let mut lock = messages_clone
             .try_lock()
             .map_err(|_| new_error!("Error locking"))
             .unwrap();
         lock.push(msg);
-        Ok(0)
+        0
     };
-
-    let writer_func = Arc::new(Mutex::new(writer));
 
     let test_cases = vec![
         (
@@ -320,7 +318,7 @@ fn multiple_parameters() {
         )
     ];
 
-    for mut sandbox in get_simpleguest_sandboxes(Some(&writer_func)).into_iter() {
+    for mut sandbox in get_simpleguest_sandboxes(Some(writer.into())).into_iter() {
         for (fn_name, args, _expected) in test_cases.clone().into_iter() {
             let res = sandbox.call_guest_function_by_name(fn_name, ReturnType::Int, Some(args));
             println!("{:?}", res);
@@ -426,14 +424,13 @@ fn simple_test_helper() -> Result<()> {
             .map_err(|_| new_error!("Error locking"))
             .unwrap();
         lock.push(msg);
-        Ok(len as i32)
+        len as i32
     };
 
     let message = "hello";
     let message2 = "world";
 
-    let writer_func = Arc::new(Mutex::new(writer));
-    for mut sandbox in get_simpleguest_sandboxes(Some(&writer_func)).into_iter() {
+    for mut sandbox in get_simpleguest_sandboxes(Some(writer.into())).into_iter() {
         let res = sandbox.call_guest_function_by_name(
             "PrintOutput",
             ReturnType::Int,


### PR DESCRIPTION
Some more refactor of `HostFunction`.
In this PR:
* the registration can't be made from the function anymore, and has to be done from the sandbox.
* the registered function can return either the plain type `T`, or a `Result<T>`.
* adds a new `ParameterTuple` trait that is used to define serializable input to a function.