### PR TITLE
cargo: fix hyperlight_testing Cargo.lock version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1280,7 +1280,7 @@ dependencies = [
 
 [[package]]
 name = "hyperlight-testing"
-version = "0.6.0"
+version = "0.0.0"
 dependencies = [
  "anyhow",
  "log",


### PR DESCRIPTION
When checking out the latest `main` branch, the hyperlight_testing version in `Cargo.lock` is automatically changed.