### PR TITLE
Make common and guest libs portable

### DIFF
--- a/src/hyperlight_common/src/mem.rs
+++ b/src/hyperlight_common/src/mem.rs
@@ -46,10 +46,6 @@ pub struct GuestStackData {
     pub minUserStackAddress: u64,
     /// This is the user stack pointer
     pub userStackAddress: u64,
-    /// This is the stack pointer for the kernel mode stack
-    pub kernelStackAddress: u64,
-    /// This is the initial stack pointer when init is called its used before the TSS is set up
-    pub bootStackAddress: u64,
 }
 
 #[repr(C)]

--- a/src/hyperlight_common/src/mem.rs
+++ b/src/hyperlight_common/src/mem.rs
@@ -20,24 +20,22 @@ pub const PAGE_SHIFT: u64 = 12;
 pub const PAGE_SIZE: u64 = 1 << 12;
 pub const PAGE_SIZE_USIZE: usize = 1 << 12;
 
-use core::ffi::{c_char, c_void};
-
 #[repr(C)]
 pub struct InputData {
     pub inputDataSize: u64,
-    pub inputDataBuffer: *mut c_void,
+    pub inputDataBuffer: u64,
 }
 
 #[repr(C)]
 pub struct OutputData {
     pub outputDataSize: u64,
-    pub outputDataBuffer: *mut c_void,
+    pub outputDataBuffer: u64,
 }
 
 #[repr(C)]
 pub struct GuestHeapData {
     pub guestHeapSize: u64,
-    pub guestHeapBuffer: *mut c_void,
+    pub guestHeapBuffer: u64,
 }
 
 #[repr(C)]
