### PR TITLE
Prepare for v0.5.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,32 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Prerelease] - Unreleased
 
+## [v0.5.0] - 2025-05-28
+
+### Changed
+- Change base address from 0x200_000 to 0x0 by @danbugs in https://github.com/hyperlight-dev/hyperlight/pull/450
+- Unify HostFunctionXX traits into a single HostFunction by @jprendes in https://github.com/hyperlight-dev/hyperlight/pull/
+- Improve the ergonomics of registering host functions by @jprendes in https://github.com/hyperlight-dev/hyperlight/pull/468
+- Remove generics from SupportedParameterType and SupportedReturnType traits by @jprendes in https://github.com/hyperlight-dev/hyperlight/pull/475
+- Improve ergonomics of SupportedParameterType and SupportedReturnType by @jprendes in https://github.com/hyperlight-dev/hyperlight/pull/476
+
+### Fixed
+- Add error logging when MapViewOfFileNuma2 fails by @ludfjig in https://github.com/hyperlight-dev/hyperlight/pull/460
+- Make common and guest libs portable by @danbugs in https://github.com/hyperlight-dev/hyperlight/pull/524
+- Fix breaking changes for hyperlight js by @simongdavies in https://github.com/hyperlight-dev/hyperlight/pull/531
+
+### Added
+- Gdb debug improvements by @dblnz in https://github.com/hyperlight-dev/hyperlight/pull/456
+
+### Removed  
+- Remove kernel stack and boot stack memory regions by @danbugs in https://github.com/hyperlight-dev/hyperlight/pull/451
+- Removing HostFunctionDefinitions region by @danbugs in https://github.com/hyperlight-dev/hyperlight/pull/453
+- Removed host error region by @danbugs in https://github.com/hyperlight-dev/hyperlight/pull/457
+- Remove dependency on the paste crate by @jprendes in https://github.com/hyperlight-dev/hyperlight/pull/467
+- Remove support from hyperlight_host for PE formatted guests by @simongdavies in https://github.com/hyperlight-dev/hyperlight/pull/485
+- Remove in process mode from hyperlight-host by @simongdavies in https://github.com/hyperlight-dev/hyperlight/pull/490
+- Remove `host_print_writer` from the arguments to `UninitializedSandbox::new` by @jprendes in https://github.com/hyperlight-dev/hyperlight/pull/487
+
 
 ## [v0.4.0] - 2025-04-30
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1144,7 +1144,7 @@ dependencies = [
 
 [[package]]
 name = "hyperlight-common"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -1166,7 +1166,7 @@ dependencies = [
 
 [[package]]
 name = "hyperlight-guest"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "buddy_system_allocator",
@@ -1181,7 +1181,7 @@ dependencies = [
 
 [[package]]
 name = "hyperlight-host"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "bitflags 2.9.1",
@@ -1264,7 +1264,7 @@ dependencies = [
 
 [[package]]
 name = "hyperlight_guest_capi"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "cbindgen",
  "hyperlight-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 rust-version = "1.81.0"
 license = "Apache-2.0"
@@ -30,9 +30,9 @@ repository = "https://github.com/hyperlight-dev/hyperlight"
 readme = "README.md"
 
 [workspace.dependencies]
-hyperlight-common = { path = "src/hyperlight_common", version = "0.4.0", default-features = false }
-hyperlight-host = { path = "src/hyperlight_host", version = "0.4.0", default-features = false }
-hyperlight-guest = { path = "src/hyperlight_guest", version = "0.4.0", default-features = false }
+hyperlight-common = { path = "src/hyperlight_common", version = "0.5.0", default-features = false }
+hyperlight-host = { path = "src/hyperlight_host", version = "0.5.0", default-features = false }
+hyperlight-guest = { path = "src/hyperlight_guest", version = "0.5.0", default-features = false }
 hyperlight-testing = { path = "src/hyperlight_testing", default-features = false }
 
 [workspace.lints.rust]

--- a/src/tests/rust_guests/callbackguest/Cargo.lock
+++ b/src/tests/rust_guests/callbackguest/Cargo.lock
@@ -76,7 +76,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hyperlight-common"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "flatbuffers",
@@ -86,7 +86,7 @@ dependencies = [
 
 [[package]]
 name = "hyperlight-guest"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "buddy_system_allocator",

--- a/src/tests/rust_guests/simpleguest/Cargo.lock
+++ b/src/tests/rust_guests/simpleguest/Cargo.lock
@@ -68,7 +68,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hyperlight-common"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "flatbuffers",
@@ -78,7 +78,7 @@ dependencies = [
 
 [[package]]
 name = "hyperlight-guest"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "buddy_system_allocator",


### PR DESCRIPTION
As discussed in today's community meeting.  Following instructions for release in https://github.com/hyperlight-dev/hyperlight/blob/main/docs/how-to-make-releases.md