### PR TITLE
Set fmt style-edition to 2024

### DIFF
--- a/fuzz/fuzz_targets/host_print.rs
+++ b/fuzz/fuzz_targets/host_print.rs
@@ -7,7 +7,7 @@ use hyperlight_host::sandbox_state::sandbox::EvolvableSandbox;
 use hyperlight_host::sandbox_state::transition::Noop;
 use hyperlight_host::{MultiUseSandbox, UninitializedSandbox};
 use hyperlight_testing::simple_guest_for_fuzzing_as_string;
-use libfuzzer_sys::{fuzz_target, Corpus};
+use libfuzzer_sys::{Corpus, fuzz_target};
 
 static SANDBOX: OnceLock<Mutex<MultiUseSandbox>> = OnceLock::new();
 

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -4,4 +4,4 @@ group_imports = "StdExternalCrate" # create three groups for std, external and l
 # Merge imports from the same module
 # See: https://rust-lang.github.io/rustfmt/?version=v1.4.38&search=#imports_granularity
 imports_granularity = "Module"
-style_edition = "2021"
+style_edition = "2024"

--- a/src/hyperlight_common/src/flatbuffer_wrappers/function_call.rs
+++ b/src/hyperlight_common/src/flatbuffer_wrappers/function_call.rs
@@ -17,18 +17,18 @@ limitations under the License.
 use alloc::string::{String, ToString};
 use alloc::vec::Vec;
 
-use anyhow::{bail, Error, Result};
-use flatbuffers::{size_prefixed_root, WIPOffset};
+use anyhow::{Error, Result, bail};
+use flatbuffers::{WIPOffset, size_prefixed_root};
 #[cfg(feature = "tracing")]
-use tracing::{instrument, Span};
+use tracing::{Span, instrument};
 
 use super::function_types::{ParameterValue, ReturnType};
 use crate::flatbuffers::hyperlight::generated::{
-    hlbool, hlboolArgs, hldouble, hldoubleArgs, hlfloat, hlfloatArgs, hlint, hlintArgs, hllong,
-    hllongArgs, hlstring, hlstringArgs, hluint, hluintArgs, hlulong, hlulongArgs, hlvecbytes,
-    hlvecbytesArgs, FunctionCall as FbFunctionCall, FunctionCallArgs as FbFunctionCallArgs,
+    FunctionCall as FbFunctionCall, FunctionCallArgs as FbFunctionCallArgs,
     FunctionCallType as FbFunctionCallType, Parameter, ParameterArgs,
-    ParameterValue as FbParameterValue,
+    ParameterValue as FbParameterValue, hlbool, hlboolArgs, hldouble, hldoubleArgs, hlfloat,
+    hlfloatArgs, hlint, hlintArgs, hllong, hllongArgs, hlstring, hlstringArgs, hluint, hluintArgs,
+    hlulong, hlulongArgs, hlvecbytes, hlvecbytesArgs,
 };
 
 /// The type of function call.

--- a/src/hyperlight_common/src/flatbuffer_wrappers/function_types.rs
+++ b/src/hyperlight_common/src/flatbuffer_wrappers/function_types.rs
@@ -17,18 +17,18 @@ limitations under the License.
 use alloc::string::{String, ToString};
 use alloc::vec::Vec;
 
-use anyhow::{anyhow, bail, Error, Result};
+use anyhow::{Error, Result, anyhow, bail};
 use flatbuffers::size_prefixed_root;
 #[cfg(feature = "tracing")]
-use tracing::{instrument, Span};
+use tracing::{Span, instrument};
 
 use crate::flatbuffers::hyperlight::generated::{
-    hlbool, hlboolArgs, hldouble, hldoubleArgs, hlfloat, hlfloatArgs, hlint, hlintArgs, hllong,
-    hllongArgs, hlsizeprefixedbuffer, hlsizeprefixedbufferArgs, hlstring, hlstringArgs, hluint,
-    hluintArgs, hlulong, hlulongArgs, hlvoid, hlvoidArgs,
     FunctionCallResult as FbFunctionCallResult, FunctionCallResultArgs as FbFunctionCallResultArgs,
     Parameter, ParameterType as FbParameterType, ParameterValue as FbParameterValue,
-    ReturnType as FbReturnType, ReturnValue as FbReturnValue,
+    ReturnType as FbReturnType, ReturnValue as FbReturnValue, hlbool, hlboolArgs, hldouble,
+    hldoubleArgs, hlfloat, hlfloatArgs, hlint, hlintArgs, hllong, hllongArgs, hlsizeprefixedbuffer,
+    hlsizeprefixedbufferArgs, hlstring, hlstringArgs, hluint, hluintArgs, hlulong, hlulongArgs,
+    hlvoid, hlvoidArgs,
 };
 
 /// Supported parameter types with values for function calling.

--- a/src/hyperlight_common/src/flatbuffer_wrappers/guest_error.rs
+++ b/src/hyperlight_common/src/flatbuffer_wrappers/guest_error.rs
@@ -22,7 +22,7 @@ use alloc::vec::Vec;
 use anyhow::{Error, Result};
 use flatbuffers::size_prefixed_root;
 #[cfg(feature = "tracing")]