@@ -52,7 +50,7 @@ pub struct GuestStackData {
 pub struct HyperlightPEB {
     pub security_cookie_seed: u64,
     pub guest_function_dispatch_ptr: u64,
-    pub pCode: *mut c_char,
+    pub pCode: u64,
     pub inputdata: InputData,
     pub outputdata: OutputData,
     pub guestheapData: GuestHeapData,

--- a/src/hyperlight_common/src/mem.rs
+++ b/src/hyperlight_common/src/mem.rs
@@ -14,40 +14,28 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#![allow(non_snake_case)]
-
 pub const PAGE_SHIFT: u64 = 12;
 pub const PAGE_SIZE: u64 = 1 << 12;
 pub const PAGE_SIZE_USIZE: usize = 1 << 12;
 
+/// A memory region in the guest address space
 #[derive(Debug, Clone, Copy)]
 #[repr(C)]
-pub struct InputData {
-    pub inputDataSize: u64,
-    pub inputDataBuffer: u64,
+pub struct GuestMemoryRegion {
+    /// The size of the memory region
+    pub size: u64,
+    /// The address of the memory region
+    pub ptr: u64,
 }
 
+/// A memory region in the guest address space that is used for the stack
 #[derive(Debug, Clone, Copy)]
 #[repr(C)]
-pub struct OutputData {
-    pub outputDataSize: u64,
-    pub outputDataBuffer: u64,
-}
-
-#[derive(Debug, Clone, Copy)]
-#[repr(C)]
-pub struct GuestHeapData {
-    pub guestHeapSize: u64,
-    pub guestHeapBuffer: u64,
-}
-
-#[derive(Debug, Clone, Copy)]
-#[repr(C)]
-pub struct GuestStackData {
-    /// This is the top of the user stack
-    pub minUserStackAddress: u64,
-    /// This is the user stack pointer
-    pub userStackAddress: u64,
+pub struct GuestStack {
+    /// The top of the user stack
+    pub min_user_stack_address: u64,
+    /// The user stack pointer
+    pub user_stack_address: u64,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -55,9 +43,9 @@ pub struct GuestStackData {
 pub struct HyperlightPEB {
     pub security_cookie_seed: u64,
     pub guest_function_dispatch_ptr: u64,
-    pub pCode: u64,
-    pub inputdata: InputData,
-    pub outputdata: OutputData,
-    pub guestheapData: GuestHeapData,
-    pub gueststackData: GuestStackData,
+    pub code_ptr: u64,
+    pub input_stack: GuestMemoryRegion,
+    pub output_stack: GuestMemoryRegion,
+    pub guest_heap: GuestMemoryRegion,
+    pub guest_stack: GuestStack,
 }

--- a/src/hyperlight_common/src/mem.rs
+++ b/src/hyperlight_common/src/mem.rs
@@ -20,24 +20,28 @@ pub const PAGE_SHIFT: u64 = 12;
 pub const PAGE_SIZE: u64 = 1 << 12;
 pub const PAGE_SIZE_USIZE: usize = 1 << 12;
 
+#[derive(Debug, Clone, Copy)]
 #[repr(C)]
 pub struct InputData {
     pub inputDataSize: u64,
     pub inputDataBuffer: u64,
 }
 
+#[derive(Debug, Clone, Copy)]
 #[repr(C)]
 pub struct OutputData {
     pub outputDataSize: u64,
     pub outputDataBuffer: u64,
 }
 
+#[derive(Debug, Clone, Copy)]
 #[repr(C)]
 pub struct GuestHeapData {
     pub guestHeapSize: u64,
     pub guestHeapBuffer: u64,
 }
 
+#[derive(Debug, Clone, Copy)]
 #[repr(C)]
 pub struct GuestStackData {
     /// This is the top of the user stack
@@ -46,6 +50,7 @@ pub struct GuestStackData {
     pub userStackAddress: u64,
 }
 
+#[derive(Debug, Clone, Copy)]
 #[repr(C)]
 pub struct HyperlightPEB {
     pub security_cookie_seed: u64,

--- a/src/hyperlight_guest/src/entrypoint.rs
+++ b/src/hyperlight_guest/src/entrypoint.rs
@@ -98,7 +98,7 @@ pub extern "C" fn entrypoint(peb_address: u64, seed: u64, ops: u64, max_log_leve
             // This static is to make it easier to implement the __chkstk function in assembly.
             // It also means that should we change the layout of the struct in the future, we
             // don't have to change the assembly code.
-            MIN_STACK_ADDRESS = (*peb_ptr).gueststackData.minUserStackAddress;
+            MIN_STACK_ADDRESS = (*peb_ptr).guest_stack.min_user_stack_address;
 
             #[cfg(target_arch = "x86_64")]
             {
@@ -107,8 +107,8 @@ pub extern "C" fn entrypoint(peb_address: u64, seed: u64, ops: u64, max_log_leve
                 load_idt();
             }
 
-            let heap_start = (*peb_ptr).guestheapData.guestHeapBuffer as usize;
-            let heap_size = (*peb_ptr).guestheapData.guestHeapSize as usize;
+            let heap_start = (*peb_ptr).guest_heap.ptr as usize;
+            let heap_size = (*peb_ptr).guest_heap.size as usize;
             HEAP_ALLOCATOR
                 .try_lock()
                 .expect("Failed to access HEAP_ALLOCATOR")

--- a/src/hyperlight_guest/src/shared_input_data.rs
+++ b/src/hyperlight_guest/src/shared_input_data.rs
@@ -43,10 +43,10 @@ where
     }
 
     // get relative offset to next free address
-    let stack_ptr_rel: usize =
-        usize::from_le_bytes(idb[..8].try_into().expect("Shared input buffer too small"));
+    let stack_ptr_rel: u64 =
+        u64::from_le_bytes(idb[..8].try_into().expect("Shared input buffer too small"));
 
-    if stack_ptr_rel > shared_buffer_size || stack_ptr_rel < 16 {
+    if stack_ptr_rel as usize > shared_buffer_size || stack_ptr_rel < 16 {
         return Err(HyperlightGuestError::new(
             ErrorCode::GuestError,
             format!(
@@ -57,13 +57,13 @@ where
     }
 
     // go back 8 bytes and read. This is the offset to the element on top of stack
-    let last_element_offset_rel = usize::from_le_bytes(
-        idb[stack_ptr_rel - 8..stack_ptr_rel]
+    let last_element_offset_rel = u64::from_le_bytes(
+        idb[stack_ptr_rel as usize - 8..stack_ptr_rel as usize]
             .try_into()
             .expect("Invalid stack pointer in pop_shared_input_data_into"),
     );
 
-    let buffer = &idb[last_element_offset_rel..];
+    let buffer = &idb[last_element_offset_rel as usize..];
 
     // convert the buffer to T
     let type_t = match T::try_from(buffer) {
@@ -80,7 +80,7 @@ where
     idb[..8].copy_from_slice(&last_element_offset_rel.to_le_bytes());
 
     // zero out popped off buffer
-    idb[last_element_offset_rel..stack_ptr_rel].fill(0);
+    idb[last_element_offset_rel as usize..stack_ptr_rel as usize].fill(0);
 
     type_t
 }

--- a/src/hyperlight_guest/src/shared_input_data.rs
+++ b/src/hyperlight_guest/src/shared_input_data.rs
@@ -30,14 +30,10 @@ where
     T: for<'a> TryFrom<&'a [u8]>,
 {
     let peb_ptr = unsafe { P_PEB.unwrap() };
-    let shared_buffer_size = unsafe { (*peb_ptr).inputdata.inputDataSize as usize };
+    let shared_buffer_size = unsafe { (*peb_ptr).input_stack.size as usize };
 
-    let idb = unsafe {
-        from_raw_parts_mut(
-            (*peb_ptr).inputdata.inputDataBuffer as *mut u8,
-            shared_buffer_size,
-        )
-    };
+    let idb =
+        unsafe { from_raw_parts_mut((*peb_ptr).input_stack.ptr as *mut u8, shared_buffer_size) };
 
     if idb.is_empty() {
         return Err(HyperlightGuestError::new(

--- a/src/hyperlight_guest/src/shared_output_data.rs
+++ b/src/hyperlight_guest/src/shared_output_data.rs
@@ -26,13 +26,9 @@ use crate::P_PEB;
 
 pub fn push_shared_output_data(data: Vec<u8>) -> Result<()> {
     let peb_ptr = unsafe { P_PEB.unwrap() };
-    let shared_buffer_size = unsafe { (*peb_ptr).outputdata.outputDataSize as usize };
-    let odb = unsafe {
-        from_raw_parts_mut(
-            (*peb_ptr).outputdata.outputDataBuffer as *mut u8,
-            shared_buffer_size,
-        )
-    };
+    let shared_buffer_size = unsafe { (*peb_ptr).output_stack.size as usize };
+    let odb =
+        unsafe { from_raw_parts_mut((*peb_ptr).output_stack.ptr as *mut u8, shared_buffer_size) };
 
     if odb.is_empty() {
         return Err(HyperlightGuestError::new(

--- a/src/hyperlight_host/src/lib.rs
+++ b/src/hyperlight_host/src/lib.rs
@@ -41,22 +41,7 @@ pub mod hypervisor;
 /// Functionality to establish and manage an individual sandbox's
 /// memory.
 ///
-/// The following structs are not used other than to calculate the size of the memory needed
-/// and also to illustrate the layout of the memory:
-///
-/// - `HostFunctionDefinitions`
-/// - `HostExceptionData`
-/// - `GuestError`
-/// - `CodeAndOutBPointers`
-/// - `InputData`
-/// - `OutputData`
-/// - `GuestHeap`
-/// - `GuestStack`
-///
-/// the start of the guest  memory contains the page tables and is always located at the Virtual Address 0x00200000 when
-/// running in a Hypervisor:
-///
-/// Virtual Address
+/// - Virtual Address
 ///
 /// 0x0000    PML4
 /// 0x1000    PDPT
@@ -64,8 +49,8 @@ pub mod hypervisor;
 /// 0x3000    The guest PE code (When the code has been loaded using LoadLibrary to debug the guest this will not be
 /// present and code length will be zero;
 ///
-/// The pointer passed to the Entrypoint in the Guest application is the ize of page table + size of code,
-/// at this address structs below are laid out in this order
+/// - The pointer passed to the Entrypoint in the Guest application is the size of page table + size of code,
+///     at this address structs below are laid out in this order
 pub mod mem;
 /// Metric definitions and helpers
 pub mod metrics;


### PR DESCRIPTION
This PR changes our pointer usage in the guest and common lib to be portable (i.e., using `u64s` instead of `usize` or pointer types that vary between architectures).

Plus, I did some general housekeeping like removing legacy fields/comments, refactored the PEB structs to avoid code duplication, and madeour PEB related struct items snake case.

Reviews can be made commit-by-commit, if you preferred. 