### PR TITLE
Fix breaking changes for hyperlight js

### DIFF
--- a/src/hyperlight_guest/third_party/musl/arch/x86_64/bits/setjmp.h
+++ b/src/hyperlight_guest/third_party/musl/arch/x86_64/bits/setjmp.h
@@ -1,0 +1,1 @@
+typedef unsigned long __jmp_buf[8];

--- a/src/hyperlight_host/Cargo.toml
+++ b/src/hyperlight_host/Cargo.toml
@@ -41,6 +41,7 @@ thiserror = "2.0.12"
 tempfile = { version = "3.20", optional = true }
 anyhow = "1.0"
 metrics = "0.24.2"
+serde_json = "1.0"
 
 [target.'cfg(windows)'.dependencies]
 windows = { version = "0.61", features = [

--- a/src/hyperlight_host/src/error.rs
+++ b/src/hyperlight_host/src/error.rs
@@ -155,6 +155,10 @@ pub enum HyperlightError {
     #[cfg(kvm)]
     KVMError(#[from] kvm_ioctls::Error),
 
+    /// Conversion of str to Json failed
+    #[error("Conversion of str data to json failed")]
+    JsonConversionFailure(#[from] serde_json::Error),
+
     /// An attempt to get a lock from a Mutex failed.
     #[error("Unable to lock resource")]
     LockAttemptFailed(String),


### PR DESCRIPTION
This PR fixes up a couple of changes in this version of hyperlight which are breaking changes to `hyperlight-js`:

[Add JsonConversionFailure back as it used by hyperlight-js](https://github.com/hyperlight-dev/hyperlight/commit/9b68df50bdb876d8565908a0c5b510d7b6f2519e)

[Add missing musl arch specific setjmp.h file](https://github.com/hyperlight-dev/hyperlight/commit/11cf7fdc289a3ff26fa16af440592ac30359dcb8)