### PR TITLE
Automatically install guest cross-compilation target if not installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,13 +173,6 @@ After having an environment with a hypervisor setup, running the example has the
 1. On Linux or WSL, you'll most likely need build essential. For Ubuntu, run `sudo apt install build-essential`. For
    Azure Linux, run `sudo dnf install build-essential`.
 2. [Rust](https://www.rust-lang.org/tools/install). Install toolchain v1.85 or later.
-
-   Also, install the `x86_64-unknown-none` target, it is needed to build the test
-   guest binaries.
-    ```sh
-    rustup target add x86_64-unknown-none
-    ```
-
 3. [just](https://github.com/casey/just). `cargo install just` On Windows you also need [pwsh](https://learn.microsoft.com/en-us/powershell/scripting/install/installing-powershell-on-windows?view=powershell-7.4).
 4. [clang and LLVM](https://clang.llvm.org/get_started.html).
     - On Ubuntu, run:

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,5 @@
 [toolchain]
 channel = "1.85"
+# Target used for guest binaries. This is an additive list of targets in addition to host platform.
+# Will install the target if not already installed when building guest binaries.
+targets = ["x86_64-unknown-none"]


### PR DESCRIPTION
Automatically installs the guest cross-compilation target if not installed.
Should at least help alleviate some potential friction when getting started with hyperlight.

Tested on a fresh VM by calling `just rg` before the rust target `x86_64-unknown-none` is installed.

Docs: https://rust-lang.github.io/rustup/overrides.html#targets