### PR TITLE
Remove version number from hyperlight-testing crate dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ hyperlight-common = { path = "src/hyperlight_common", version = "0.6.0", default
 hyperlight-host = { path = "src/hyperlight_host", version = "0.6.0", default-features = false }
 hyperlight-guest = { path = "src/hyperlight_guest", version = "0.6.0", default-features = false }
 hyperlight-guest-bin = { path = "src/hyperlight_guest_bin", version = "0.6.0", default-features = false }
-hyperlight-testing = { path = "src/hyperlight_testing", version = "0.6.0", default-features = false }
+hyperlight-testing = { path = "src/hyperlight_testing", default-features = false }
 hyperlight-component-util = { path = "src/hyperlight_component_util", version = "0.6.0", default-features = false }
 hyperlight-component-macro = { path = "src/hyperlight_component_macro", version = "0.6.0", default-features = false }
 

--- a/src/hyperlight_testing/Cargo.toml
+++ b/src/hyperlight_testing/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "hyperlight-testing"
-version.workspace = true
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
In #580 a version number was adding to the hyperlight-testing dependency. This caused the Cargo pubish job for the last release to [fail](https://github.com/hyperlight-dev/hyperlight/actions/runs/15502276649/job/43652946703).

This PR removes the version number so we don't have to publish the hyperlight-testing crate