### PR TITLE
Remove support for building PE files from hyperlight-guest-bin build.rs

### DIFF
--- a/src/hyperlight_guest_bin/.cargo/config.toml
+++ b/src/hyperlight_guest_bin/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+target = "x86_64-unknown-none"


### PR DESCRIPTION
This pull request simplifies the build process for the `hyperlight_guest_bin` by removing support for Windows-specific tools and configurations since we no longer support PE guests. 