### PR TITLE
Update kvm-ioctls crate  to 0.22 and kvm-bindings crate to 0.12

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1554,23 +1554,23 @@ dependencies = [
 
 [[package]]
 name = "kvm-bindings"
-version = "0.11.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b13baf7bdfda2e10bcb109fcb099ef40cff82374eb6b7cdcf4695bdec4e522c"
+checksum = "d4b153a59bb3ca930ff8148655b2ef68c34259a623ae08cf2fb9b570b2e45363"
 dependencies = [
- "vmm-sys-util 0.12.1",
+ "vmm-sys-util 0.14.0",
 ]
 
 [[package]]
 name = "kvm-ioctls"
-version = "0.21.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "083c460d5a272c2f22205973e319147b791d92a288d7d7a8d4c6194f95229440"
+checksum = "b702df98508cb63ad89dd9beb9f6409761b30edca10d48e57941d3f11513a006"
 dependencies = [
  "bitflags 2.9.1",
  "kvm-bindings",
  "libc",
- "vmm-sys-util 0.12.1",
+ "vmm-sys-util 0.14.0",
 ]
 
 [[package]]
@@ -3528,9 +3528,9 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vmm-sys-util"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d1435039746e20da4f8d507a72ee1b916f7b4b05af7a91c093d2c6561934ede"
+checksum = "945fecc32d9b44069437b7aacd2257556a91a2054ae10e9e7538fe498e442db9"
 dependencies = [
  "bitflags 1.3.2",
  "libc",
@@ -3538,9 +3538,9 @@ dependencies = [
 
 [[package]]
 name = "vmm-sys-util"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "945fecc32d9b44069437b7aacd2257556a91a2054ae10e9e7538fe498e442db9"
+checksum = "d21f366bf22bfba3e868349978766a965cbe628c323d58e026be80b8357ab789"
 dependencies = [
  "bitflags 1.3.2",
  "libc",

--- a/src/hyperlight_host/Cargo.toml
+++ b/src/hyperlight_host/Cargo.toml
@@ -69,8 +69,8 @@ lazy_static = "1.4.0"
 gdbstub = { version = "0.7.5", optional = true }
 gdbstub_arch = { version = "0.3.1", optional = true }
 seccompiler = { version = "0.5.0", optional = true }
-kvm-bindings = { version = "0.11", features = ["fam-wrappers"], optional = true }
-kvm-ioctls = { version = "0.21", optional = true }
+kvm-bindings = { version = "0.12", features = ["fam-wrappers"], optional = true }
+kvm-ioctls = { version = "0.22", optional = true }
 mshv-bindings2 = { package="mshv-bindings", version = "=0.2.1", optional = true }
 mshv-ioctls2 = { package="mshv-ioctls",  version = "=0.2.1", optional = true}
 mshv-bindings3 = { package="mshv-bindings", version = "=0.3.2", optional = true }


### PR DESCRIPTION
Updates `kvm-ioctls` crate to version 0.22 and `kvm-bindings` crate to version 0.12