### PR TITLE
Update mshv crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1255,9 +1255,9 @@ dependencies = [
  "metrics-exporter-prometheus",
  "metrics-util",
  "mshv-bindings 0.2.1",
- "mshv-bindings 0.3.2",
+ "mshv-bindings 0.5.1",
  "mshv-ioctls 0.2.1",
- "mshv-ioctls 0.3.2",
+ "mshv-ioctls 0.5.1",
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry-semantic-conventions",
@@ -1870,9 +1870,9 @@ dependencies = [
 
 [[package]]
 name = "mshv-bindings"
-version = "0.3.2"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e0cb5031f3243a7459b7c13d960d25420980874eebda816db24ce6077e21d43"
+checksum = "909de5fd4a5a3347a6c62872f6816e6279efd8615a753f10a3bc4daaef8a72ef"
 dependencies = [
  "libc",
  "num_enum",
@@ -1894,12 +1894,12 @@ dependencies = [
 
 [[package]]
 name = "mshv-ioctls"
-version = "0.3.2"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89abe853221fa6f14ad4066affb9abda241a03d65622887d5794e1422d0bd75a"
+checksum = "8c7d94972588d562bd349b916de6a43f2ee268e6e9c91cfb5b30549ed4ea2751"
 dependencies = [
  "libc",
- "mshv-bindings 0.3.2",
+ "mshv-bindings 0.5.1",
  "thiserror 2.0.12",
  "vmm-sys-util",
 ]

--- a/src/hyperlight_host/Cargo.toml
+++ b/src/hyperlight_host/Cargo.toml
@@ -74,8 +74,8 @@ kvm-bindings = { version = "0.12", features = ["fam-wrappers"], optional = true 
 kvm-ioctls = { version = "0.22", optional = true }
 mshv-bindings2 = { package="mshv-bindings", version = "=0.2.1", optional = true }
 mshv-ioctls2 = { package="mshv-ioctls",  version = "=0.2.1", optional = true}
-mshv-bindings3 = { package="mshv-bindings", version = "=0.3.2", optional = true }
-mshv-ioctls3 = { package="mshv-ioctls",  version = "=0.3.2", optional = true}
+mshv-bindings3 = { package="mshv-bindings", version = "0.5.1", optional = true }
+mshv-ioctls3 = { package="mshv-ioctls",  version = "0.5.1", optional = true}
 
 [dev-dependencies]
 uuid = { version = "1.17.0", features = ["v4"] }

--- a/src/hyperlight_host/src/hypervisor/hyperv_linux.rs
+++ b/src/hyperlight_host/src/hypervisor/hyperv_linux.rs
@@ -343,7 +343,7 @@ impl HypervLinuxDriver {
 
             let vm_fd = mshv.create_vm_with_args(&pr)?;
             let features: hv_partition_synthetic_processor_features = Default::default();
-            vm_fd.hvcall_set_partition_property(
+            vm_fd.set_partition_property(
                 hv_partition_property_code_HV_PARTITION_PROPERTY_SYNTHETIC_PROC_FEATURES,
                 unsafe { features.as_uint64[0] },
             )?;


### PR DESCRIPTION
Updates mshv crates to version 0.5.1 and removes the fix to a version