### PR TITLE
Fix typo in path to docs/github-labels.md

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,4 +1,4 @@
-This repository contains hyperlight. Hyperlight is a lightweight Virtual Machine Manager (VMM) designed to be embedded within applications. 
+This repository contains hyperlight. Hyperlight is a lightweight Virtual Machine Manager (VMM) designed to be embedded within applications.
 It enables safe execution of untrusted code within micro virtual machines with very low latency and minimal overhead.
 
 This project uses just as a runner for building, testing etc. Just should already be installed. Most of the code in the repository is written in Rust, with a few files in C.
@@ -20,7 +20,7 @@ just clippy release
 If any lints fail you can try to fix them by running the following command for debug failures:
 
 ```bash
-    cargo clippy --fix --all 
+    cargo clippy --fix --all
 ```
 And the following command for release failures:
 
@@ -36,15 +36,15 @@ If this does not work, you should try and fix the errors and then run the comman
     - `just build` - builds the project in debug mode
     - `just build release` - builds the project in release mode
     - `just guests` - builds the guest library and test guests for both debug and release modes
-- test 
+- test
     - `just test` - runs all tests in debug mode
     - `just test release` - runs all tests in release mode
 
-**IMPORTANT** You will need to run `just guests` to build the guest library  before running the tests.
+**IMPORTANT** You will need to run `just guests` to build the guest library before running the tests.
 
-Before pushing your code, make sure to run the following commands to ensure that everything is working correctly make sure all tests pass by running 
+Before pushing your code, make sure to run the following commands to ensure that everything is working correctly make sure all tests pass by running
 ```bash
-just test-like-ci 
+just test-like-ci
 just test-like-ci release
 ```
 
@@ -57,11 +57,11 @@ Maintain the structure and organization of the codebase. Do not introduce new cr
 Make sure to write tests for any new code you add. Follow the existing testing patterns in the codebase.
 Make sure to fully document any new code you add. Use rustdoc comments and follow guidelines for good documentation.
 Make sure that any changes which alter anything documented in the README or the documentation in the docs directory are reflected in the documentation.
-Make sure that you label the PRs that you create with the correct labels. You can find details about which labels to use in the documents `docs\github-labels,md`
+Make sure that you label the PRs that you create with the correct labels. You can find details about which labels to use in the documents `docs/github-labels.md`.
 Make sure that you do not include any large binary files in your PR. If you need to include a large binary file, please discuss it with the team first.
 Make sure that you keep commits small and focused. Each commit should represent a single change or addition to the codebase. This will make it easier for reviewers to understand your changes and for you to revert them if necessary.
-Make sure that you arrange your commits in a logical order. You can use `git rebase -i` to do this. 
-If you update your PR branch with new commits, make sure to rebase your branch on top of the main branch. This will help keep the commit history clean and make it easier to review your changes
+Make sure that you arrange your commits in a logical order. You can use `git rebase -i` to do this.
+If you update your PR branch with new commits, make sure to rebase your branch on top of the main branch. This will help keep the commit history clean and make it easier to review your changes.
 Make sure that you do not have any merge commits in your PR.
 
 ## Repository Structure
@@ -71,9 +71,9 @@ Make sure that you do not have any merge commits in your PR.
 - `Justfile` - contains the just commands for building, testing and running the project
 - `fuzz` - contains the fuzzing tests for the project
 - `src/hyperlight_common/` - contains the common code shared between the host and guest
-- `src/hyperlight_guest/` - contains the hyperlight-guest library code 
+- `src/hyperlight_guest/` - contains the hyperlight-guest library code
 - `src/hyperlight_host/` - contains the hyperlight-host library code
-- `src/hyperlight_guest_capi/` - contains the hyperlight-guest  C library code
+- `src/hyperlight_guest_capi/` - contains the hyperlight-guest C library code
 - `src/hyperlight_testing/` - contains the shared code for tests
 - `schema/` - contains the flatbuffer schemas for the project
 - `tests/` - contains the test guest code for the project in C and Rust


### PR DESCRIPTION
The path to github-labels.md has a comma instead of a period before the extension.
Also removed some extra spaces between words or at ends of lines.