### PR TITLE
Use native types when calling host functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,10 +59,9 @@ fn main() -> hyperlight_host::Result<()> {
     let message = "Hello, World! I am executing inside of a VM :)\n".to_string();
     // in order to call a function it first must be defined in the guest and exposed so that 
     // the host can call it
-    let result = multi_use_sandbox.call_guest_function_by_name(
+    let result: i32 = multi_use_sandbox.call_guest_function_by_name(
         "PrintOutput",
-        ReturnType::Int,
-        Some(vec![ParameterValue::String(message.clone())]),
+        (message),
     );
 
     assert!(result.is_ok());

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ fn main() -> hyperlight_host::Result<()> {
     // the host can call it
     let result: i32 = multi_use_sandbox.call_guest_function_by_name(
         "PrintOutput",
-        (message),
+        message,
     );
 
     assert!(result.is_ok());

--- a/fuzz/fuzz_targets/guest_call.rs
+++ b/fuzz/fuzz_targets/guest_call.rs
@@ -42,8 +42,8 @@ fuzz_target!(
         SANDBOX.set(Mutex::new(mu_sbox)).unwrap();
     },
 
-    |data: (ReturnType, Option<Vec<ParameterValue>>)| {
+    |data: (ReturnType, Vec<ParameterValue>)| {
         let mut sandbox = SANDBOX.get().unwrap().lock().unwrap();
-        let _ = sandbox.call_guest_function_by_name("PrintOutput", data.0, data.1);
+        let _ = sandbox.call_type_erased_guest_function_by_name("PrintOutput", data.0, data.1);
     }
 );

--- a/fuzz/fuzz_targets/host_call.rs
+++ b/fuzz/fuzz_targets/host_call.rs
@@ -45,7 +45,7 @@ fuzz_target!(
         let (host_func_name, host_func_return, mut host_func_params) = data;
         let mut sandbox = SANDBOX.get().unwrap().lock().unwrap();
         host_func_params.insert(0, ParameterValue::String(host_func_name));
-        match sandbox.call_guest_function_by_name("FuzzHostFunc", host_func_return, Some(host_func_params)) {
+        match sandbox.call_type_erased_guest_function_by_name("FuzzHostFunc", host_func_return, host_func_params) {
             Err(HyperlightError::GuestAborted(_, message)) if !message.contains("Host Function Not Found") => {
                 // We don't allow GuestAborted errors, except for the "Host Function Not Found" case
                 panic!("Guest Aborted: {}", message);

--- a/src/hyperlight_host/benches/benchmarks.rs
+++ b/src/hyperlight_host/benches/benchmarks.rs
@@ -17,7 +17,6 @@ limitations under the License.
 use std::time::Duration;
 
 use criterion::{criterion_group, criterion_main, Criterion};
-use hyperlight_common::flatbuffer_wrappers::function_types::{ParameterValue, ReturnType};
 use hyperlight_host::sandbox::{MultiUseSandbox, SandboxConfiguration, UninitializedSandbox};
 use hyperlight_host::sandbox_state::sandbox::EvolvableSandbox;
 use hyperlight_host::sandbox_state::transition::Noop;
@@ -43,11 +42,7 @@ fn guest_call_benchmark(c: &mut Criterion) {
 
         b.iter(|| {
             call_ctx
-                .call(
-                    "Echo",
-                    ReturnType::Int,
-                    Some(vec![ParameterValue::String("hello\n".to_string())]),
-                )
+                .call::<String>("Echo", "hello\n".to_string())
                 .unwrap()
         });
     });
@@ -59,11 +54,7 @@ fn guest_call_benchmark(c: &mut Criterion) {
 
         b.iter(|| {
             sandbox
-                .call_guest_function_by_name(
-                    "Echo",
-                    ReturnType::Int,
-                    Some(vec![ParameterValue::String("hello\n".to_string())]),
-                )
+                .call_guest_function_by_name::<String>("Echo", "hello\n".to_string())
                 .unwrap()
         });
     });
@@ -88,13 +79,9 @@ fn guest_call_benchmark(c: &mut Criterion) {
 
         b.iter(|| {
             sandbox
-                .call_guest_function_by_name(
+                .call_guest_function_by_name::<()>(
                     "LargeParameters",
-                    ReturnType::Void,
-                    Some(vec![
-                        ParameterValue::VecBytes(large_vec.clone()),
-                        ParameterValue::String(large_string.clone()),
-                    ]),
+                    (large_vec.clone(), large_string.clone()),
                 )
                 .unwrap()
         });
@@ -114,15 +101,7 @@ fn guest_call_benchmark(c: &mut Criterion) {
             uninitialized_sandbox.evolve(Noop::default()).unwrap();
         let mut call_ctx = multiuse_sandbox.new_call_context();
 
-        b.iter(|| {
-            call_ctx
-                .call(
-                    "Add",
-                    ReturnType::Int,
-                    Some(vec![ParameterValue::Int(1), ParameterValue::Int(41)]),
-                )
-                .unwrap()
-        });
+        b.iter(|| call_ctx.call::<i32>("Add", (1_i32, 41_i32)).unwrap());
     });
 
     group.finish();

--- a/src/hyperlight_host/examples/func_ctx/main.rs
+++ b/src/hyperlight_host/examples/func_ctx/main.rs
@@ -14,12 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use hyperlight_common::flatbuffer_wrappers::function_types::{ParameterValue, ReturnType};
 use hyperlight_host::func::call_ctx::MultiUseGuestCallContext;
 use hyperlight_host::sandbox::{MultiUseSandbox, UninitializedSandbox};
 use hyperlight_host::sandbox_state::sandbox::EvolvableSandbox;
 use hyperlight_host::sandbox_state::transition::Noop;
-use hyperlight_host::{new_error, GuestBinary, Result};
+use hyperlight_host::{GuestBinary, Result};
 use hyperlight_testing::simple_guest_as_string;
 
 fn main() {
@@ -47,29 +46,10 @@ fn main() {
 /// call `ctx.finish()` and return the resulting `MultiUseSandbox`. Return an `Err`
 /// if anything failed.
 fn do_calls(mut ctx: MultiUseGuestCallContext) -> Result<MultiUseSandbox> {
-    {
-        let res1: String = {
-            let rv = ctx.call(
-                "Echo",
-                ReturnType::Int,
-                Some(vec![ParameterValue::String("hello".to_string())]),
-            )?;
-            rv.try_into()
-        }
-        .map_err(|e| new_error!("failed to get Echo result: {}", e))?;
-        println!("got Echo res: {res1}");
-    }
-    {
-        let res2: i32 = {
-            let rv = ctx.call(
-                "CallMalloc",
-                ReturnType::Int,
-                Some(vec![ParameterValue::Int(200)]),
-            )?;
-            rv.try_into()
-        }
-        .map_err(|e| new_error!("failed to get CallMalloc result: {}", e))?;
-        println!("got CallMalloc res: {res2}");
-    }
+    let res: String = ctx.call("Echo", "hello".to_string())?;
+    println!("got Echo res: {res}");
+
+    let res: i32 = ctx.call("CallMalloc", 200_i32)?;
+    println!("got CallMalloc res: {res}");
     ctx.finish()
 }

--- a/src/hyperlight_host/examples/guest-debugging/main.rs
+++ b/src/hyperlight_host/examples/guest-debugging/main.rs
@@ -16,7 +16,6 @@ limitations under the License.
 #![allow(clippy::disallowed_macros)]
 use std::thread;
 
-use hyperlight_common::flatbuffer_wrappers::function_types::{ParameterValue, ReturnType};
 #[cfg(gdb)]
 use hyperlight_host::sandbox::config::DebugInfo;
 use hyperlight_host::sandbox::SandboxConfiguration;
@@ -62,13 +61,12 @@ fn main() -> hyperlight_host::Result<()> {
 
     // Call guest function
     let message = "Hello, World! I am executing inside of a VM :)\n".to_string();
-    let result = multi_use_sandbox.call_guest_function_by_name(
-        "PrintOutput", // function must be defined in the guest binary
-        ReturnType::Int,
-        Some(vec![ParameterValue::String(message.clone())]),
-    );
-
-    assert!(result.is_ok());
+    multi_use_sandbox
+        .call_guest_function_by_name::<i32>(
+            "PrintOutput", // function must be defined in the guest binary
+            message.clone(),
+        )
+        .unwrap();
 
     Ok(())
 }

--- a/src/hyperlight_host/examples/hello-world/main.rs
+++ b/src/hyperlight_host/examples/hello-world/main.rs
@@ -16,7 +16,6 @@ limitations under the License.
 #![allow(clippy::disallowed_macros)]
 use std::thread;
 
-use hyperlight_common::flatbuffer_wrappers::function_types::{ParameterValue, ReturnType};
 use hyperlight_host::sandbox_state::sandbox::EvolvableSandbox;
 use hyperlight_host::sandbox_state::transition::Noop;
 use hyperlight_host::{MultiUseSandbox, UninitializedSandbox};
@@ -42,13 +41,12 @@ fn main() -> hyperlight_host::Result<()> {
 
     // Call guest function
     let message = "Hello, World! I am executing inside of a VM :)\n".to_string();
-    let result = multi_use_sandbox.call_guest_function_by_name(
-        "PrintOutput", // function must be defined in the guest binary
-        ReturnType::Int,
-        Some(vec![ParameterValue::String(message.clone())]),
-    );
-
-    assert!(result.is_ok());
+    multi_use_sandbox
+        .call_guest_function_by_name::<i32>(
+            "PrintOutput", // function must be defined in the guest binary
+            message,
+        )
+        .unwrap();
 
     Ok(())
 }

--- a/src/hyperlight_host/examples/logging/main.rs
+++ b/src/hyperlight_host/examples/logging/main.rs
@@ -16,7 +16,6 @@ limitations under the License.
 #![allow(clippy::disallowed_macros)]
 extern crate hyperlight_host;
 
-use hyperlight_common::flatbuffer_wrappers::function_types::{ParameterValue, ReturnType};
 use hyperlight_host::sandbox::uninitialized::UninitializedSandbox;
 use hyperlight_host::sandbox_state::sandbox::EvolvableSandbox;
 use hyperlight_host::sandbox_state::transition::Noop;
@@ -53,12 +52,9 @@ fn main() -> Result<()> {
 
             // Call a guest function 5 times to generate some log entries.
             for _ in 0..5 {
-                let result = multiuse_sandbox.call_guest_function_by_name(
-                    "Echo",
-                    ReturnType::String,
-                    Some(vec![ParameterValue::String("a".to_string())]),
-                );
-                result.unwrap();
+                multiuse_sandbox
+                    .call_guest_function_by_name::<String>("Echo", "a".to_string())
+                    .unwrap();
             }
 
             // Define a message to send to the guest.
@@ -67,12 +63,9 @@ fn main() -> Result<()> {
 
             // Call a guest function that calls the HostPrint host function 5 times to generate some log entries.
             for _ in 0..5 {
-                let result = multiuse_sandbox.call_guest_function_by_name(
-                    "PrintOutput",
-                    ReturnType::Int,
-                    Some(vec![ParameterValue::String(msg.clone())]),
-                );
-                result.unwrap();
+                multiuse_sandbox
+                    .call_guest_function_by_name::<i32>("PrintOutput", msg.clone())
+                    .unwrap();
             }
             Ok(())
         };
@@ -95,10 +88,8 @@ fn main() -> Result<()> {
     for _ in 0..5 {
         let mut ctx = multiuse_sandbox.new_call_context();
 
-        let result = ctx.call("Spin", ReturnType::Void, None);
-        assert!(result.is_err());
-        let result = ctx.finish();
-        multiuse_sandbox = result.unwrap();
+        ctx.call::<()>("Spin", ()).unwrap_err();
+        multiuse_sandbox = ctx.finish().unwrap();
     }
 
     Ok(())

--- a/src/hyperlight_host/examples/metrics/main.rs
+++ b/src/hyperlight_host/examples/metrics/main.rs
@@ -17,7 +17,6 @@ limitations under the License.
 extern crate hyperlight_host;
 use std::thread::{spawn, JoinHandle};
 
-use hyperlight_common::flatbuffer_wrappers::function_types::{ParameterValue, ReturnType};
 use hyperlight_host::sandbox::uninitialized::UninitializedSandbox;
 use hyperlight_host::sandbox_state::sandbox::EvolvableSandbox;
 use hyperlight_host::sandbox_state::transition::Noop;
@@ -65,12 +64,9 @@ fn do_hyperlight_stuff() {
 
             // Call a guest function 5 times to generate some metrics.
             for _ in 0..5 {
-                let result = multiuse_sandbox.call_guest_function_by_name(
-                    "Echo",
-                    ReturnType::String,
-                    Some(vec![ParameterValue::String("a".to_string())]),
-                );
-                assert!(result.is_ok());
+                multiuse_sandbox
+                    .call_guest_function_by_name::<String>("Echo", "a".to_string())
+                    .unwrap();
             }
 
             // Define a message to send to the guest.
@@ -79,12 +75,9 @@ fn do_hyperlight_stuff() {
 
             // Call a guest function that calls the HostPrint host function 5 times to generate some metrics.
             for _ in 0..5 {
-                let result = multiuse_sandbox.call_guest_function_by_name(
-                    "PrintOutput",
-                    ReturnType::Int,
-                    Some(vec![ParameterValue::String(msg.clone())]),
-                );
-                assert!(result.is_ok());
+                multiuse_sandbox
+                    .call_guest_function_by_name::<i32>("PrintOutput", msg.clone())
+                    .unwrap();
             }
             Ok(())
         });
@@ -108,11 +101,8 @@ fn do_hyperlight_stuff() {
     for _ in 0..5 {
         let mut ctx = multiuse_sandbox.new_call_context();
 
-        let result = ctx.call("Spin", ReturnType::Void, None);
-        assert!(result.is_err());
-        let result = ctx.finish();
-        assert!(result.is_ok());
-        multiuse_sandbox = result.unwrap();
+        ctx.call::<()>("Spin", ()).unwrap_err();
+        multiuse_sandbox = ctx.finish().unwrap();
     }
 
     for join_handle in join_handles {

--- a/src/hyperlight_host/examples/tracing-chrome/main.rs
+++ b/src/hyperlight_host/examples/tracing-chrome/main.rs
@@ -14,7 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 #![allow(clippy::disallowed_macros)]
-use hyperlight_host::func::{ParameterValue, ReturnType, ReturnValue};
 use hyperlight_host::sandbox::uninitialized::UninitializedSandbox;
 use hyperlight_host::sandbox_state::sandbox::EvolvableSandbox;
 use hyperlight_host::sandbox_state::transition::Noop;
@@ -41,13 +40,9 @@ fn main() -> Result<()> {
 
     // do the function call
     let current_time = std::time::Instant::now();
-    let res = sbox.call_guest_function_by_name(
-        "Echo",
-        ReturnType::String,
-        Some(vec![ParameterValue::String("Hello, World!".to_string())]),
-    )?;
+    let res: String = sbox.call_guest_function_by_name("Echo", "Hello, World!".to_string())?;
     let elapsed = current_time.elapsed();
     println!("Function call finished in {:?}.", elapsed);
-    assert!(matches!(res, ReturnValue::String(s) if s == "Hello, World!"));
+    assert_eq!(res, "Hello, World!");
     Ok(())
 }

--- a/src/hyperlight_host/examples/tracing-otlp/main.rs
+++ b/src/hyperlight_host/examples/tracing-otlp/main.rs
@@ -14,7 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 #![allow(clippy::disallowed_macros)]
-use hyperlight_common::flatbuffer_wrappers::function_types::{ParameterValue, ReturnType};
 //use opentelemetry_sdk::resource::ResourceBuilder;
 use opentelemetry_sdk::trace::SdkTracerProvider;
 use rand::Rng;
@@ -108,7 +107,7 @@ fn run_example(wait_input: bool) -> HyperlightResult<()> {
     let mut join_handles: Vec<JoinHandle<HyperlightResult<()>>> = vec![];
 
     // Construct a new span named "hyperlight otel tracing example" with INFO  level.
-    let span = span!(Level::INFO, "hyperlight otel tracing example",);
+    let span = span!(Level::INFO, "hyperlight otel tracing example");
     let _entered = span.enter();
 
     let should_exit = Arc::new(Mutex::new(false));
@@ -141,12 +140,9 @@ fn run_example(wait_input: bool) -> HyperlightResult<()> {
 
                 // Call a guest function 5 times to generate some log entries.
                 for _ in 0..5 {
-                    let result = multiuse_sandbox.call_guest_function_by_name(
-                        "Echo",
-                        ReturnType::String,
-                        Some(vec![ParameterValue::String("a".to_string())]),
-                    );
-                    assert!(result.is_ok());
+                    multiuse_sandbox
+                        .call_guest_function_by_name::<String>("Echo", "a".to_string())
+                        .unwrap();
                 }
 
                 // Define a message to send to the guest.
@@ -155,12 +151,9 @@ fn run_example(wait_input: bool) -> HyperlightResult<()> {
 
                 // Call a guest function that calls the HostPrint host function 5 times to generate some log entries.
                 for _ in 0..5 {
-                    let result = multiuse_sandbox.call_guest_function_by_name(
-                        "PrintOutput",
-                        ReturnType::Int,
-                        Some(vec![ParameterValue::String(msg.clone())]),
-                    );
-                    assert!(result.is_ok());
+                    multiuse_sandbox
+                        .call_guest_function_by_name::<i32>("PrintOutput", msg.clone())
+                        .unwrap();
                 }
 
                 // Call a function that gets cancelled by the host function 5 times to generate some log entries.
@@ -177,11 +170,8 @@ fn run_example(wait_input: bool) -> HyperlightResult<()> {
                     let _entered = span.enter();
                     let mut ctx = multiuse_sandbox.new_call_context();
 
-                    let result = ctx.call("Spin", ReturnType::Void, None);
-                    assert!(result.is_err());
-                    let result = ctx.finish();
-                    assert!(result.is_ok());
-                    multiuse_sandbox = result.unwrap();
+                    ctx.call::<()>("Spin", ()).unwrap_err();
+                    multiuse_sandbox = ctx.finish().unwrap();
                 }
                 let sleep_for = {
                     let mut rng = rand::rng();

--- a/src/hyperlight_host/examples/tracing-tracy/main.rs
+++ b/src/hyperlight_host/examples/tracing-tracy/main.rs
@@ -14,7 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 #![allow(clippy::disallowed_macros)]
-use hyperlight_host::func::{ParameterValue, ReturnType, ReturnValue};
 use hyperlight_host::sandbox::uninitialized::UninitializedSandbox;
 use hyperlight_host::sandbox_state::sandbox::EvolvableSandbox;
 use hyperlight_host::sandbox_state::transition::Noop;
@@ -47,13 +46,9 @@ fn main() -> Result<()> {
 
     // do the function call
     let current_time = std::time::Instant::now();
-    let res = sbox.call_guest_function_by_name(
-        "Echo",
-        ReturnType::String,
-        Some(vec![ParameterValue::String("Hello, World!".to_string())]),
-    )?;
+    let res: String = sbox.call_guest_function_by_name("Echo", "Hello, World!".to_string())?;
     let elapsed = current_time.elapsed();
     println!("Function call finished in {:?}.", elapsed);
-    assert!(matches!(res, ReturnValue::String(s) if s == "Hello, World!"));
+    assert_eq!(res, "Hello, World!");
     Ok(())
 }

--- a/src/hyperlight_host/src/func/call_ctx.rs
+++ b/src/hyperlight_host/src/func/call_ctx.rs
@@ -14,12 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use hyperlight_common::flatbuffer_wrappers::function_types::{
-    ParameterValue, ReturnType, ReturnValue,
-};
 use tracing::{instrument, Span};
 
 use super::guest_dispatch::call_function_on_guest;
+use super::{ParameterTuple, SupportedReturnType};
 use crate::{MultiUseSandbox, Result};
 /// A context for calling guest functions.
 ///
@@ -61,18 +59,19 @@ impl MultiUseGuestCallContext {
     /// If you want  to reset state, call `finish()` on this `MultiUseGuestCallContext`
     /// and get a new one from the resulting `MultiUseSandbox`
     #[instrument(err(Debug),skip(self, args),parent = Span::current())]
-    pub fn call(
+    pub fn call<Output: SupportedReturnType>(
         &mut self,
         func_name: &str,
-        func_ret_type: ReturnType,
-        args: Option<Vec<ParameterValue>>,
-    ) -> Result<ReturnValue> {
+        args: impl ParameterTuple,
+    ) -> Result<Output> {
         // we are guaranteed to be holding a lock now, since `self` can't
         // exist without doing so. Since GuestCallContext is effectively
         // !Send (and !Sync), we also don't need to worry about
         // synchronization
 
-        call_function_on_guest(&mut self.sbox, func_name, func_ret_type, args)
+        let ret =
+            call_function_on_guest(&mut self.sbox, func_name, Output::TYPE, args.into_value());
+        Output::from_value(ret?)
     }
 
     /// Close out the context and get back the internally-stored
@@ -104,11 +103,9 @@ mod tests {
     use std::sync::mpsc::sync_channel;
     use std::thread::{self, JoinHandle};
 
-    use hyperlight_common::flatbuffer_wrappers::function_types::{
-        ParameterValue, ReturnType, ReturnValue,
-    };
     use hyperlight_testing::simple_guest_as_string;
 
+    use super::MultiUseGuestCallContext;
     use crate::sandbox_state::sandbox::EvolvableSandbox;
     use crate::sandbox_state::transition::Noop;
     use crate::{GuestBinary, HyperlightError, MultiUseSandbox, Result, UninitializedSandbox};
@@ -148,10 +145,7 @@ mod tests {
             while let Ok(calls) = recv.recv() {
                 let mut ctx = sbox.new_call_context();
                 for call in calls {
-                    let res = ctx
-                        .call(call.func_name.as_str(), call.ret_type, call.params)
-                        .unwrap();
-                    assert_eq!(call.expected_ret, res);
+                    call.call(&mut ctx);
                 }
                 sbox = ctx.finish().unwrap();
             }
@@ -162,21 +156,16 @@ mod tests {
             .map(|i| {
                 let sender = snd.clone();
                 thread::spawn(move || {
-                    let calls: Vec<TestFuncCall> = vec![
-                        TestFuncCall {
-                            func_name: "Echo".to_string(),
-                            ret_type: ReturnType::String,
-                            params: Some(vec![ParameterValue::String(
-                                format!("Hello {}", i).to_string(),
-                            )]),
-                            expected_ret: ReturnValue::String(format!("Hello {}", i).to_string()),
-                        },
-                        TestFuncCall {
-                            func_name: "CallMalloc".to_string(),
-                            ret_type: ReturnType::Int,
-                            params: Some(vec![ParameterValue::Int(i + 2)]),
-                            expected_ret: ReturnValue::Int(i + 2),
-                        },
+                    let calls = vec![
+                        TestFuncCall::new(move |ctx| {
+                            let msg = format!("Hello {}", i);
+                            let ret: String = ctx.call("Echo", msg.clone()).unwrap();
+                            assert_eq!(ret, msg)
+                        }),
+                        TestFuncCall::new(move |ctx| {
+                            let ret: i32 = ctx.call("CallMalloc", i + 2).unwrap();
+                            assert_eq!(ret, i + 2)
+                        }),
                     ];
                     sender.send(calls).unwrap();
                 })
@@ -206,15 +195,11 @@ mod tests {
             let mut ctx = self.sandbox.new_call_context();
             let mut sum: i32 = 0;
             for n in 0..i {
-                let result = ctx.call(
-                    "AddToStatic",
-                    ReturnType::Int,
-                    Some(vec![ParameterValue::Int(n)]),
-                );
+                let result = ctx.call::<i32>("AddToStatic", n);
                 sum += n;
                 println!("{:?}", result);
                 let result = result.unwrap();
-                assert_eq!(result, ReturnValue::Int(sum));
+                assert_eq!(result, sum);
             }
             let result = ctx.finish();
             assert!(result.is_ok());
@@ -224,14 +209,12 @@ mod tests {
 
         pub fn call_add_to_static(mut self, i: i32) -> Result<()> {
             for n in 0..i {
-                let result = self.sandbox.call_guest_function_by_name(
-                    "AddToStatic",
-                    ReturnType::Int,
-                    Some(vec![ParameterValue::Int(n)]),
-                );
+                let result = self
+                    .sandbox
+                    .call_guest_function_by_name::<i32>("AddToStatic", n);
                 println!("{:?}", result);
                 let result = result.unwrap();
-                assert_eq!(result, ReturnValue::Int(n));
+                assert_eq!(result, n);
             }
             Ok(())
         }
@@ -251,10 +234,15 @@ mod tests {
         assert!(result.is_ok());
     }
 
-    struct TestFuncCall {
-        func_name: String,
-        ret_type: ReturnType,
-        params: Option<Vec<ParameterValue>>,
-        expected_ret: ReturnValue,
+    struct TestFuncCall(Box<dyn FnOnce(&mut MultiUseGuestCallContext) + Send>);
+
+    impl TestFuncCall {
+        fn new(f: impl FnOnce(&mut MultiUseGuestCallContext) + Send + 'static) -> Self {
+            TestFuncCall(Box::new(f))
+        }
+
+        fn call(self, ctx: &mut MultiUseGuestCallContext) {
+            (self.0)(ctx);
+        }
     }
 }

--- a/src/hyperlight_host/src/func/ret_type.rs
+++ b/src/hyperlight_host/src/func/ret_type.rs
@@ -49,6 +49,8 @@ macro_rules! for_each_return_type {
         $macro!(u32, UInt);
         $macro!(i64, Long);
         $macro!(u64, ULong);
+        $macro!(f32, Float);
+        $macro!(f64, Double);
         $macro!(bool, Bool);
         $macro!(Vec<u8>, VecBytes);
     };

--- a/src/hyperlight_host/src/hypervisor/hypervisor_handler.rs
+++ b/src/hyperlight_host/src/hypervisor/hypervisor_handler.rs
@@ -929,7 +929,6 @@ mod tests {
     use std::sync::{Arc, Barrier};
     use std::thread;
 
-    use hyperlight_common::flatbuffer_wrappers::function_types::{ParameterValue, ReturnType};
     use hyperlight_testing::simple_guest_as_string;
 
     #[cfg(target_os = "windows")]
@@ -1013,11 +1012,7 @@ mod tests {
         let mut sandbox = create_multi_use_sandbox();
 
         let msg = "Hello, World!\n".to_string();
-        let res = sandbox.call_guest_function_by_name(
-            "PrintOutput",
-            ReturnType::Int,
-            Some(vec![ParameterValue::String(msg.clone())]),
-        );
+        let res = sandbox.call_guest_function_by_name::<i32>("PrintOutput", msg);
 
         assert!(res.is_ok());
 
@@ -1028,7 +1023,7 @@ mod tests {
     fn terminate_execution_then_call_another_function() -> Result<()> {
         let mut sandbox = create_multi_use_sandbox();
 
-        let res = sandbox.call_guest_function_by_name("Spin", ReturnType::Void, None);
+        let res = sandbox.call_guest_function_by_name::<()>("Spin", ());
 
         assert!(res.is_err());
 
@@ -1037,11 +1032,7 @@ mod tests {
             _ => panic!("Expected ExecutionTerminated error"),
         }
 
-        let res = sandbox.call_guest_function_by_name(
-            "Echo",
-            ReturnType::String,
-            Some(vec![ParameterValue::String("a".to_string())]),
-        );
+        let res = sandbox.call_guest_function_by_name::<String>("Echo", "a".to_string());
 
         assert!(res.is_ok());
 
@@ -1053,11 +1044,7 @@ mod tests {
     {
         let call_print_output = |sandbox: &mut MultiUseSandbox| {
             let msg = "Hello, World!\n".to_string();
-            let res = sandbox.call_guest_function_by_name(
-                "PrintOutput",
-                ReturnType::Int,
-                Some(vec![ParameterValue::String(msg.clone())]),
-            );
+            let res = sandbox.call_guest_function_by_name::<i32>("PrintOutput", msg);
 
             assert!(res.is_ok());
         };

--- a/src/hyperlight_host/src/metrics/mod.rs
+++ b/src/hyperlight_host/src/metrics/mod.rs
@@ -85,7 +85,6 @@ pub(crate) fn maybe_time_and_emit_host_call<T, F: FnOnce() -> T>(
 
 #[cfg(test)]
 mod tests {
-    use hyperlight_common::flatbuffer_wrappers::function_types::{ParameterValue, ReturnType};
     use hyperlight_testing::simple_guest_as_string;
     use metrics::Key;
     use metrics_util::CompositeKey;
@@ -116,15 +115,11 @@ mod tests {
             let mut multi = uninit.evolve(Noop::default()).unwrap();
 
             multi
-                .call_guest_function_by_name(
-                    "PrintOutput",
-                    ReturnType::Int,
-                    Some(vec![ParameterValue::String("Hello".to_string())]),
-                )
+                .call_guest_function_by_name::<i32>("PrintOutput", "Hello".to_string())
                 .unwrap();
 
             multi
-                .call_guest_function_by_name("Spin", ReturnType::Int, None)
+                .call_guest_function_by_name::<i32>("Spin", ())
                 .unwrap_err();
 
             snapshotter.snapshot()

--- a/src/hyperlight_host/src/sandbox/host_funcs.rs
+++ b/src/hyperlight_host/src/sandbox/host_funcs.rs
@@ -159,7 +159,7 @@ fn maybe_with_seccomp<T: Send>(
     // Use a scoped thread so that we can pass around references without having to clone them.
     crossbeam::thread::scope(|s| {
         s.builder()
-            .name(format!("Host Function Worker Thread for: {name:?}",))
+            .name(format!("Host Function Worker Thread for: {name:?}"))
             .spawn(move |_| {
                 let seccomp_filter = get_seccomp_filter_for_host_function_worker_thread(syscalls)?;
                 seccompiler::apply_filter(&seccomp_filter)?;

--- a/src/hyperlight_host/src/sandbox/initialized_multi_use.rs
+++ b/src/hyperlight_host/src/sandbox/initialized_multi_use.rs
@@ -25,6 +25,7 @@ use super::host_funcs::FunctionRegistry;
 use super::{MemMgrWrapper, WrapperGetter};
 use crate::func::call_ctx::MultiUseGuestCallContext;
 use crate::func::guest_dispatch::call_function_on_guest;
+use crate::func::{ParameterTuple, SupportedReturnType};
 use crate::hypervisor::hypervisor_handler::HypervisorHandler;
 use crate::mem::shared_mem::HostSharedMemory;
 use crate::sandbox_state::sandbox::{DevolvableSandbox, EvolvableSandbox, Sandbox};
@@ -155,15 +156,28 @@ impl MultiUseSandbox {
 
     /// Call a guest function by name, with the given return type and arguments.
     #[instrument(err(Debug), skip(self, args), parent = Span::current())]
-    pub fn call_guest_function_by_name(
+    pub fn call_guest_function_by_name<Output: SupportedReturnType>(
         &mut self,
         func_name: &str,
-        func_ret_type: ReturnType,
-        args: Option<Vec<ParameterValue>>,
-    ) -> Result<ReturnValue> {
-        let res = call_function_on_guest(self, func_name, func_ret_type, args);
+        args: impl ParameterTuple,
+    ) -> Result<Output> {
+        let ret = call_function_on_guest(self, func_name, Output::TYPE, args.into_value());
         self.restore_state()?;
-        res
+        Output::from_value(ret?)
+    }
+
+    /// This function is kept here for fuzz testing
+    #[doc(hidden)]
+    #[instrument(err(Debug), skip(self, args), parent = Span::current())]
+    pub fn call_type_erased_guest_function_by_name(
+        &mut self,
+        func_name: &str,
+        ret_type: ReturnType,
+        args: Vec<ParameterValue>,
+    ) -> Result<ReturnValue> {
+        let ret = call_function_on_guest(self, func_name, ret_type, args);
+        self.restore_state()?;
+        ret
     }
 
     /// Restore the Sandbox's state
@@ -255,9 +269,6 @@ where
 
 #[cfg(test)]
 mod tests {
-    use hyperlight_common::flatbuffer_wrappers::function_types::{
-        ParameterValue, ReturnType, ReturnValue,
-    };
     use hyperlight_testing::simple_guest_as_string;
 
     use crate::func::call_ctx::MultiUseGuestCallContext;
@@ -284,12 +295,7 @@ mod tests {
         let mut ctx = sbox1.new_call_context();
 
         for _ in 0..1000 {
-            ctx.call(
-                "Echo",
-                ReturnType::String,
-                Some(vec![ParameterValue::String("hello".to_string())]),
-            )
-            .unwrap();
+            ctx.call::<String>("Echo", "hello".to_string()).unwrap();
         }
 
         let sbox2: MultiUseSandbox = {
@@ -302,12 +308,9 @@ mod tests {
         let mut ctx = sbox2.new_call_context();
 
         for i in 0..1000 {
-            ctx.call(
+            ctx.call::<i32>(
                 "PrintUsingPrintf",
-                ReturnType::Int,
-                Some(vec![ParameterValue::String(
-                    format!("Hello World {}\n", i).to_string(),
-                )]),
+                format!("Hello World {}\n", i).to_string(),
             )
             .unwrap();
         }
@@ -325,23 +328,15 @@ mod tests {
         .unwrap();
 
         let func = Box::new(|call_ctx: &mut MultiUseGuestCallContext| {
-            call_ctx.call(
-                "AddToStatic",
-                ReturnType::Int,
-                Some(vec![ParameterValue::Int(5)]),
-            )?;
+            call_ctx.call::<i32>("AddToStatic", 5i32)?;
             Ok(())
         });
         let transition_func = MultiUseContextCallback::from(func);
         let mut sbox2 = sbox1.evolve(transition_func).unwrap();
-        let res = sbox2
-            .call_guest_function_by_name("GetStatic", ReturnType::Int, None)
-            .unwrap();
-        assert_eq!(res, ReturnValue::Int(5));
+        let res: i32 = sbox2.call_guest_function_by_name("GetStatic", ()).unwrap();
+        assert_eq!(res, 5);
         let mut sbox3: MultiUseSandbox = sbox2.devolve(Noop::default()).unwrap();
-        let res = sbox3
-            .call_guest_function_by_name("GetStatic", ReturnType::Int, None)
-            .unwrap();
-        assert_eq!(res, ReturnValue::Int(0));
+        let res: i32 = sbox3.call_guest_function_by_name("GetStatic", ()).unwrap();
+        assert_eq!(res, 0);
     }
 }

--- a/src/hyperlight_host/src/sandbox/initialized_multi_use.rs
+++ b/src/hyperlight_host/src/sandbox/initialized_multi_use.rs
@@ -166,8 +166,8 @@ impl MultiUseSandbox {
         Output::from_value(ret?)
     }
 
-    /// This function is kept here for fuzz testing
-    #[doc(hidden)]
+    /// This function is kept here for fuzz testing the parameter and return types
+    #[cfg(feature = "fuzzing")]
     #[instrument(err(Debug), skip(self, args), parent = Span::current())]
     pub fn call_type_erased_guest_function_by_name(
         &mut self,

--- a/src/hyperlight_host/src/seccomp/guest.rs
+++ b/src/hyperlight_host/src/seccomp/guest.rs
@@ -57,6 +57,8 @@ fn syscalls_allowlist() -> Result<Vec<(i64, Vec<SeccompRule>)>> {
         // `sched_yield` is needed for many synchronization primitives that may be invoked
         // on the host function worker thread
         (libc::SYS_sched_yield, vec![]),
+        // `mprotect` is needed by malloc during memory allocation
+        (libc::SYS_mprotect, vec![]),
     ])
 }
 

--- a/src/hyperlight_host/tests/sandbox_host_tests.rs
+++ b/src/hyperlight_host/tests/sandbox_host_tests.rs
@@ -15,10 +15,10 @@ limitations under the License.
 */
 #![allow(clippy::disallowed_macros)]
 use core::f64;
+use std::sync::mpsc::channel;
 use std::sync::{Arc, Mutex};
 
 use common::new_uninit;
-use hyperlight_host::func::{ParameterValue, ReturnType, ReturnValue};
 use hyperlight_host::sandbox::SandboxConfiguration;
 use hyperlight_host::sandbox_state::sandbox::EvolvableSandbox;
 use hyperlight_host::sandbox_state::transition::Noop;
@@ -39,26 +39,13 @@ fn pass_byte_array() {
         let mut ctx = sandbox.new_call_context();
         const LEN: usize = 10;
         let bytes = vec![1u8; LEN];
-        let res = ctx.call(
-            "SetByteArrayToZero",
-            ReturnType::VecBytes,
-            Some(vec![ParameterValue::VecBytes(bytes.clone())]),
-        );
+        let res: Vec<u8> = ctx
+            .call("SetByteArrayToZero", bytes.clone())
+            .expect("Expected VecBytes");
+        assert_eq!(res, [0; LEN]);
 
-        match res.unwrap() {
-            ReturnValue::VecBytes(res_bytes) => {
-                assert_eq!(res_bytes.len(), LEN);
-                assert!(res_bytes.iter().all(|&b| b == 0));
-            }
-            _ => panic!("Expected VecBytes"),
-        }
-
-        let res = ctx.call(
-            "SetByteArrayToZeroNoLength",
-            ReturnType::Int,
-            Some(vec![ParameterValue::VecBytes(bytes.clone())]),
-        );
-        assert!(res.is_err()); // missing length param
+        ctx.call::<i32>("SetByteArrayToZeroNoLength", bytes.clone())
+            .unwrap_err(); // missing length param
     }
 }
 
@@ -100,28 +87,24 @@ fn float_roundtrip() {
     ];
     let mut sandbox: MultiUseSandbox = new_uninit().unwrap().evolve(Noop::default()).unwrap();
     for f in doubles.iter() {
-        let res = sandbox.call_guest_function_by_name(
-            "EchoDouble",
-            ReturnType::Double,
-            Some(vec![ParameterValue::Double(*f)]),
-        );
+        let res: f64 = sandbox
+            .call_guest_function_by_name("EchoDouble", *f)
+            .unwrap();
 
         assert!(
-            matches!(res, Ok(ReturnValue::Double(f2)) if f2 == *f || f2.is_nan() && f.is_nan()),
+            res.total_cmp(f).is_eq(),
             "Expected {:?} but got {:?}",
             f,
             res
         );
     }
     for f in floats.iter() {
-        let res = sandbox.call_guest_function_by_name(
-            "EchoFloat",
-            ReturnType::Float,
-            Some(vec![ParameterValue::Float(*f)]),
-        );
+        let res: f32 = sandbox
+            .call_guest_function_by_name("EchoFloat", *f)
+            .unwrap();
 
         assert!(
-            matches!(res, Ok(ReturnValue::Float(f2)) if f2 == *f || f2.is_nan() && f.is_nan()),
+            res.total_cmp(f).is_eq(),
             "Expected {:?} but got {:?}",
             f,
             res
@@ -134,7 +117,7 @@ fn float_roundtrip() {
 fn invalid_guest_function_name() {
     for mut sandbox in get_simpleguest_sandboxes(None).into_iter() {
         let fn_name = "FunctionDoesntExist";
-        let res = sandbox.call_guest_function_by_name(fn_name, ReturnType::Int, None);
+        let res = sandbox.call_guest_function_by_name::<i32>(fn_name, ());
         println!("{:?}", res);
         assert!(
             matches!(res.unwrap_err(), HyperlightError::GuestError(hyperlight_common::flatbuffer_wrappers::guest_error::ErrorCode::GuestFunctionNotFound, error_name) if error_name == fn_name)
@@ -147,208 +130,68 @@ fn invalid_guest_function_name() {
 fn set_static() {
     for mut sandbox in get_simpleguest_sandboxes(None).into_iter() {
         let fn_name = "SetStatic";
-        let res = sandbox.call_guest_function_by_name(fn_name, ReturnType::Int, None);
+        let res = sandbox.call_guest_function_by_name::<i32>(fn_name, ());
         println!("{:?}", res);
         assert!(res.is_ok());
         // the result is the size of the static array in the guest
-        assert_eq!(res.unwrap(), ReturnValue::Int(1024 * 1024));
+        assert_eq!(res.unwrap(), 1024 * 1024);
     }
 }
 
 #[test]
 #[cfg_attr(target_os = "windows", serial)] // using LoadLibrary requires serial tests
 fn multiple_parameters() {
-    let messages = Arc::new(Mutex::new(Vec::new()));
-    let messages_clone = messages.clone();
+    let (tx, rx) = channel();
     let writer = move |msg: String| {
-        let mut lock = messages_clone
-            .try_lock()
-            .map_err(|_| new_error!("Error locking"))
-            .unwrap();
-        lock.push(msg);
+        tx.send(msg).unwrap();
         0
     };
 
-    let test_cases = vec![
-        (
-            "PrintTwoArgs",
-            vec![
-                ParameterValue::String("1".to_string()),
-                ParameterValue::Int(2),
-            ],
-            format!("Message: arg1:{} arg2:{}.", "1", 2),
-        ),
-        (
-            "PrintThreeArgs",
-            vec![
-                ParameterValue::String("1".to_string()),
-                ParameterValue::Int(2),
-                ParameterValue::Long(3),
-            ],
-            format!("Message: arg1:{} arg2:{} arg3:{}.", "1", 2, 3),
-        ),
-        (
-            "PrintFourArgs",
-            vec![
-                ParameterValue::String("1".to_string()),
-                ParameterValue::Int(2),
-                ParameterValue::Long(3),
-                ParameterValue::String("4".to_string()),
-            ],
-            format!("Message: arg1:{} arg2:{} arg3:{} arg4:{}.", "1", 2, 3, "4"),
-        ),
-        (
-            "PrintFiveArgs",
-            vec![
-                ParameterValue::String("1".to_string()),
-                ParameterValue::Int(2),
-                ParameterValue::Long(3),
-                ParameterValue::String("4".to_string()),
-                ParameterValue::String("5".to_string()),
-            ],
-            format!(
-                "Message: arg1:{} arg2:{} arg3:{} arg4:{} arg5:{}.",
-                "1", 2, 3, "4", "5"
-            ),
-        ),
-        (
-            "PrintSixArgs",
-            vec![
-                ParameterValue::String("1".to_string()),
-                ParameterValue::Int(2),
-                ParameterValue::Long(3),
-                ParameterValue::String("4".to_string()),
-                ParameterValue::String("5".to_string()),
-                ParameterValue::Bool(true),
-            ],
-            format!(
-                "Message: arg1:{} arg2:{} arg3:{} arg4:{} arg5:{} arg6:{}.",
-                "1", 2, 3, "4", "5", true
-            ),
-        ),
-        (
-            "PrintSevenArgs",
-            vec![
-                ParameterValue::String("1".to_string()),
-                ParameterValue::Int(2),
-                ParameterValue::Long(3),
-                ParameterValue::String("4".to_string()),
-                ParameterValue::String("5".to_string()),
-                ParameterValue::Bool(true),
-                ParameterValue::Bool(false),
-            ],
-            format!(
-                "Message: arg1:{} arg2:{} arg3:{} arg4:{} arg5:{} arg6:{} arg7:{}.",
-                "1", 2, 3, "4", "5", true, false
-            ),
-        ),
-        (
-            "PrintEightArgs",
-            vec![
-                ParameterValue::String("1".to_string()),
-                ParameterValue::Int(2),
-                ParameterValue::Long(3),
-                ParameterValue::String("4".to_string()),
-                ParameterValue::String("5".to_string()),
-                ParameterValue::Bool(true),
-                ParameterValue::Bool(false),
-                ParameterValue::UInt(8),
-            ],
-            format!(
-                "Message: arg1:{} arg2:{} arg3:{} arg4:{} arg5:{} arg6:{} arg7:{} arg8:{}.",
-                "1", 2, 3, "4", "5", true, false, 8
-            ),
-        ),
-        (
-            "PrintNineArgs",
-            vec![
-                ParameterValue::String("1".to_string()),
-                ParameterValue::Int(2),
-                ParameterValue::Long(3),
-                ParameterValue::String("4".to_string()),
-                ParameterValue::String("5".to_string()),
-                ParameterValue::Bool(true),
-                ParameterValue::Bool(false),
-                ParameterValue::UInt(8),
-                ParameterValue::ULong(9),
-            ],
-            format!(
-                "Message: arg1:{} arg2:{} arg3:{} arg4:{} arg5:{} arg6:{} arg7:{} arg8:{} arg9:{}.",
-                "1", 2, 3, "4", "5", true, false, 8, 9
-            ),
-        ),
-        (
-            "PrintTenArgs",
-            vec![
-                ParameterValue::String("1".to_string()),
-                ParameterValue::Int(2),
-                ParameterValue::Long(3),
-                ParameterValue::String("4".to_string()),
-                ParameterValue::String("5".to_string()),
-                ParameterValue::Bool(true),
-                ParameterValue::Bool(false),
-                ParameterValue::UInt(8),
-                ParameterValue::ULong(9),
-                ParameterValue::Int(10),
-            ],
-            format!(
-                "Message: arg1:{} arg2:{} arg3:{} arg4:{} arg5:{} arg6:{} arg7:{} arg8:{} arg9:{} arg10:{}.",
-                "1", 2, 3, "4", "5", true, false, 8, 9, 10
-            ),
-        ),
-        (
-            "PrintElevenArgs",
-            vec![
-                ParameterValue::String("1".to_string()),
-                ParameterValue::Int(2),
-                ParameterValue::Long(3),
-                ParameterValue::String("4".to_string()),
-                ParameterValue::String("5".to_string()),
-                ParameterValue::Bool(true),
-                ParameterValue::Bool(false),
-                ParameterValue::UInt(8),
-                ParameterValue::ULong(9),
-                ParameterValue::Int(10),
-                ParameterValue::Float(3.123),
-            ],
-            format!(
-                "Message: arg1:{} arg2:{} arg3:{} arg4:{} arg5:{} arg6:{} arg7:{} arg8:{} arg9:{} arg10:{} arg11:{}.",
-                "1", 2, 3, "4", "5", true, false, 8, 9, 10, 3.123
-            ),
-        )
-    ];
+    let args = (
+        ("1".to_string(), "arg1:1"),
+        (2_i32, "arg2:2"),
+        (3_i64, "arg3:3"),
+        ("4".to_string(), "arg4:4"),
+        ("5".to_string(), "arg5:5"),
+        (true, "arg6:true"),
+        (false, "arg7:false"),
+        (8_u32, "arg8:8"),
+        (9_u64, "arg9:9"),
+        (10_i32, "arg10:10"),
+        (3.123_f32, "arg11:3.123"),
+    );
 
-    for mut sandbox in get_simpleguest_sandboxes(Some(writer.into())).into_iter() {
-        for (fn_name, args, _expected) in test_cases.clone().into_iter() {
-            let res = sandbox.call_guest_function_by_name(fn_name, ReturnType::Int, Some(args));
-            println!("{:?}", res);
-            assert!(res.is_ok());
-        }
+    macro_rules! test_case {
+        ($sandbox:ident, $rx:ident, $name:literal, ($($p:ident),+)) => {{
+            let ($($p),+, ..) = args.clone();
+            let res: i32 = $sandbox.call_guest_function_by_name($name, ($($p.0,)+)).unwrap();
+            println!("{res:?}");
+            let output = $rx.try_recv().unwrap();
+            println!("{output:?}");
+            assert_eq!(output, format!("Message: {}.", [$($p.1),+].join(" ")));
+        }};
     }
 
-    let lock = messages
-        .try_lock()
-        .map_err(|_| new_error!("Error locking"))
-        .unwrap();
-    lock.clone()
-        .into_iter()
-        .zip(test_cases)
-        .for_each(|(printed_msg, expected)| {
-            println!("{:?}", printed_msg);
-            assert_eq!(printed_msg, expected.2);
-        });
+    for mut sb in get_simpleguest_sandboxes(Some(writer.into())).into_iter() {
+        test_case!(sb, rx, "PrintTwoArgs", (a, b));
+        test_case!(sb, rx, "PrintThreeArgs", (a, b, c));
+        test_case!(sb, rx, "PrintFourArgs", (a, b, c, d));
+        test_case!(sb, rx, "PrintFiveArgs", (a, b, c, d, e));
+        test_case!(sb, rx, "PrintSixArgs", (a, b, c, d, e, f));
+        test_case!(sb, rx, "PrintSevenArgs", (a, b, c, d, e, f, g));
+        test_case!(sb, rx, "PrintEightArgs", (a, b, c, d, e, f, g, h));
+        test_case!(sb, rx, "PrintNineArgs", (a, b, c, d, e, f, g, h, i));
+        test_case!(sb, rx, "PrintTenArgs", (a, b, c, d, e, f, g, h, i, j));
+        test_case!(sb, rx, "PrintElevenArgs", (a, b, c, d, e, f, g, h, i, j, k));
+    }
 }
 
 #[test]
 #[cfg_attr(target_os = "windows", serial)] // using LoadLibrary requires serial tests
 fn incorrect_parameter_type() {
     for mut sandbox in get_simpleguest_sandboxes(None) {
-        let res = sandbox.call_guest_function_by_name(
-            "Echo",
-            ReturnType::Int,
-            Some(vec![
-                ParameterValue::Int(2), // should be string
-            ]),
+        let res = sandbox.call_guest_function_by_name::<i32>(
+            "Echo", 2_i32, // should be string
         );
 
         assert!(matches!(
@@ -365,14 +208,7 @@ fn incorrect_parameter_type() {
 #[cfg_attr(target_os = "windows", serial)] // using LoadLibrary requires serial tests
 fn incorrect_parameter_num() {
     for mut sandbox in get_simpleguest_sandboxes(None).into_iter() {
-        let res = sandbox.call_guest_function_by_name(
-            "Echo",
-            ReturnType::Int,
-            Some(vec![
-                ParameterValue::String("1".to_string()),
-                ParameterValue::Int(2),
-            ]),
-        );
+        let res = sandbox.call_guest_function_by_name::<i32>("Echo", ("1".to_string(), 2_i32));
         assert!(matches!(
             res.unwrap_err(),
             HyperlightError::GuestError(
@@ -402,14 +238,10 @@ fn max_memory_sandbox() {
 #[cfg_attr(target_os = "windows", serial)] // using LoadLibrary requires serial tests
 fn iostack_is_working() {
     for mut sandbox in get_simpleguest_sandboxes(None).into_iter() {
-        let res = sandbox.call_guest_function_by_name(
-            "ThisIsNotARealFunctionButTheNameIsImportant",
-            ReturnType::Int,
-            None,
-        );
-        println!("{:?}", res);
-        assert!(res.is_ok());
-        assert_eq!(res.unwrap(), ReturnValue::Int(99));
+        let res: i32 = sandbox
+            .call_guest_function_by_name::<i32>("ThisIsNotARealFunctionButTheNameIsImportant", ())
+            .unwrap();
+        assert_eq!(res, 99);
     }
 }
 
@@ -430,30 +262,21 @@ fn simple_test_helper() -> Result<()> {
     let message2 = "world";
 
     for mut sandbox in get_simpleguest_sandboxes(Some(writer.into())).into_iter() {
-        let res = sandbox.call_guest_function_by_name(
-            "PrintOutput",
-            ReturnType::Int,
-            Some(vec![ParameterValue::String(message.to_string())]),
-        );
-        println!("res: {:?}", res);
-        assert!(matches!(res, Ok(ReturnValue::Int(5))));
+        let res: i32 = sandbox
+            .call_guest_function_by_name("PrintOutput", message.to_string())
+            .unwrap();
+        assert_eq!(res, 5);
 
-        let res2 = sandbox.call_guest_function_by_name(
-            "Echo",
-            ReturnType::String,
-            Some(vec![ParameterValue::String(message2.to_string())]),
-        );
-        println!("res2: {:?}", res2);
-        assert!(matches!(res2, Ok(ReturnValue::String(s)) if s == "world"));
+        let res: String = sandbox
+            .call_guest_function_by_name("Echo", message2.to_string())
+            .unwrap();
+        assert_eq!(res, "world");
 
-        let buffer = vec![1u8, 2, 3, 4, 5, 6];
-        let res3 = sandbox.call_guest_function_by_name(
-            "GetSizePrefixedBuffer",
-            ReturnType::Int,
-            Some(vec![ParameterValue::VecBytes(buffer.clone())]),
-        );
-        println!("res3: {:?}", res3);
-        assert!(matches!(res3, Ok(ReturnValue::VecBytes(v)) if v == buffer));
+        let buffer = [1u8, 2, 3, 4, 5, 6];
+        let res: Vec<u8> = sandbox
+            .call_guest_function_by_name("GetSizePrefixedBuffer", buffer.to_vec())
+            .unwrap();
+        assert_eq!(res, buffer);
     }
 
     let expected_calls = 1;
@@ -499,39 +322,20 @@ fn simple_test_parallel() {
 fn callback_test_helper() -> Result<()> {
     for mut sandbox in get_callbackguest_uninit_sandboxes(None).into_iter() {
         // create host function
-        let vec = Arc::new(Mutex::new(vec![]));
-        let vec_cloned = vec.clone();
-
+        let (tx, rx) = channel();
         sandbox.register("HostMethod1", move |msg: String| {
             let len = msg.len();
-            vec_cloned
-                .try_lock()
-                .map_err(|e| new_error!("Error locking at {}:{}: {}", file!(), line!(), e))?
-                .push(msg);
+            tx.send(msg).unwrap();
             Ok(len as i32)
         })?;
 
         // call guest function that calls host function
         let mut init_sandbox: MultiUseSandbox = sandbox.evolve(Noop::default())?;
         let msg = "Hello world";
-        init_sandbox.call_guest_function_by_name(
-            "GuestMethod1",
-            ReturnType::Int,
-            Some(vec![ParameterValue::String(msg.to_string())]),
-        )?;
+        init_sandbox.call_guest_function_by_name::<i32>("GuestMethod1", msg.to_string())?;
 
-        assert_eq!(
-            vec.try_lock()
-                .map_err(|e| new_error!("Error locking at {}:{}: {}", file!(), line!(), e))?
-                .len(),
-            1
-        );
-        assert_eq!(
-            vec.try_lock()
-                .map_err(|e| new_error!("Error locking at {}:{}: {}", file!(), line!(), e))?
-                .remove(0),
-            format!("Hello from GuestFunction1, {}", msg)
-        );
+        let messages = rx.try_iter().collect::<Vec<_>>();
+        assert_eq!(messages, [format!("Hello from GuestFunction1, {msg}")]);
     }
     Ok(())
 }
@@ -570,13 +374,10 @@ fn host_function_error() -> Result<()> {
         // call guest function that calls host function
         let mut init_sandbox: MultiUseSandbox = sandbox.evolve(Noop::default())?;
         let msg = "Hello world";
-        let res = init_sandbox.call_guest_function_by_name(
-            "GuestMethod1",
-            ReturnType::Int,
-            Some(vec![ParameterValue::String(msg.to_string())]),
-        );
-        println!("res {:?}", res);
-        assert!(matches!(res, Err(HyperlightError::Error(msg)) if msg == "Host function error!"));
+        let res = init_sandbox
+            .call_guest_function_by_name::<i32>("GuestMethod1", msg.to_string())
+            .unwrap_err();
+        assert!(matches!(res, HyperlightError::Error(msg) if msg == "Host function error!"));
     }
     Ok(())
 }


### PR DESCRIPTION
This PR changes the signature of `MultiUseSandbox::call_guest_function_by_name` and `MultiUseGuestCallContext::call` to use native Rust types instead of using `ParamerValue` and `ReturnValue`.
