### PR TITLE
Don't include PRs with kind/dependencies in wrong changelog category

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -5,7 +5,9 @@ changelog:
     - title: Full Changelog (excl. dependencies)
       labels:
         - "*"
+      exclude:
+        labels:
+          - kind/dependencies
     - title: Full Changelog (dependencies)
       labels:
         - kind/dependencies
-


### PR DESCRIPTION
Running `just create-release-notes v0.4.0` incorrectly includes dependecy-prs in the category that should exclude the dependencies PR, see the following "bump" prs:

```
### Full Changelog (excl. dependencies)
* Update the README & Code of conduct sections to the CNCF CoC by @benazirk in https://github.com/hyperlight-dev/hyperlight/pull/383
* changelog: fix version typo by @dblnz in https://github.com/hyperlight-dev/hyperlight/pull/388
* Fix dependabot by @simongdavies in https://github.com/hyperlight-dev/hyperlight/pull/390
* Bump windows-result from 0.3.1 to 0.3.2 by @dependabot in https://github.com/hyperlight-dev/hyperlight/pull/395
* Bump opentelemetry-semantic-conventions from 0.28.0 to 0.29.0 by @dependabot in https://github.com/hyperlight-dev/hyperlight/pull/391
* Bump crate-ci/typos from 1.30.3 to 1.31.1 by @dependabot in https://github.com/hyperlight-dev/hyperlight/pull/387
* Bump windows-version from 0.1.3 to 0.1.4 by @dependabot in https://github.com/hyperlight-dev/hyperlight/pull/392
* Bump tempfile from 3.19.0 to 3.19.1 by @dependabot in https://github.com/hyperlight-dev/hyperlight/pull/394
* Bump windows from 0.60.0 to 0.61.1 by @dependabot in https://github.com/hyperlight-dev/hyperlight/pull/393
```