### PR TITLE
Adds setup and instructions for Github Copilot

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,71 @@
+This repository contains hyperlight. Hyperlight is a lightweight Virtual Machine Manager (VMM) designed to be embedded within applications. 
+It enables safe execution of untrusted code within micro virtual machines with very low latency and minimal overhead.
+
+This project uses just as a runner for building, testing etc. Just should already be installed. Most of the code in the repository is written in Rust, with a few files in C.
+
+## Code Standards
+
+Make sure that code is formatted and linted before committing. You can do this by running the following command:
+
+```bash
+just fmt-apply
+```
+This will format the code and apply any necessary changes. You can also run the following command to check for any linting errors:
+
+```bash
+just clippy debug
+just clippy release
+```
+
+If any lints fail you can try to fix them by running the following command for debug failures:
+
+```bash
+    cargo clippy --fix --all 
+```
+And the following command for release failures:
+
+```bash
+    cargo clippy --fix --all --release
+```
+
+If this does not work, you should try and fix the errors and then run the commands again.
+
+## Development flow
+
+- build:
+    - `just build` - builds the project in debug mode
+    - `just build release` - builds the project in release mode
+    - `just guests` - builds the guest library and test guests for both debug and release modes
+- test 
+    - `just test` - runs all tests in debug mode
+    - `just test release` - runs all tests in release mode
+
+Note that if any guest code has changed, you will need to run `just guests` to build the guest library, before running the tests, if the test fail make sure to run `just guests` again to build the guest library, before running the tests again.
+
+Before pushing your code, make sure to run the following commands to ensure that everything is working correctly make sure all tests pass by running 
+```bash
+just test-like-ci 
+just test-like-ci release
+```
+
+## Key Instructions
+
+Follow best practices and idioms for writing Rust code.
+Maintain the structure and organization of the codebase. Do not introduce new crates or dependencies without discussing them first.
+Make sure to write tests for any new code you add. Follow the existing testing patterns in the codebase.
+Make sure to fully document any new code you add. Use rustdoc comments and follow guidelines for good documentation.
+Make sure that any changes which alter anything documented in the README or the documentation in the docs directory are reflected in the documentation.
+
+## Repository Structure
+- `dev/` - contains development scripts and tools
+- `src/` - contains the source code for the project
+.editorconfig - contains the editor config for the project you should use this to configure your editor to use the same settings as the rest of the projec
+- Justfile - contains the just commands for building, testing and running the project
+- `fuzz` - contains the fuzzing tests for the project
+- `src/hyperlight_common/` - contains the common code shared between the host and guest
+- `src/hyperlight_guest/` - contains the hyperlight-guest library code 
+- `src/hyperlight_host/` - contains the hyperlight-host library code
+- `src/hyperlight_guest_capi/` - contains the hyperlight-guest  C library code
+- `src/hyperlight_testing/` - contains the shared code for tests
+- `schema/` - contains the flatbuffer schemas for the project
+- `tests/` - contains the test guest code for the project in C and Rust

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,0 +1,33 @@
+name: "Copilot Setup Steps"
+
+# Allow testing of the setup steps from your repository's "Actions" tab.
+on: workflow_dispatch
+
+jobs:
+  # The job MUST be called `copilot-setup-steps` or it will not be picked up by Copilot.
+  copilot-setup-steps:
+    runs-on: ubuntu-latest
+
+    # Set the permissions to the lowest permissions possible needed for your steps.
+    # Copilot will be given its own token for its operations.
+    permissions:
+      # If you want to clone the repository as part of your setup steps, for example to install dependencies, you'll need the `contents: read` permission. If you don't clone the repository in your setup steps, Copilot will do this for you automatically after the steps complete.
+      contents: read
+
+    # You can define any steps you want, and they will run before the agent starts.
+    # If you do not check out your code, Copilot will do this for you.
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      # For rust-fmt 
+      - name: Set up nightly rust 
+        uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: rustfmt
+
+      - uses: hyperlight-dev/ci-setup-workflow@v1.3.0
+        with:
+          rust-toolchain: "1.81.0" 
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Adds 2 files to air co-pilot agent mode development. 

See [customizing the development environment for copilot coding agent](https://docs.github.com/en/enterprise-cloud@latest/copilot/customizing-copilot/customizing-the-development-environment-for-copilot-coding-agent) and [adding repository custom instructions for github copilot](https://docs.github.com/en/enterprise-cloud@latest/copilot/customizing-copilot/adding-repository-custom-instructions-for-github-copilot) for details about these files