### PR TITLE
Only clear 'cancel_requested' flag when cancelling vcpu run.

### DIFF
--- a/src/hyperlight_host/src/hypervisor/hyperv_linux.rs
+++ b/src/hyperlight_host/src/hypervisor/hyperv_linux.rs
@@ -631,7 +631,7 @@ impl Hypervisor for HypervLinuxDriver {
         let cancel_requested = self
             .interrupt_handle
             .cancel_requested
-            .swap(false, Ordering::Relaxed);
+            .load(Ordering::Relaxed);
         // Note: if a `InterruptHandle::kill()` called while this thread is **here**
         // Then `cancel_requested` will be set to true again, which will cancel the **next vcpu run**.
         // Additionally signals will be sent to this thread until `running` is set to false.
@@ -722,6 +722,9 @@ impl Hypervisor for HypervLinuxDriver {
                     // If cancellation was not requested for this specific vm, the vcpu was interrupted because of stale signal
                     // that was meant to be delivered to a previous/other vcpu on this same thread, so let's ignore it
                     if cancel_requested {
+                        self.interrupt_handle
+                            .cancel_requested
+                            .store(false, Ordering::Relaxed);
                         HyperlightExit::Cancelled()
                     } else {
                         HyperlightExit::Retry()


### PR DESCRIPTION
Currently, it's possible for the 'cancel_requested' flag to be cleared without the vcpu being cancelled. This can lead to a call to `kill()` being lost.