### PR TITLE
Bump version to 0.5.1 and add changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Prerelease] - Unreleased
 
+## [v0.5.1] - 2025-06-02
+### Fixed
+- Fixed an issue with the `hyperlight_host` not building on v0.5.0
+
 ## [v0.5.0] - 2025-05-28
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1144,7 +1144,7 @@ dependencies = [
 
 [[package]]
 name = "hyperlight-common"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -1165,7 +1165,7 @@ dependencies = [
 
 [[package]]
 name = "hyperlight-guest"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "hyperlight-common",
@@ -1174,7 +1174,7 @@ dependencies = [
 
 [[package]]
 name = "hyperlight-guest-bin"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "buddy_system_allocator",
  "cc",
@@ -1188,7 +1188,7 @@ dependencies = [
 
 [[package]]
 name = "hyperlight-host"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "bitflags 2.9.1",
@@ -1271,7 +1271,7 @@ dependencies = [
 
 [[package]]
 name = "hyperlight_guest_capi"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "cbindgen",
  "hyperlight-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.5.0"
+version = "0.5.1"
 edition = "2024"
 rust-version = "1.85"
 license = "Apache-2.0"
@@ -31,10 +31,10 @@ repository = "https://github.com/hyperlight-dev/hyperlight"
 readme = "README.md"
 
 [workspace.dependencies]
-hyperlight-common = { path = "src/hyperlight_common", version = "0.5.0", default-features = false }
-hyperlight-host = { path = "src/hyperlight_host", version = "0.5.0", default-features = false }
-hyperlight-guest = { path = "src/hyperlight_guest", version = "0.5.0", default-features = false }
-hyperlight-guest-bin = { path = "src/hyperlight_guest_bin", version = "0.5.0", default-features = false }
+hyperlight-common = { path = "src/hyperlight_common", version = "0.5.1", default-features = false }
+hyperlight-host = { path = "src/hyperlight_host", version = "0.5.1", default-features = false }
+hyperlight-guest = { path = "src/hyperlight_guest", version = "0.5.1", default-features = false }
+hyperlight-guest-bin = { path = "src/hyperlight_guest_bin", version = "0.5.1", default-features = false }
 hyperlight-testing = { path = "src/hyperlight_testing", default-features = false }
 
 [workspace.lints.rust]

--- a/src/tests/rust_guests/callbackguest/Cargo.lock
+++ b/src/tests/rust_guests/callbackguest/Cargo.lock
@@ -71,7 +71,7 @@ checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
 name = "hyperlight-common"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "flatbuffers",
@@ -80,7 +80,7 @@ dependencies = [
 
 [[package]]
 name = "hyperlight-guest"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "hyperlight-common",
@@ -89,7 +89,7 @@ dependencies = [
 
 [[package]]
 name = "hyperlight-guest-bin"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "buddy_system_allocator",
  "cc",

--- a/src/tests/rust_guests/simpleguest/Cargo.lock
+++ b/src/tests/rust_guests/simpleguest/Cargo.lock
@@ -62,7 +62,7 @@ checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
 name = "hyperlight-common"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "flatbuffers",
@@ -71,7 +71,7 @@ dependencies = [
 
 [[package]]
 name = "hyperlight-guest"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "hyperlight-common",
@@ -80,7 +80,7 @@ dependencies = [
 
 [[package]]
 name = "hyperlight-guest-bin"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "buddy_system_allocator",
  "cc",


### PR DESCRIPTION
This commit was (incorrectly) only made to `release/v0.5.1` branch. Adds it here to main as well so everything is sync.