-use tracing::{instrument, Span};
+use tracing::{Span, instrument};
 
 use crate::flatbuffers::hyperlight::generated::{
     ErrorCode as FbErrorCode, GuestError as FbGuestError, GuestErrorArgs,

--- a/src/hyperlight_common/src/flatbuffer_wrappers/guest_log_data.rs
+++ b/src/hyperlight_common/src/flatbuffer_wrappers/guest_log_data.rs
@@ -17,10 +17,10 @@ limitations under the License.
 use alloc::string::{String, ToString};
 use alloc::vec::Vec;
 
-use anyhow::{anyhow, Error, Result};
+use anyhow::{Error, Result, anyhow};
 use flatbuffers::size_prefixed_root;
 #[cfg(feature = "tracing")]
-use tracing::{instrument, Span};
+use tracing::{Span, instrument};
 
 use super::guest_log_level::LogLevel;
 use crate::flatbuffers::hyperlight::generated::{

--- a/src/hyperlight_common/src/flatbuffer_wrappers/guest_log_level.rs
+++ b/src/hyperlight_common/src/flatbuffer_wrappers/guest_log_level.rs
@@ -14,10 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use anyhow::{bail, Error, Result};
+use anyhow::{Error, Result, bail};
 use log::Level;
 #[cfg(feature = "tracing")]
-use tracing::{instrument, Span};
+use tracing::{Span, instrument};
 
 use crate::flatbuffers::hyperlight::generated::LogLevel as FbLogLevel;
 

--- a/src/hyperlight_common/src/flatbuffer_wrappers/util.rs
+++ b/src/hyperlight_common/src/flatbuffer_wrappers/util.rs
@@ -19,15 +19,15 @@ use alloc::vec::Vec;
 use flatbuffers::FlatBufferBuilder;
 
 use crate::flatbuffers::hyperlight::generated::{
-    hlbool as Fbhlbool, hlboolArgs as FbhlboolArgs, hldouble as Fbhldouble,
-    hldoubleArgs as FbhldoubleArgs, hlfloat as Fbhlfloat, hlfloatArgs as FbhlfloatArgs,
-    hlint as Fbhlint, hlintArgs as FbhlintArgs, hllong as Fbhllong, hllongArgs as FbhllongArgs,
-    hlsizeprefixedbuffer as Fbhlsizeprefixedbuffer,
+    FunctionCallResult as FbFunctionCallResult, FunctionCallResultArgs as FbFunctionCallResultArgs,
+    ReturnValue as FbReturnValue, hlbool as Fbhlbool, hlboolArgs as FbhlboolArgs,
+    hldouble as Fbhldouble, hldoubleArgs as FbhldoubleArgs, hlfloat as Fbhlfloat,
+    hlfloatArgs as FbhlfloatArgs, hlint as Fbhlint, hlintArgs as FbhlintArgs, hllong as Fbhllong,
+    hllongArgs as FbhllongArgs, hlsizeprefixedbuffer as Fbhlsizeprefixedbuffer,
     hlsizeprefixedbufferArgs as FbhlsizeprefixedbufferArgs, hlstring as Fbhlstring,
     hlstringArgs as FbhlstringArgs, hluint as Fbhluint, hluintArgs as FbhluintArgs,
     hlulong as Fbhlulong, hlulongArgs as FbhlulongArgs, hlvoid as Fbhlvoid,
-    hlvoidArgs as FbhlvoidArgs, FunctionCallResult as FbFunctionCallResult,
-    FunctionCallResultArgs as FbFunctionCallResultArgs, ReturnValue as FbReturnValue,
+    hlvoidArgs as FbhlvoidArgs,
 };
 
 /// Flatbuffer-encodes the given value

--- a/src/hyperlight_common/src/outb.rs
+++ b/src/hyperlight_common/src/outb.rs
@@ -16,7 +16,7 @@ limitations under the License.
 
 use core::convert::TryFrom;
 
-use anyhow::{anyhow, Error};
+use anyhow::{Error, anyhow};
 
 /// Exception codes for the x86 architecture.
 /// These are helpful to identify the type of exception that occurred

--- a/src/hyperlight_guest/src/exit.rs
+++ b/src/hyperlight_guest/src/exit.rs
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 use core::arch::asm;
-use core::ffi::{c_char, CStr};
+use core::ffi::{CStr, c_char};
 
 use hyperlight_common::outb::OutBAction;
 

--- a/src/hyperlight_guest_bin/src/exceptions/idt.rs
+++ b/src/hyperlight_guest_bin/src/exceptions/idt.rs
@@ -17,9 +17,9 @@ limitations under the License.
 use hyperlight_common::outb::Exception;
 
 use crate::exceptions::interrupt_entry::{
-    _do_excp0, _do_excp1, _do_excp10, _do_excp11, _do_excp12, _do_excp13, _do_excp14, _do_excp15,
-    _do_excp16, _do_excp17, _do_excp18, _do_excp19, _do_excp2, _do_excp20, _do_excp3, _do_excp30,
-    _do_excp4, _do_excp5, _do_excp6, _do_excp7, _do_excp8, _do_excp9,
+    _do_excp0, _do_excp1, _do_excp2, _do_excp3, _do_excp4, _do_excp5, _do_excp6, _do_excp7,
+    _do_excp8, _do_excp9, _do_excp10, _do_excp11, _do_excp12, _do_excp13, _do_excp14, _do_excp15,
+    _do_excp16, _do_excp17, _do_excp18, _do_excp19, _do_excp20, _do_excp30,
 };
 
 // An entry in the Interrupt Descriptor Table (IDT)

--- a/src/hyperlight_guest_bin/src/exceptions/idtr.rs
+++ b/src/hyperlight_guest_bin/src/exceptions/idtr.rs
@@ -17,7 +17,7 @@ limitations under the License.
 use core::mem::size_of;
 use core::ptr::addr_of;
 
-use crate::exceptions::idt::{init_idt, IdtEntry, IDT};
+use crate::exceptions::idt::{IDT, IdtEntry, init_idt};
 
 #[repr(C, packed)]
 pub struct Idtr {

--- a/src/hyperlight_guest_bin/src/guest_err.rs
+++ b/src/hyperlight_guest_bin/src/guest_err.rs
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use core::ffi::{c_char, CStr};
+use core::ffi::{CStr, c_char};
 
 use hyperlight_common::flatbuffer_wrappers::guest_error::ErrorCode;
 use hyperlight_guest::exit::halt;

--- a/src/hyperlight_guest_bin/src/host_comm.rs
+++ b/src/hyperlight_guest_bin/src/host_comm.rs
@@ -16,7 +16,7 @@ limitations under the License.
 
 use alloc::string::{String, ToString};
 use alloc::vec::Vec;
-use core::ffi::{c_char, CStr};
+use core::ffi::{CStr, c_char};
 use core::mem;
 
 use hyperlight_common::flatbuffer_wrappers::function_call::FunctionCall;

--- a/src/hyperlight_guest_capi/src/dispatch.rs
+++ b/src/hyperlight_guest_capi/src/dispatch.rs
@@ -17,7 +17,7 @@ limitations under the License.
 use alloc::boxed::Box;
 use alloc::slice;
 use alloc::vec::Vec;
-use core::ffi::{c_char, CStr};
+use core::ffi::{CStr, c_char};
 use core::mem;
 
 use hyperlight_common::flatbuffer_wrappers::function_call::FunctionCall;

--- a/src/hyperlight_guest_capi/src/flatbuffer.rs
+++ b/src/hyperlight_guest_capi/src/flatbuffer.rs
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 use alloc::boxed::Box;
-use core::ffi::{c_char, CStr};
+use core::ffi::{CStr, c_char};
 
 use hyperlight_common::flatbuffer_wrappers::util::get_flatbuffer_result;
 use hyperlight_guest_bin::host_comm::get_host_return_value;

--- a/src/hyperlight_guest_capi/src/types/function_call.rs
+++ b/src/hyperlight_guest_capi/src/types/function_call.rs
@@ -19,7 +19,7 @@ use alloc::ffi::CString;
 use alloc::slice;
 use alloc::string::String;
 use alloc::vec::Vec;
-use core::ffi::{c_char, CStr};
+use core::ffi::{CStr, c_char};
 
 use hyperlight_common::flatbuffer_wrappers::function_call::FunctionCall;
 use hyperlight_common::flatbuffer_wrappers::function_types::{ParameterValue, ReturnType};

--- a/src/hyperlight_guest_capi/src/types/parameter.rs
+++ b/src/hyperlight_guest_capi/src/types/parameter.rs
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 use alloc::ffi::CString;
-use core::ffi::{c_char, CStr};
+use core::ffi::{CStr, c_char};
 
 use hyperlight_common::flatbuffer_wrappers::function_types::{ParameterType, ParameterValue};
 use hyperlight_guest::error::Result;

--- a/src/hyperlight_host/benches/benchmarks.rs
+++ b/src/hyperlight_host/benches/benchmarks.rs
@@ -14,11 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{Criterion, criterion_group, criterion_main};
+use hyperlight_host::GuestBinary;
 use hyperlight_host::sandbox::{MultiUseSandbox, SandboxConfiguration, UninitializedSandbox};
 use hyperlight_host::sandbox_state::sandbox::EvolvableSandbox;
 use hyperlight_host::sandbox_state::transition::Noop;
-use hyperlight_host::GuestBinary;
 use hyperlight_testing::simple_guest_as_string;
 
 fn create_uninit_sandbox() -> UninitializedSandbox {

--- a/src/hyperlight_host/examples/guest-debugging/main.rs
+++ b/src/hyperlight_host/examples/guest-debugging/main.rs
@@ -16,9 +16,9 @@ limitations under the License.
 #![allow(clippy::disallowed_macros)]
 use std::thread;
 
+use hyperlight_host::sandbox::SandboxConfiguration;
 #[cfg(gdb)]
 use hyperlight_host::sandbox::config::DebugInfo;
-use hyperlight_host::sandbox::SandboxConfiguration;
 use hyperlight_host::sandbox_state::sandbox::EvolvableSandbox;
 use hyperlight_host::sandbox_state::transition::Noop;
 use hyperlight_host::{MultiUseSandbox, UninitializedSandbox};
@@ -79,7 +79,7 @@ mod tests {
     use std::process::{Command, Stdio};
     use std::time::Duration;
 
-    use hyperlight_host::{new_error, Result};
+    use hyperlight_host::{Result, new_error};
     use io::{BufReader, BufWriter, Read, Write};
 
     use super::*;

--- a/src/hyperlight_host/examples/metrics/main.rs
+++ b/src/hyperlight_host/examples/metrics/main.rs
@@ -16,7 +16,7 @@ limitations under the License.
 #![allow(clippy::disallowed_macros)]
 extern crate hyperlight_host;
 use std::sync::{Arc, Barrier};
-use std::thread::{spawn, JoinHandle};
+use std::thread::{JoinHandle, spawn};
 
 use hyperlight_host::sandbox::uninitialized::UninitializedSandbox;
 use hyperlight_host::sandbox_state::sandbox::EvolvableSandbox;

--- a/src/hyperlight_host/examples/tracing-otlp/main.rs
+++ b/src/hyperlight_host/examples/tracing-otlp/main.rs
@@ -16,7 +16,7 @@ limitations under the License.
 #![allow(clippy::disallowed_macros)]
 //use opentelemetry_sdk::resource::ResourceBuilder;
 use opentelemetry_sdk::trace::SdkTracerProvider;
-use tracing::{span, Level};
+use tracing::{Level, span};
 use tracing_opentelemetry::OpenTelemetryLayer;
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
@@ -24,7 +24,7 @@ extern crate hyperlight_host;
 use std::error::Error;
 use std::io::stdin;
 use std::sync::{Arc, Barrier, Mutex};
-use std::thread::{spawn, JoinHandle};
+use std::thread::{JoinHandle, spawn};
 
 use hyperlight_host::sandbox::uninitialized::UninitializedSandbox;
 use hyperlight_host::sandbox_state::sandbox::EvolvableSandbox;
@@ -32,7 +32,7 @@ use hyperlight_host::sandbox_state::transition::Noop;
 use hyperlight_host::{GuestBinary, MultiUseSandbox, Result as HyperlightResult};
 use hyperlight_testing::simple_guest_as_string;
 use opentelemetry::trace::TracerProvider;
-use opentelemetry::{global, KeyValue};
+use opentelemetry::{KeyValue, global};
 use opentelemetry_otlp::{SpanExporter, WithExportConfig};
 //use opentelemetry_sdk::runtime::Tokio;
 use opentelemetry_sdk::Resource;

--- a/src/hyperlight_host/examples/tracing-tracy/main.rs
+++ b/src/hyperlight_host/examples/tracing-tracy/main.rs
@@ -19,8 +19,8 @@ use hyperlight_host::sandbox_state::sandbox::EvolvableSandbox;
 use hyperlight_host::sandbox_state::transition::Noop;
 use hyperlight_host::{GuestBinary, MultiUseSandbox, Result};
 use hyperlight_testing::simple_guest_as_string;
-use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::EnvFilter;
+use tracing_subscriber::layer::SubscriberExt;
 
 // An example of how to get tracy tracing working with hyperlight.
 // Run with:

--- a/src/hyperlight_host/examples/tracing/main.rs
+++ b/src/hyperlight_host/examples/tracing/main.rs
@@ -14,10 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 #![allow(clippy::disallowed_macros)]
-use tracing::{span, Level};
+use tracing::{Level, span};
 extern crate hyperlight_host;
 use std::sync::{Arc, Barrier};
-use std::thread::{spawn, JoinHandle};
+use std::thread::{JoinHandle, spawn};
 
 use hyperlight_host::sandbox::uninitialized::UninitializedSandbox;
 use hyperlight_host::sandbox_state::sandbox::EvolvableSandbox;

--- a/src/hyperlight_host/src/func/call_ctx.rs
+++ b/src/hyperlight_host/src/func/call_ctx.rs
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use tracing::{instrument, Span};
+use tracing::{Span, instrument};
 
 use super::{ParameterTuple, SupportedReturnType};
 use crate::{MultiUseSandbox, Result};

--- a/src/hyperlight_host/src/func/guest_err.rs
+++ b/src/hyperlight_host/src/func/guest_err.rs
@@ -20,7 +20,7 @@ use crate::error::HyperlightError::{GuestError, StackOverflow};
 use crate::mem::shared_mem::HostSharedMemory;
 use crate::metrics::{METRIC_GUEST_ERROR, METRIC_GUEST_ERROR_LABEL_CODE};
 use crate::sandbox::mem_mgr::MemMgrWrapper;
-use crate::{log_then_return, Result};
+use crate::{Result, log_then_return};
 
 /// Check for a guest error and return an `Err` if one was found,
 /// and `Ok` if one was not found.

--- a/src/hyperlight_host/src/func/host_functions.rs
+++ b/src/hyperlight_host/src/func/host_functions.rs
@@ -21,7 +21,7 @@ use hyperlight_common::flatbuffer_wrappers::function_types::{ParameterValue, Ret
 use super::utils::for_each_tuple;
 use super::{ParameterTuple, ResultType, SupportedReturnType};
 use crate::sandbox::{ExtraAllowedSyscall, UninitializedSandbox};
-use crate::{log_then_return, new_error, Result};
+use crate::{Result, log_then_return, new_error};
 
 /// A representation of a host function.
 /// This is a thin wrapper around a `Fn(Args) -> Result<Output>`.

--- a/src/hyperlight_host/src/func/param_type.rs
+++ b/src/hyperlight_host/src/func/param_type.rs
@@ -15,11 +15,11 @@ limitations under the License.
 */
 
 use hyperlight_common::flatbuffer_wrappers::function_types::{ParameterType, ParameterValue};
-use tracing::{instrument, Span};
+use tracing::{Span, instrument};
 
 use super::utils::for_each_tuple;
 use crate::HyperlightError::{ParameterValueConversionFailure, UnexpectedNoOfArguments};
-use crate::{log_then_return, Result};
+use crate::{Result, log_then_return};
 
 /// This is a marker trait that is used to indicate that a type is a
 /// valid Hyperlight parameter type.

--- a/src/hyperlight_host/src/func/ret_type.rs
+++ b/src/hyperlight_host/src/func/ret_type.rs
@@ -15,10 +15,10 @@ limitations under the License.
 */
 
 use hyperlight_common::flatbuffer_wrappers::function_types::{ReturnType, ReturnValue};
-use tracing::{instrument, Span};
+use tracing::{Span, instrument};
 
 use crate::HyperlightError::ReturnValueConversionFailure;
-use crate::{log_then_return, Result};
+use crate::{Result, log_then_return};
 
 /// This is a marker trait that is used to indicate that a type is a valid Hyperlight return type.
 pub trait SupportedReturnType: Sized + Clone + Send + Sync + 'static {

--- a/src/hyperlight_host/src/hypervisor/crashdump.rs
+++ b/src/hyperlight_host/src/hypervisor/crashdump.rs
@@ -19,7 +19,7 @@ use std::io::Write;
 use tempfile::NamedTempFile;
 
 use super::Hypervisor;
-use crate::{new_error, Result};
+use crate::{Result, new_error};
 
 /// Dump registers + memory regions + raw memory to a tempfile
 #[cfg(crashdump)]

--- a/src/hyperlight_host/src/hypervisor/gdb/event_loop.rs
+++ b/src/hyperlight_host/src/hypervisor/gdb/event_loop.rs
@@ -17,9 +17,9 @@ limitations under the License.
 use gdbstub::common::Signal;
 use gdbstub::conn::ConnectionExt;
 use gdbstub::stub::{
-    run_blocking, BaseStopReason, DisconnectReason, GdbStub, SingleThreadStopReason,
+    BaseStopReason, DisconnectReason, GdbStub, SingleThreadStopReason, run_blocking,
 };
-use libc::{pthread_kill, SIGRTMIN};
+use libc::{SIGRTMIN, pthread_kill};
 
 use super::x86_64_target::HyperlightSandboxTarget;
 use super::{DebugResponse, GdbTargetError, VcpuStopReason};

--- a/src/hyperlight_host/src/hypervisor/gdb/kvm_debug.rs
+++ b/src/hyperlight_host/src/hypervisor/gdb/kvm_debug.rs
@@ -17,14 +17,14 @@ limitations under the License.
 use std::collections::HashMap;
 
 use kvm_bindings::{
-    kvm_debug_exit_arch, kvm_guest_debug, kvm_regs, KVM_GUESTDBG_ENABLE, KVM_GUESTDBG_SINGLESTEP,
-    KVM_GUESTDBG_USE_HW_BP, KVM_GUESTDBG_USE_SW_BP,
+    KVM_GUESTDBG_ENABLE, KVM_GUESTDBG_SINGLESTEP, KVM_GUESTDBG_USE_HW_BP, KVM_GUESTDBG_USE_SW_BP,
+    kvm_debug_exit_arch, kvm_guest_debug, kvm_regs,
 };
 use kvm_ioctls::VcpuFd;
 
-use super::arch::{vcpu_stop_reason, MAX_NO_OF_HW_BP, SW_BP_SIZE};
+use super::arch::{MAX_NO_OF_HW_BP, SW_BP_SIZE, vcpu_stop_reason};
 use super::{GuestDebug, VcpuStopReason, X86_64Regs};
-use crate::{new_error, HyperlightError, Result};
+use crate::{HyperlightError, Result, new_error};
 
 /// KVM Debug struct
 /// This struct is used to abstract the internal details of the kvm

--- a/src/hyperlight_host/src/hypervisor/gdb/mod.rs
+++ b/src/hyperlight_host/src/hypervisor/gdb/mod.rs
@@ -43,7 +43,7 @@ use x86_64_target::HyperlightSandboxTarget;
 
 use crate::hypervisor::handlers::DbgMemAccessHandlerCaller;
 use crate::mem::layout::SandboxMemoryLayout;
-use crate::{new_error, HyperlightError};
+use crate::{HyperlightError, new_error};
 
 #[derive(Debug, Error)]
 pub(crate) enum GdbTargetError {

--- a/src/hyperlight_host/src/hypervisor/gdb/mshv_debug.rs
+++ b/src/hyperlight_host/src/hypervisor/gdb/mshv_debug.rs
@@ -27,14 +27,14 @@ extern crate mshv_ioctls3 as mshv_ioctls;
 use std::collections::HashMap;
 
 use mshv_bindings::{
-    DebugRegisters, StandardRegisters, HV_TRANSLATE_GVA_VALIDATE_READ,
-    HV_TRANSLATE_GVA_VALIDATE_WRITE,
+    DebugRegisters, HV_TRANSLATE_GVA_VALIDATE_READ, HV_TRANSLATE_GVA_VALIDATE_WRITE,
+    StandardRegisters,
 };
 use mshv_ioctls::VcpuFd;
 
-use super::arch::{vcpu_stop_reason, MAX_NO_OF_HW_BP, SW_BP_SIZE};
+use super::arch::{MAX_NO_OF_HW_BP, SW_BP_SIZE, vcpu_stop_reason};
 use super::{GuestDebug, VcpuStopReason, X86_64Regs};
-use crate::{new_error, HyperlightError, Result};
+use crate::{HyperlightError, Result, new_error};
 
 #[derive(Debug, Default)]
 pub(crate) struct MshvDebug {

--- a/src/hyperlight_host/src/hypervisor/gdb/x86_64_target.rs
+++ b/src/hyperlight_host/src/hypervisor/gdb/x86_64_target.rs
@@ -17,11 +17,11 @@ limitations under the License.
 use crossbeam_channel::TryRecvError;
 use gdbstub::arch::Arch;
 use gdbstub::common::Signal;
+use gdbstub::target::ext::base::BaseOps;
 use gdbstub::target::ext::base::singlethread::{
     SingleThreadBase, SingleThreadResume, SingleThreadResumeOps, SingleThreadSingleStep,
     SingleThreadSingleStepOps,
 };
-use gdbstub::target::ext::base::BaseOps;
 use gdbstub::target::ext::breakpoints::{
     Breakpoints, BreakpointsOps, HwBreakpoint, HwBreakpointOps, SwBreakpoint, SwBreakpointOps,
 };

--- a/src/hyperlight_host/src/hypervisor/handlers.rs
+++ b/src/hyperlight_host/src/hypervisor/handlers.rs
@@ -16,9 +16,9 @@ limitations under the License.
 
 use std::sync::{Arc, Mutex};
 
-use tracing::{instrument, Span};
+use tracing::{Span, instrument};
 
-use crate::{new_error, Result};
+use crate::{Result, new_error};
 
 /// The trait representing custom logic to handle the case when
 /// a Hypervisor's virtual CPU (vCPU) informs Hyperlight the guest

--- a/src/hyperlight_host/src/hypervisor/hyperv_linux.rs
+++ b/src/hyperlight_host/src/hypervisor/hyperv_linux.rs
@@ -25,23 +25,23 @@ extern crate mshv_bindings3 as mshv_bindings;
 extern crate mshv_ioctls3 as mshv_ioctls;
 
 use std::fmt::{Debug, Formatter};
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 
-use log::{error, LevelFilter};
+use log::{LevelFilter, error};
 #[cfg(mshv2)]
 use mshv_bindings::hv_message;
-#[cfg(gdb)]
 use mshv_bindings::{
-    hv_intercept_parameters, hv_intercept_type_HV_INTERCEPT_TYPE_EXCEPTION,
-    hv_message_type_HVMSG_X64_EXCEPTION_INTERCEPT, mshv_install_intercept,
-    HV_INTERCEPT_ACCESS_MASK_EXECUTE,
-};
-use mshv_bindings::{
-    hv_message_type, hv_message_type_HVMSG_GPA_INTERCEPT, hv_message_type_HVMSG_UNMAPPED_GPA,
+    FloatingPointUnit, SegmentRegister, SpecialRegisters, StandardRegisters, hv_message_type,
+    hv_message_type_HVMSG_GPA_INTERCEPT, hv_message_type_HVMSG_UNMAPPED_GPA,
     hv_message_type_HVMSG_X64_HALT, hv_message_type_HVMSG_X64_IO_PORT_INTERCEPT, hv_register_assoc,
     hv_register_name_HV_X64_REGISTER_RIP, hv_register_value, mshv_user_mem_region,
-    FloatingPointUnit, SegmentRegister, SpecialRegisters, StandardRegisters,
+};
+#[cfg(gdb)]
+use mshv_bindings::{
+    HV_INTERCEPT_ACCESS_MASK_EXECUTE, hv_intercept_parameters,
+    hv_intercept_type_HV_INTERCEPT_TYPE_EXCEPTION, hv_message_type_HVMSG_X64_EXCEPTION_INTERCEPT,
+    mshv_install_intercept,
 };
 #[cfg(mshv3)]
 use mshv_bindings::{
@@ -49,7 +49,7 @@ use mshv_bindings::{
     hv_partition_synthetic_processor_features,
 };
 use mshv_ioctls::{Mshv, MshvError, VcpuFd, VmFd};
-use tracing::{instrument, Span};
+use tracing::{Span, instrument};
 
 use super::fpu::{FP_CONTROL_WORD_DEFAULT, FP_TAG_WORD_DEFAULT, MXCSR_DEFAULT};
 #[cfg(gdb)]
@@ -58,17 +58,17 @@ use super::gdb::{DebugCommChannel, DebugMsg, DebugResponse, GuestDebug, MshvDebu
 use super::handlers::DbgMemAccessHandlerWrapper;
 use super::handlers::{MemAccessHandlerWrapper, OutBHandlerWrapper};
 use super::{
-    Hypervisor, InterruptHandle, LinuxInterruptHandle, VirtualCPU, CR0_AM, CR0_ET, CR0_MP, CR0_NE,
-    CR0_PE, CR0_PG, CR0_WP, CR4_OSFXSR, CR4_OSXMMEXCPT, CR4_PAE, EFER_LMA, EFER_LME, EFER_NX,
-    EFER_SCE,
+    CR0_AM, CR0_ET, CR0_MP, CR0_NE, CR0_PE, CR0_PG, CR0_WP, CR4_OSFXSR, CR4_OSXMMEXCPT, CR4_PAE,
+    EFER_LMA, EFER_LME, EFER_NX, EFER_SCE, Hypervisor, InterruptHandle, LinuxInterruptHandle,
+    VirtualCPU,
 };
+#[cfg(gdb)]
+use crate::HyperlightError;
 use crate::hypervisor::HyperlightExit;
 use crate::mem::memory_region::{MemoryRegion, MemoryRegionFlags};
 use crate::mem::ptr::{GuestPtr, RawPtr};
 use crate::sandbox::SandboxConfiguration;
-#[cfg(gdb)]
-use crate::HyperlightError;
-use crate::{log_then_return, new_error, Result};
+use crate::{Result, log_then_return, new_error};
 
 #[cfg(gdb)]
 mod debug {
@@ -78,7 +78,7 @@ mod debug {
     use super::{HypervLinuxDriver, *};
     use crate::hypervisor::gdb::{DebugMsg, DebugResponse, VcpuStopReason, X86_64Regs};
     use crate::hypervisor::handlers::DbgMemAccessHandlerCaller;
-    use crate::{new_error, Result};
+    use crate::{Result, new_error};
 
     impl HypervLinuxDriver {
         /// Resets the debug information to disable debugging

--- a/src/hyperlight_host/src/hypervisor/hyperv_windows.rs
+++ b/src/hyperlight_host/src/hypervisor/hyperv_windows.rs
@@ -18,17 +18,17 @@ use core::ffi::c_void;
 use std::fmt;
 use std::fmt::{Debug, Formatter};
 use std::string::String;
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use hyperlight_common::mem::PAGE_SIZE_USIZE;
 use log::LevelFilter;
-use tracing::{instrument, Span};
+use tracing::{Span, instrument};
 use windows::Win32::System::Hypervisor::{
+    WHV_MEMORY_ACCESS_TYPE, WHV_PARTITION_HANDLE, WHV_REGISTER_VALUE, WHV_RUN_VP_EXIT_CONTEXT,
+    WHV_RUN_VP_EXIT_REASON, WHV_X64_SEGMENT_REGISTER, WHV_X64_SEGMENT_REGISTER_0,
     WHvCancelRunVirtualProcessor, WHvX64RegisterCr0, WHvX64RegisterCr3, WHvX64RegisterCr4,
-    WHvX64RegisterCs, WHvX64RegisterEfer, WHV_MEMORY_ACCESS_TYPE, WHV_PARTITION_HANDLE,
-    WHV_REGISTER_VALUE, WHV_RUN_VP_EXIT_CONTEXT, WHV_RUN_VP_EXIT_REASON, WHV_X64_SEGMENT_REGISTER,
-    WHV_X64_SEGMENT_REGISTER_0,
+    WHvX64RegisterCs, WHvX64RegisterEfer,
 };
 
 use super::fpu::{FP_TAG_WORD_DEFAULT, MXCSR_DEFAULT};
@@ -40,15 +40,14 @@ use super::surrogate_process_manager::*;
 use super::windows_hypervisor_platform::{VMPartition, VMProcessor};
 use super::wrappers::{HandleWrapper, WHvFPURegisters};
 use super::{
-    HyperlightExit, Hypervisor, InterruptHandle, VirtualCPU, CR0_AM, CR0_ET, CR0_MP, CR0_NE,
-    CR0_PE, CR0_PG, CR0_WP, CR4_OSFXSR, CR4_OSXMMEXCPT, CR4_PAE, EFER_LMA, EFER_LME, EFER_NX,
-    EFER_SCE,
+    CR0_AM, CR0_ET, CR0_MP, CR0_NE, CR0_PE, CR0_PG, CR0_WP, CR4_OSFXSR, CR4_OSXMMEXCPT, CR4_PAE,
+    EFER_LMA, EFER_LME, EFER_NX, EFER_SCE, HyperlightExit, Hypervisor, InterruptHandle, VirtualCPU,
 };
 use crate::hypervisor::fpu::FP_CONTROL_WORD_DEFAULT;
 use crate::hypervisor::wrappers::WHvGeneralRegisters;
 use crate::mem::memory_region::{MemoryRegion, MemoryRegionFlags};
 use crate::mem::ptr::{GuestPtr, RawPtr};
-use crate::{debug, new_error, Result};
+use crate::{Result, debug, new_error};
 
 /// A Hypervisor driver for HyperV-on-Windows.
 pub(crate) struct HypervWindowsDriver {

--- a/src/hyperlight_host/src/hypervisor/kvm.rs
+++ b/src/hyperlight_host/src/hypervisor/kvm.rs
@@ -16,16 +16,16 @@ limitations under the License.
 
 use std::convert::TryFrom;
 use std::fmt::Debug;
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
 #[cfg(gdb)]
 use std::sync::Mutex;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 
-use kvm_bindings::{kvm_fpu, kvm_regs, kvm_userspace_memory_region, KVM_MEM_READONLY};
+use kvm_bindings::{KVM_MEM_READONLY, kvm_fpu, kvm_regs, kvm_userspace_memory_region};
 use kvm_ioctls::Cap::UserMemory;
 use kvm_ioctls::{Kvm, VcpuExit, VcpuFd, VmFd};
 use log::LevelFilter;
-use tracing::{instrument, Span};
+use tracing::{Span, instrument};
 
 use super::fpu::{FP_CONTROL_WORD_DEFAULT, FP_TAG_WORD_DEFAULT, MXCSR_DEFAULT};
 #[cfg(gdb)]
@@ -34,16 +34,16 @@ use super::gdb::{DebugCommChannel, DebugMsg, DebugResponse, GuestDebug, KvmDebug
 use super::handlers::DbgMemAccessHandlerWrapper;
 use super::handlers::{MemAccessHandlerWrapper, OutBHandlerWrapper};
 use super::{
-    HyperlightExit, Hypervisor, InterruptHandle, LinuxInterruptHandle, VirtualCPU, CR0_AM, CR0_ET,
-    CR0_MP, CR0_NE, CR0_PE, CR0_PG, CR0_WP, CR4_OSFXSR, CR4_OSXMMEXCPT, CR4_PAE, EFER_LMA,
-    EFER_LME, EFER_NX, EFER_SCE,
+    CR0_AM, CR0_ET, CR0_MP, CR0_NE, CR0_PE, CR0_PG, CR0_WP, CR4_OSFXSR, CR4_OSXMMEXCPT, CR4_PAE,
+    EFER_LMA, EFER_LME, EFER_NX, EFER_SCE, HyperlightExit, Hypervisor, InterruptHandle,
+    LinuxInterruptHandle, VirtualCPU,
 };
+#[cfg(gdb)]
+use crate::HyperlightError;
 use crate::mem::memory_region::{MemoryRegion, MemoryRegionFlags};
 use crate::mem::ptr::{GuestPtr, RawPtr};
 use crate::sandbox::SandboxConfiguration;
-#[cfg(gdb)]
-use crate::HyperlightError;
-use crate::{log_then_return, new_error, Result};
+use crate::{Result, log_then_return, new_error};
 
 /// Return `true` if the KVM API is available, version 12, and has UserMemory capability, or `false` otherwise
 #[instrument(skip_all, parent = Span::current(), level = "Trace")]
@@ -78,7 +78,7 @@ mod debug {
         DebugMsg, DebugResponse, GuestDebug, KvmDebug, VcpuStopReason, X86_64Regs,
     };
     use crate::hypervisor::handlers::DbgMemAccessHandlerCaller;
-    use crate::{new_error, Result};
+    use crate::{Result, new_error};
 
     impl KVMDriver {
         /// Resets the debug information to disable debugging

--- a/src/hyperlight_host/src/hypervisor/mod.rs
+++ b/src/hyperlight_host/src/hypervisor/mod.rs
@@ -15,12 +15,12 @@ limitations under the License.
 */
 
 use log::LevelFilter;
-use tracing::{instrument, Span};
+use tracing::{Span, instrument};
 
 use crate::error::HyperlightError::ExecutionCanceledByHost;
 use crate::mem::memory_region::{MemoryRegion, MemoryRegionFlags};
 use crate::metrics::METRIC_GUEST_CANCELLATION;
-use crate::{log_then_return, new_error, HyperlightError, Result};
+use crate::{HyperlightError, Result, log_then_return, new_error};
 
 /// Util for handling x87 fpu state
 #[cfg(any(kvm, mshv, target_os = "windows"))]
@@ -457,7 +457,7 @@ pub(crate) mod tests {
     use crate::sandbox::uninitialized::GuestBinary;
     use crate::sandbox::uninitialized_evolve::set_up_hypervisor_partition;
     use crate::sandbox::{SandboxConfiguration, UninitializedSandbox};
-    use crate::{is_hypervisor_present, new_error, Result};
+    use crate::{Result, is_hypervisor_present, new_error};
 
     #[cfg(gdb)]
     struct DbgMemAccessHandler {}

--- a/src/hyperlight_host/src/hypervisor/surrogate_process.rs
+++ b/src/hyperlight_host/src/hypervisor/surrogate_process.rs
@@ -16,10 +16,10 @@ limitations under the License.
 
 use core::ffi::c_void;
 
-use tracing::{instrument, Span};
+use tracing::{Span, instrument};
 use windows::Win32::Foundation::HANDLE;
 use windows::Win32::System::Memory::{
-    UnmapViewOfFile2, MEMORY_MAPPED_VIEW_ADDRESS, UNMAP_VIEW_OF_FILE_FLAGS,
+    MEMORY_MAPPED_VIEW_ADDRESS, UNMAP_VIEW_OF_FILE_FLAGS, UnmapViewOfFile2,
 };
 
 use super::surrogate_process_manager::get_surrogate_process_manager;
@@ -78,7 +78,10 @@ impl Drop for SurrogateProcess {
             Ok(manager) => match manager.return_surrogate_process(self.process_handle) {
                 Ok(_) => (),
                 Err(e) => {
-                    tracing::error!("Failed to return surrogate process to surrogate process manager when dropping : {:?}", e);
+                    tracing::error!(
+                        "Failed to return surrogate process to surrogate process manager when dropping : {:?}",
+                        e
+                    );
                     return;
                 }
             },

--- a/src/hyperlight_host/src/hypervisor/surrogate_process_manager.rs
+++ b/src/hyperlight_host/src/hypervisor/surrogate_process_manager.rs
@@ -20,30 +20,30 @@ use std::io::Write;
 use std::mem::size_of;
 use std::path::{Path, PathBuf};
 
-use crossbeam_channel::{unbounded, Receiver, Sender};
+use crossbeam_channel::{Receiver, Sender, unbounded};
 use hyperlight_common::mem::PAGE_SIZE_USIZE;
 use rust_embed::RustEmbed;
-use tracing::{error, info, instrument, Span};
-use windows::core::{s, PCSTR};
+use tracing::{Span, error, info, instrument};
 use windows::Win32::Foundation::HANDLE;
 use windows::Win32::Security::SECURITY_ATTRIBUTES;
 use windows::Win32::System::JobObjects::{
-    AssignProcessToJobObject, CreateJobObjectA, JobObjectExtendedLimitInformation,
-    SetInformationJobObject, TerminateJobObject, JOBOBJECT_BASIC_LIMIT_INFORMATION,
-    JOBOBJECT_EXTENDED_LIMIT_INFORMATION, JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
+    AssignProcessToJobObject, CreateJobObjectA, JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
+    JOBOBJECT_BASIC_LIMIT_INFORMATION, JOBOBJECT_EXTENDED_LIMIT_INFORMATION,
+    JobObjectExtendedLimitInformation, SetInformationJobObject, TerminateJobObject,
 };
 use windows::Win32::System::Memory::{
-    MapViewOfFileNuma2, VirtualProtectEx, PAGE_NOACCESS, PAGE_PROTECTION_FLAGS, PAGE_READWRITE,
+    MapViewOfFileNuma2, PAGE_NOACCESS, PAGE_PROTECTION_FLAGS, PAGE_READWRITE, VirtualProtectEx,
 };
 use windows::Win32::System::SystemServices::NUMA_NO_PREFERRED_NODE;
 use windows::Win32::System::Threading::{
-    CreateProcessA, CREATE_SUSPENDED, PROCESS_INFORMATION, STARTUPINFOA,
+    CREATE_SUSPENDED, CreateProcessA, PROCESS_INFORMATION, STARTUPINFOA,
 };
+use windows::core::{PCSTR, s};
 
 use super::surrogate_process::SurrogateProcess;
 use super::wrappers::{HandleWrapper, PSTRWrapper};
 use crate::HyperlightError::WindowsAPIError;
-use crate::{log_then_return, new_error, Result};
+use crate::{Result, log_then_return, new_error};
 
 // Use the rust-embed crate to embed the hyperlights_surrogate.exe
 // binary in the hyperlight-host library to make dependency management easier.
@@ -433,16 +433,16 @@ mod tests {
     use std::time::{Duration, Instant};
 
     use hyperlight_common::mem::PAGE_SIZE_USIZE;
-    use rand::{rng, Rng};
+    use rand::{Rng, rng};
     use serial_test::serial;
     use windows::Win32::Foundation::{CloseHandle, HANDLE, INVALID_HANDLE_VALUE};
     use windows::Win32::System::Diagnostics::ToolHelp::{
-        CreateToolhelp32Snapshot, Process32First, Process32Next, PROCESSENTRY32, TH32CS_SNAPPROCESS,
+        CreateToolhelp32Snapshot, PROCESSENTRY32, Process32First, Process32Next, TH32CS_SNAPPROCESS,
     };
     use windows::Win32::System::JobObjects::IsProcessInJob;
     use windows::Win32::System::Memory::{
-        CreateFileMappingA, MapViewOfFile, UnmapViewOfFile, FILE_MAP_ALL_ACCESS, PAGE_READWRITE,
-        SEC_COMMIT,
+        CreateFileMappingA, FILE_MAP_ALL_ACCESS, MapViewOfFile, PAGE_READWRITE, SEC_COMMIT,
+        UnmapViewOfFile,
     };
     use windows_result::BOOL;
 

--- a/src/hyperlight_host/src/hypervisor/windows_hypervisor_platform.rs
+++ b/src/hyperlight_host/src/hypervisor/windows_hypervisor_platform.rs
@@ -16,17 +16,17 @@ limitations under the License.
 
 use core::ffi::c_void;
 
-use tracing::{instrument, Span};
-use windows::core::s;
+use tracing::{Span, instrument};
 use windows::Win32::Foundation::{FreeLibrary, HANDLE};
 use windows::Win32::System::Hypervisor::*;
 use windows::Win32::System::LibraryLoader::*;
+use windows::core::s;
 use windows_result::HRESULT;
 
 use super::wrappers::HandleWrapper;
 use crate::hypervisor::wrappers::{WHvFPURegisters, WHvGeneralRegisters, WHvSpecialRegisters};
 use crate::mem::memory_region::{MemoryRegion, MemoryRegionFlags};
-use crate::{new_error, Result};
+use crate::{Result, new_error};
 
 /// Interop calls for Windows Hypervisor Platform APIs
 ///

--- a/src/hyperlight_host/src/hypervisor/wrappers.rs
+++ b/src/hyperlight_host/src/hypervisor/wrappers.rs
@@ -16,10 +16,10 @@ limitations under the License.
 
 use std::ffi::CString;
 
-use tracing::{instrument, Span};
-use windows::core::PSTR;
+use tracing::{Span, instrument};
 use windows::Win32::Foundation::{HANDLE, HMODULE};
 use windows::Win32::System::Hypervisor::WHV_REGISTER_VALUE;
+use windows::core::PSTR;
 
 use crate::{HyperlightError, Result};
 

--- a/src/hyperlight_host/src/lib.rs
+++ b/src/hyperlight_host/src/lib.rs
@@ -73,10 +73,6 @@ pub(crate) mod testing;
 
 /// The re-export for the `HyperlightError` type
 pub use error::HyperlightError;
-/// The re-export for the `is_hypervisor_present` type
-pub use sandbox::is_hypervisor_present;
-/// The re-export for the `GuestBinary` type
-pub use sandbox::uninitialized::GuestBinary;
 /// Re-export for `HypervisorWrapper` trait
 /// Re-export for `MemMgrWrapper` type
 /// A sandbox that can call be used to make multiple calls to guest functions,
@@ -84,6 +80,10 @@ pub use sandbox::uninitialized::GuestBinary;
 pub use sandbox::MultiUseSandbox;
 /// The re-export for the `UninitializedSandbox` type
 pub use sandbox::UninitializedSandbox;
+/// The re-export for the `is_hypervisor_present` type
+pub use sandbox::is_hypervisor_present;
+/// The re-export for the `GuestBinary` type
+pub use sandbox::uninitialized::GuestBinary;
 
 /// The re-export for the `MultiUseGuestCallContext` type`
 pub use crate::func::call_ctx::MultiUseGuestCallContext;

--- a/src/hyperlight_host/src/mem/elf.rs
+++ b/src/hyperlight_host/src/mem/elf.rs
@@ -21,7 +21,7 @@ use goblin::elf::reloc::{R_X86_64_NONE, R_X86_64_RELATIVE};
 use goblin::elf::{Elf, ProgramHeaders, Reloc};
 use goblin::elf64::program_header::PT_LOAD;
 
-use crate::{log_then_return, new_error, Result};
+use crate::{Result, log_then_return, new_error};
 
 pub(crate) struct ElfInfo {
     payload: Vec<u8>,

--- a/src/hyperlight_host/src/mem/layout.rs
+++ b/src/hyperlight_host/src/mem/layout.rs
@@ -17,8 +17,8 @@ use std::fmt::Debug;
 use std::mem::{offset_of, size_of};
 
 use hyperlight_common::mem::{GuestStack, HyperlightPEB, PAGE_SIZE_USIZE};
-use rand::{rng, RngCore};
-use tracing::{instrument, Span};
+use rand::{RngCore, rng};
+use tracing::{Span, instrument};
 
 use super::memory_region::MemoryRegionType::{
     Code, GuardPage, Heap, InputData, OutputData, PageTables, Peb, Stack,
@@ -28,7 +28,7 @@ use super::mgr::AMOUNT_OF_MEMORY_PER_PT;
 use super::shared_mem::{ExclusiveSharedMemory, GuestSharedMemory, SharedMemory};
 use crate::error::HyperlightError::{GuestOffsetIsInvalid, MemoryRequestTooBig};
 use crate::sandbox::SandboxConfiguration;
-use crate::{new_error, Result};
+use crate::{Result, new_error};
 
 // +-------------------------------------------+
 // |             Guest (User) Stack            |

--- a/src/hyperlight_host/src/mem/memory_region.rs
+++ b/src/hyperlight_host/src/mem/memory_region.rs
@@ -30,8 +30,6 @@ use bitflags::bitflags;
 #[cfg(mshv)]
 use hyperlight_common::mem::PAGE_SHIFT;
 use hyperlight_common::mem::PAGE_SIZE_USIZE;
-#[cfg(mshv)]
-use mshv_bindings::{hv_x64_memory_intercept_message, mshv_user_mem_region};
 #[cfg(mshv2)]
 use mshv_bindings::{
     HV_MAP_GPA_EXECUTABLE, HV_MAP_GPA_PERMISSIONS_NONE, HV_MAP_GPA_READABLE, HV_MAP_GPA_WRITABLE,
@@ -40,6 +38,8 @@ use mshv_bindings::{
 use mshv_bindings::{
     MSHV_SET_MEM_BIT_EXECUTABLE, MSHV_SET_MEM_BIT_UNMAP, MSHV_SET_MEM_BIT_WRITABLE,
 };
+#[cfg(mshv)]
+use mshv_bindings::{hv_x64_memory_intercept_message, mshv_user_mem_region};
 #[cfg(target_os = "windows")]
 use windows::Win32::System::Hypervisor::{self, WHV_MEMORY_ACCESS_TYPE};
 

--- a/src/hyperlight_host/src/mem/mgr.rs
+++ b/src/hyperlight_host/src/mem/mgr.rs
@@ -18,12 +18,12 @@ use std::cmp::Ordering;
 use std::sync::{Arc, Mutex};
 
 use hyperlight_common::flatbuffer_wrappers::function_call::{
-    validate_guest_function_call_buffer, FunctionCall,
+    FunctionCall, validate_guest_function_call_buffer,
 };
 use hyperlight_common::flatbuffer_wrappers::function_types::ReturnValue;
 use hyperlight_common::flatbuffer_wrappers::guest_error::GuestError;
 use hyperlight_common::flatbuffer_wrappers::guest_log_data::GuestLogData;
-use tracing::{instrument, Span};
+use tracing::{Span, instrument};
 
 use super::exe::ExeInfo;
 use super::layout::SandboxMemoryLayout;
@@ -34,7 +34,7 @@ use super::shared_mem::{ExclusiveSharedMemory, GuestSharedMemory, HostSharedMemo
 use super::shared_mem_snapshot::SharedMemorySnapshot;
 use crate::error::HyperlightError::NoMemorySnapshot;
 use crate::sandbox::SandboxConfiguration;
-use crate::{log_then_return, new_error, HyperlightError, Result};
+use crate::{HyperlightError, Result, log_then_return, new_error};
 
 /// Paging Flags
 ///

--- a/src/hyperlight_host/src/mem/ptr.rs
+++ b/src/hyperlight_host/src/mem/ptr.rs
@@ -16,12 +16,12 @@ limitations under the License.
 
 use std::ops::Add;
 
-use tracing::{instrument, Span};
+use tracing::{Span, instrument};
 
 use super::ptr_addr_space::{AddressSpace, GuestAddressSpace};
 use super::ptr_offset::Offset;
-use crate::error::HyperlightError::{self, CheckedAddOverflow, RawPointerLessThanBaseAddress};
 use crate::Result;
+use crate::error::HyperlightError::{self, CheckedAddOverflow, RawPointerLessThanBaseAddress};
 
 /// A representation of a raw pointer inside a given address space.
 ///

--- a/src/hyperlight_host/src/mem/ptr_addr_space.rs
+++ b/src/hyperlight_host/src/mem/ptr_addr_space.rs
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use tracing::{instrument, Span};
+use tracing::{Span, instrument};
 
 use super::layout::SandboxMemoryLayout;
 use crate::Result;

--- a/src/hyperlight_host/src/mem/ptr_offset.rs
+++ b/src/hyperlight_host/src/mem/ptr_offset.rs
@@ -18,10 +18,10 @@ use std::cmp::{Eq, Ord, Ordering, PartialEq, PartialOrd};
 use std::convert::From;
 use std::ops::{Add, Sub};
 
-use tracing::{instrument, Span};
+use tracing::{Span, instrument};
 
-use crate::error::HyperlightError;
 use crate::Result;
+use crate::error::HyperlightError;
 
 /// An offset into a given address space.
 ///

--- a/src/hyperlight_host/src/mem/shared_mem_snapshot.rs
+++ b/src/hyperlight_host/src/mem/shared_mem_snapshot.rs
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use tracing::{instrument, Span};
+use tracing::{Span, instrument};
 
 use super::shared_mem::SharedMemory;
 use crate::Result;

--- a/src/hyperlight_host/src/mem/shared_mem_tests.rs
+++ b/src/hyperlight_host/src/mem/shared_mem_tests.rs
@@ -22,7 +22,7 @@ use std::mem::size_of;
 
 use hyperlight_common::mem::PAGE_SIZE_USIZE;
 
-use crate::{log_then_return, new_error, Result};
+use crate::{Result, log_then_return, new_error};
 
 /// A function that knows how to read data of type `T` from a
 /// `SharedMemory` at a specified offset

--- a/src/hyperlight_host/src/metrics/mod.rs
+++ b/src/hyperlight_host/src/metrics/mod.rs
@@ -89,7 +89,7 @@ mod tests {
     use std::time::Duration;
 
     use hyperlight_testing::simple_guest_as_string;
-    use metrics::{with_local_recorder, Key};
+    use metrics::{Key, with_local_recorder};
     use metrics_util::CompositeKey;
 
     use super::*;

--- a/src/hyperlight_host/src/sandbox/config.rs
+++ b/src/hyperlight_host/src/sandbox/config.rs
@@ -19,7 +19,7 @@ use std::time::Duration;
 
 #[cfg(target_os = "linux")]
 use libc::c_int;
-use tracing::{instrument, Span};
+use tracing::{Span, instrument};
 
 use crate::mem::exe::ExeInfo;
 

--- a/src/hyperlight_host/src/sandbox/host_funcs.rs
+++ b/src/hyperlight_host/src/sandbox/host_funcs.rs
@@ -19,12 +19,12 @@ use std::io::{IsTerminal, Write};
 
 use hyperlight_common::flatbuffer_wrappers::function_types::{ParameterValue, ReturnValue};
 use termcolor::{Color, ColorChoice, ColorSpec, StandardStream, WriteColor};
-use tracing::{instrument, Span};
+use tracing::{Span, instrument};
 
 use super::ExtraAllowedSyscall;
-use crate::func::host_functions::TypeErasedHostFunction;
 use crate::HyperlightError::HostFunctionNotFound;
-use crate::{new_error, Result};
+use crate::func::host_functions::TypeErasedHostFunction;
+use crate::{Result, new_error};
 
 #[derive(Default)]
 /// A Wrapper around details of functions exposed by the Host

--- a/src/hyperlight_host/src/sandbox/initialized_multi_use.rs
+++ b/src/hyperlight_host/src/sandbox/initialized_multi_use.rs
@@ -20,7 +20,7 @@ use hyperlight_common::flatbuffer_wrappers::function_call::{FunctionCall, Functi
 use hyperlight_common::flatbuffer_wrappers::function_types::{
     ParameterValue, ReturnType, ReturnValue,
 };
-use tracing::{instrument, Span};
+use tracing::{Span, instrument};
 
 use super::host_funcs::FunctionRegistry;
 use super::{MemMgrWrapper, WrapperGetter};

--- a/src/hyperlight_host/src/sandbox/mem_access.rs
+++ b/src/hyperlight_host/src/sandbox/mem_access.rs
@@ -16,7 +16,7 @@ limitations under the License.
 
 use std::sync::{Arc, Mutex};
 
-use tracing::{instrument, Span};
+use tracing::{Span, instrument};
 
 use super::mem_mgr::MemMgrWrapper;
 use crate::error::HyperlightError::StackOverflow;
@@ -26,7 +26,7 @@ use crate::hypervisor::handlers::{
     MemAccessHandler, MemAccessHandlerFunction, MemAccessHandlerWrapper,
 };
 use crate::mem::shared_mem::HostSharedMemory;
-use crate::{log_then_return, Result};
+use crate::{Result, log_then_return};
 
 #[instrument(err(Debug), skip_all, parent = Span::current(), level= "Trace")]
 pub(super) fn handle_mem_access_impl(wrapper: &MemMgrWrapper<HostSharedMemory>) -> Result<()> {

--- a/src/hyperlight_host/src/sandbox/mem_mgr.rs
+++ b/src/hyperlight_host/src/sandbox/mem_mgr.rs
@@ -14,14 +14,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use tracing::{instrument, Span};
+use tracing::{Span, instrument};
 
+use crate::Result;
 use crate::mem::layout::SandboxMemoryLayout;
-use crate::mem::mgr::{SandboxMemoryManager, STACK_COOKIE_LEN};
+use crate::mem::mgr::{STACK_COOKIE_LEN, SandboxMemoryManager};
 use crate::mem::shared_mem::{
     ExclusiveSharedMemory, GuestSharedMemory, HostSharedMemory, SharedMemory,
 };
-use crate::Result;
 
 /// StackCookie
 pub type StackCookie = [u8; STACK_COOKIE_LEN];

--- a/src/hyperlight_host/src/sandbox/mod.rs
+++ b/src/hyperlight_host/src/sandbox/mod.rs
@@ -41,7 +41,7 @@ pub(crate) mod uninitialized_evolve;
 pub use config::SandboxConfiguration;
 /// Re-export for the `MultiUseSandbox` type
 pub use initialized_multi_use::MultiUseSandbox;
-use tracing::{instrument, Span};
+use tracing::{Span, instrument};
 /// Re-export for `GuestBinary` type
 pub use uninitialized::GuestBinary;
 /// Re-export for `UninitializedSandbox` type
@@ -98,7 +98,7 @@ mod tests {
     use crate::sandbox::uninitialized::GuestBinary;
     use crate::sandbox_state::sandbox::EvolvableSandbox;
     use crate::sandbox_state::transition::Noop;
-    use crate::{new_error, MultiUseSandbox, UninitializedSandbox};
+    use crate::{MultiUseSandbox, UninitializedSandbox, new_error};
 
     #[test]
     // TODO: add support for testing on WHP

--- a/src/hyperlight_host/src/sandbox/outb.rs
+++ b/src/hyperlight_host/src/sandbox/outb.rs
@@ -21,7 +21,7 @@ use hyperlight_common::flatbuffer_wrappers::guest_error::ErrorCode;
 use hyperlight_common::flatbuffer_wrappers::guest_log_data::GuestLogData;
 use hyperlight_common::outb::{Exception, OutBAction};
 use log::{Level, Record};
-use tracing::{instrument, Span};
+use tracing::{Span, instrument};
 use tracing_log::format_trace;
 
 use super::host_funcs::FunctionRegistry;
@@ -29,7 +29,7 @@ use super::mem_mgr::MemMgrWrapper;
 use crate::hypervisor::handlers::{OutBHandler, OutBHandlerFunction, OutBHandlerWrapper};
 use crate::mem::mgr::SandboxMemoryManager;
 use crate::mem::shared_mem::HostSharedMemory;
-use crate::{new_error, HyperlightError, Result};
+use crate::{HyperlightError, Result, new_error};
 
 #[instrument(err(Debug), skip_all, parent = Span::current(), level="Trace")]
 pub(super) fn outb_log(mgr: &mut SandboxMemoryManager<HostSharedMemory>) -> Result<()> {
@@ -207,7 +207,7 @@ pub(crate) fn outb_handler_wrapper(
 #[cfg(test)]
 mod tests {
     use hyperlight_common::flatbuffer_wrappers::guest_log_level::LogLevel;
-    use hyperlight_testing::logger::{Logger, LOGGER};
+    use hyperlight_testing::logger::{LOGGER, Logger};
     use log::Level;
     use tracing_core::callsite::rebuild_interest_cache;
 
@@ -215,8 +215,8 @@ mod tests {
     use crate::mem::layout::SandboxMemoryLayout;
     use crate::mem::mgr::SandboxMemoryManager;
     use crate::mem::shared_mem::SharedMemory;
-    use crate::sandbox::outb::GuestLogData;
     use crate::sandbox::SandboxConfiguration;
+    use crate::sandbox::outb::GuestLogData;
     use crate::testing::log_values::test_value_as_str;
     use crate::testing::simple_guest_exe_info;
 

--- a/src/hyperlight_host/src/sandbox/uninitialized.rs
+++ b/src/hyperlight_host/src/sandbox/uninitialized.rs
@@ -20,22 +20,22 @@ use std::path::Path;
 use std::sync::{Arc, Mutex};
 
 use log::LevelFilter;
-use tracing::{instrument, Span};
+use tracing::{Span, instrument};
 
-use super::host_funcs::{default_writer_func, FunctionRegistry};
+use super::host_funcs::{FunctionRegistry, default_writer_func};
 use super::mem_mgr::MemMgrWrapper;
 use super::uninitialized_evolve::evolve_impl_multi_use;
-use crate::func::host_functions::{register_host_function, HostFunction};
+use crate::func::host_functions::{HostFunction, register_host_function};
 use crate::func::{ParameterTuple, SupportedReturnType};
 #[cfg(feature = "build-metadata")]
 use crate::log_build_details;
 use crate::mem::exe::ExeInfo;
-use crate::mem::mgr::{SandboxMemoryManager, STACK_COOKIE_LEN};
+use crate::mem::mgr::{STACK_COOKIE_LEN, SandboxMemoryManager};
 use crate::mem::shared_mem::ExclusiveSharedMemory;
 use crate::sandbox::SandboxConfiguration;
 use crate::sandbox_state::sandbox::EvolvableSandbox;
 use crate::sandbox_state::transition::Noop;
-use crate::{log_then_return, new_error, MultiUseSandbox, Result};
+use crate::{MultiUseSandbox, Result, log_then_return, new_error};
 
 #[cfg(all(target_os = "linux", feature = "seccomp"))]
 const EXTRA_ALLOWED_SYSCALLS_FOR_WRITER_FUNC: &[super::ExtraAllowedSyscall] = &[
@@ -294,7 +294,7 @@ impl UninitializedSandbox {
 // Hyperlight is only supported on Windows 11 and Windows Server 2022 and later
 #[cfg(target_os = "windows")]
 fn check_windows_version() -> Result<()> {
-    use windows_version::{is_server, OsVersion};
+    use windows_version::{OsVersion, is_server};
     const WINDOWS_MAJOR: u32 = 10;
     const WINDOWS_MINOR: u32 = 0;
     const WINDOWS_PACK: u32 = 0;
@@ -317,19 +317,19 @@ fn check_windows_version() -> Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::mpsc::channel;
     use std::sync::Arc;
+    use std::sync::mpsc::channel;
     use std::{fs, thread};
 
     use crossbeam_queue::ArrayQueue;
     use hyperlight_common::flatbuffer_wrappers::function_types::{ParameterValue, ReturnValue};
     use hyperlight_testing::simple_guest_as_string;
 
-    use crate::sandbox::uninitialized::GuestBinary;
     use crate::sandbox::SandboxConfiguration;
+    use crate::sandbox::uninitialized::GuestBinary;
     use crate::sandbox_state::sandbox::EvolvableSandbox;
     use crate::sandbox_state::transition::Noop;
-    use crate::{new_error, MultiUseSandbox, Result, UninitializedSandbox};
+    use crate::{MultiUseSandbox, Result, UninitializedSandbox, new_error};
 
     #[test]
     fn test_new_sandbox() {
@@ -767,8 +767,8 @@ mod tests {
         use hyperlight_testing::tracing_subscriber::TracingSubscriber as TestSubscriber;
         use serde_json::{Map, Value};
         use tracing::Level as tracing_level;
-        use tracing_core::callsite::rebuild_interest_cache;
         use tracing_core::Subscriber;
+        use tracing_core::callsite::rebuild_interest_cache;
         use uuid::Uuid;
 
         use crate::testing::log_values::build_metadata_testing::try_to_strings;
@@ -875,7 +875,7 @@ mod tests {
     fn test_log_trace() {
         use std::path::PathBuf;
 
-        use hyperlight_testing::logger::{Logger as TestLogger, LOGGER as TEST_LOGGER};
+        use hyperlight_testing::logger::{LOGGER as TEST_LOGGER, Logger as TestLogger};
         use log::Level;
         use tracing_core::callsite::rebuild_interest_cache;
 
@@ -929,9 +929,11 @@ mod tests {
 
             let logcall = TEST_LOGGER.get_log_call(16).unwrap();
             assert_eq!(Level::Error, logcall.level);
-            assert!(logcall
-                .args
-                .starts_with("error=Error(\"GuestBinary not found:"));
+            assert!(
+                logcall
+                    .args
+                    .starts_with("error=Error(\"GuestBinary not found:")
+            );
             assert_eq!("hyperlight_host::sandbox::uninitialized", logcall.target);
 
             // Log record 18
@@ -981,9 +983,11 @@ mod tests {
 
             let logcall = TEST_LOGGER.get_log_call(1).unwrap();
             assert_eq!(Level::Error, logcall.level);
-            assert!(logcall
-                .args
-                .starts_with("error=Error(\"GuestBinary not found:"));
+            assert!(
+                logcall
+                    .args
+                    .starts_with("error=Error(\"GuestBinary not found:")
+            );
             assert_eq!("hyperlight_host::sandbox::uninitialized", logcall.target);
         }
         {

--- a/src/hyperlight_host/src/sandbox/uninitialized_evolve.rs
+++ b/src/hyperlight_host/src/sandbox/uninitialized_evolve.rs
@@ -17,14 +17,15 @@ limitations under the License.
 use std::sync::{Arc, Mutex};
 
 use rand::Rng;
-use tracing::{instrument, Span};
+use tracing::{Span, instrument};
 
-use super::hypervisor::{get_available_hypervisor, HypervisorType};
+use super::SandboxConfiguration;
+use super::hypervisor::{HypervisorType, get_available_hypervisor};
 #[cfg(gdb)]
 use super::mem_access::dbg_mem_access_handler_wrapper;
-use super::SandboxConfiguration;
-use crate::hypervisor::handlers::{MemAccessHandlerCaller, OutBHandlerCaller};
+use crate::HyperlightError::NoHypervisorFound;
 use crate::hypervisor::Hypervisor;
+use crate::hypervisor::handlers::{MemAccessHandlerCaller, OutBHandlerCaller};
 use crate::mem::layout::SandboxMemoryLayout;
 use crate::mem::mgr::SandboxMemoryManager;
 use crate::mem::ptr::{GuestPtr, RawPtr};
@@ -39,8 +40,7 @@ use crate::sandbox::{HostSharedMemory, MemMgrWrapper};
 use crate::sandbox_state::sandbox::Sandbox;
 #[cfg(target_os = "linux")]
 use crate::signal_handlers::setup_signal_handlers;
-use crate::HyperlightError::NoHypervisorFound;
-use crate::{log_then_return, new_error, MultiUseSandbox, Result, UninitializedSandbox};
+use crate::{MultiUseSandbox, Result, UninitializedSandbox, log_then_return, new_error};
 
 /// The implementation for evolving `UninitializedSandbox`es to
 /// `Sandbox`es.
@@ -256,8 +256,8 @@ mod tests {
     use hyperlight_testing::{callback_guest_as_string, simple_guest_as_string};
 
     use super::evolve_impl_multi_use;
-    use crate::sandbox::uninitialized::GuestBinary;
     use crate::UninitializedSandbox;
+    use crate::sandbox::uninitialized::GuestBinary;
 
     #[test]
     fn test_evolve() {

--- a/src/hyperlight_host/src/sandbox_state/sandbox.rs
+++ b/src/hyperlight_host/src/sandbox_state/sandbox.rs
@@ -16,10 +16,10 @@ limitations under the License.
 
 use std::fmt::Debug;
 
-use tracing::{instrument, Span};
+use tracing::{Span, instrument};
 
 use super::transition::TransitionMetadata;
-use crate::{new_error, Result};
+use crate::{Result, new_error};
 
 /// The minimal functionality of a Hyperlight sandbox. Most of the types
 /// and operations within this crate require `Sandbox` implementations.

--- a/src/hyperlight_host/src/sandbox_state/transition.rs
+++ b/src/hyperlight_host/src/sandbox_state/transition.rs
@@ -16,11 +16,11 @@ limitations under the License.
 
 use std::marker::PhantomData;
 
-use tracing::{instrument, Span};
+use tracing::{Span, instrument};
 
 use super::sandbox::Sandbox;
-use crate::func::call_ctx::MultiUseGuestCallContext;
 use crate::Result;
+use crate::func::call_ctx::MultiUseGuestCallContext;
 
 /// Metadata about an evolution or devolution. Any `Sandbox` implementation
 /// that also implements `EvolvableSandbox` or `DevolvableSandbox`
@@ -143,8 +143,8 @@ where
 #[cfg(test)]
 mod tests {
     use super::Noop;
-    use crate::sandbox_state::sandbox::{DevolvableSandbox, EvolvableSandbox, Sandbox};
     use crate::Result;
+    use crate::sandbox_state::sandbox::{DevolvableSandbox, EvolvableSandbox, Sandbox};
 
     #[derive(Debug, Eq, PartialEq, Clone)]
     struct MySandbox1 {}

--- a/src/hyperlight_host/src/seccomp/guest.rs
+++ b/src/hyperlight_host/src/seccomp/guest.rs
@@ -21,7 +21,7 @@ use seccompiler::{
 };
 
 use crate::sandbox::ExtraAllowedSyscall;
-use crate::{and, or, Result};
+use crate::{Result, and, or};
 
 fn syscalls_allowlist() -> Result<Vec<(i64, Vec<SeccompRule>)>> {
     Ok(vec![

--- a/src/hyperlight_host/src/testing/log_values.rs
+++ b/src/hyperlight_host/src/testing/log_values.rs
@@ -16,7 +16,7 @@ limitations under the License.
 
 use serde_json::{Map, Value};
 
-use crate::{new_error, Result};
+use crate::{Result, new_error};
 
 /// Call `check_value_as_str` and panic if it returned an `Err`. Otherwise,
 /// do nothing.

--- a/src/hyperlight_host/src/testing/mod.rs
+++ b/src/hyperlight_host/src/testing/mod.rs
@@ -20,7 +20,7 @@ use std::path::PathBuf;
 use hyperlight_testing::rust_guest_as_pathbuf;
 
 use crate::mem::exe::ExeInfo;
-use crate::{new_error, Result};
+use crate::{Result, new_error};
 pub(crate) mod log_values;
 
 /// Get an `ExeInfo` representing `simpleguest.exe`

--- a/src/hyperlight_host/tests/integration_test.rs
+++ b/src/hyperlight_host/tests/integration_test.rs
@@ -25,7 +25,7 @@ use hyperlight_host::sandbox::SandboxConfiguration;
 use hyperlight_host::sandbox_state::sandbox::EvolvableSandbox;
 use hyperlight_host::sandbox_state::transition::Noop;
 use hyperlight_host::{GuestBinary, HyperlightError, MultiUseSandbox, UninitializedSandbox};
-use hyperlight_testing::simplelogger::{SimpleLogger, LOGGER};
+use hyperlight_testing::simplelogger::{LOGGER, SimpleLogger};
 use hyperlight_testing::{
     c_simple_guest_as_string, callback_guest_as_string, simple_guest_as_string,
 };

--- a/src/hyperlight_host/tests/sandbox_host_tests.rs
+++ b/src/hyperlight_host/tests/sandbox_host_tests.rs
@@ -23,7 +23,7 @@ use hyperlight_host::sandbox::SandboxConfiguration;
 use hyperlight_host::sandbox_state::sandbox::EvolvableSandbox;
 use hyperlight_host::sandbox_state::transition::Noop;
 use hyperlight_host::{
-    new_error, GuestBinary, HyperlightError, MultiUseSandbox, Result, UninitializedSandbox,
+    GuestBinary, HyperlightError, MultiUseSandbox, Result, UninitializedSandbox, new_error,
 };
 use hyperlight_testing::simple_guest_as_string;
 #[cfg(target_os = "windows")]
@@ -289,11 +289,13 @@ fn simple_test_helper() -> Result<()> {
         expected_calls
     );
 
-    assert!(messages
-        .try_lock()
-        .map_err(|e| new_error!("Error locking at {}:{}: {}", file!(), line!(), e))?
-        .iter()
-        .all(|msg| msg == message));
+    assert!(
+        messages
+            .try_lock()
+            .map_err(|e| new_error!("Error locking at {}:{}: {}", file!(), line!(), e))?
+            .iter()
+            .all(|msg| msg == message)
+    );
     Ok(())
 }
 

--- a/src/hyperlight_testing/src/lib.rs
+++ b/src/hyperlight_testing/src/lib.rs
@@ -19,7 +19,7 @@ limitations under the License.
 use std::env;
 use std::path::PathBuf;
 
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 
 pub const MANIFEST_DIR: &str = env!("CARGO_MANIFEST_DIR");
 pub mod logger;

--- a/src/hyperlight_testing/src/logger.rs
+++ b/src/hyperlight_testing/src/logger.rs
@@ -18,7 +18,7 @@ use std::cell::RefCell;
 use std::sync::Once;
 use std::thread::current;
 
-use log::{set_logger, set_max_level, Level, LevelFilter, Log, Metadata, Record};
+use log::{Level, LevelFilter, Log, Metadata, Record, set_logger, set_max_level};
 use once_cell::sync::Lazy;
 use tracing_log::LogTracer;
 

--- a/src/hyperlight_testing/src/simplelogger.rs
+++ b/src/hyperlight_testing/src/simplelogger.rs
@@ -21,7 +21,7 @@ limitations under the License.
 use std::sync::Once;
 use std::thread::current;
 
-use log::{set_logger, set_max_level, Level, Log, Metadata, Record};
+use log::{Level, Log, Metadata, Record, set_logger, set_max_level};
 
 pub static LOGGER: SimpleLogger = SimpleLogger {};
 static INITLOGGER: Once = Once::new();

--- a/src/hyperlight_testing/src/tracing_subscriber.rs
+++ b/src/hyperlight_testing/src/tracing_subscriber.rs
@@ -17,7 +17,7 @@ limitations under the License.
 use std::cell::RefCell;
 use std::collections::HashMap;
 
-use serde_json::{json, to_string_pretty, Value};
+use serde_json::{Value, json, to_string_pretty};
 use tracing::Subscriber;
 use tracing_core::event::Event;
 use tracing_core::metadata::Metadata;

--- a/src/tests/rust_guests/simpleguest/src/main.rs
+++ b/src/tests/rust_guests/simpleguest/src/main.rs
@@ -49,8 +49,8 @@ use hyperlight_guest_bin::host_comm::{
     call_host_function, call_host_function_without_returning_result,
 };
 use hyperlight_guest_bin::memory::malloc;
-use hyperlight_guest_bin::{guest_logger, MIN_STACK_ADDRESS};
-use log::{error, LevelFilter};
+use hyperlight_guest_bin::{MIN_STACK_ADDRESS, guest_logger};
+use log::{LevelFilter, error};
 
 extern crate hyperlight_guest;
 
@@ -358,7 +358,10 @@ fn print_ten_args(function_call: &FunctionCall) -> Result<Vec<u8>> {
         function_call.parameters.clone().unwrap()[8].clone(),
         function_call.parameters.clone().unwrap()[9].clone(),
     ) {
-        let message = format!("Message: arg1:{} arg2:{} arg3:{} arg4:{} arg5:{} arg6:{} arg7:{} arg8:{} arg9:{} arg10:{}.", arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10);
+        let message = format!(
+            "Message: arg1:{} arg2:{} arg3:{} arg4:{} arg5:{} arg6:{} arg7:{} arg8:{} arg9:{} arg10:{}.",
+            arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10
+        );
         print_output(&message)
     } else {
         Err(HyperlightGuestError::new(
@@ -394,7 +397,10 @@ fn print_eleven_args(function_call: &FunctionCall) -> Result<Vec<u8>> {
         function_call.parameters.clone().unwrap()[9].clone(),
         function_call.parameters.clone().unwrap()[10].clone(),
     ) {
-        let message = format!("Message: arg1:{} arg2:{} arg3:{} arg4:{} arg5:{} arg6:{} arg7:{} arg8:{} arg9:{} arg10:{} arg11:{:.3}.", arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11);
+        let message = format!(
+            "Message: arg1:{} arg2:{} arg3:{} arg4:{} arg5:{} arg6:{} arg7:{} arg8:{} arg9:{} arg10:{} arg11:{:.3}.",
+            arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11
+        );
         print_output(&message)
     } else {
         Err(HyperlightGuestError::new(
@@ -1190,7 +1196,7 @@ fn fuzz_host_function(func: FunctionCall) -> Result<Vec<u8>> {
             return Err(HyperlightGuestError::new(
                 ErrorCode::GuestFunctionParameterTypeMismatch,
                 "Invalid parameters passed to fuzz_host_function".to_string(),
-            ))
+            ));
         }
     };
 


### PR DESCRIPTION
Sets the `style_edition` to 2024 in the `rustfmt.toml` file and reformats the code accordingly.

Closes #537 