### PR TITLE
Allow hyperlight-host to build with x86_64-unknown-linux-musl target

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -24,7 +24,12 @@ alias cg := build-and-move-c-guests
 
 # build host library
 build target=default-target:
-    cargo build --profile={{ if target == "debug" { "dev" } else { target } }}
+    cargo build --profile={{ if target == "debug" { "dev" } else { target } }} 
+
+# build host library
+build-with-musl-libc target=default-target:
+    cargo build --profile={{ if target == "debug" { "dev" } else { target } }} --target x86_64-unknown-linux-musl
+
 
 # build testing guest binaries
 guests: build-and-move-rust-guests build-and-move-c-guests

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,4 +2,4 @@
 channel = "1.85"
 # Target used for guest binaries. This is an additive list of targets in addition to host platform.
 # Will install the target if not already installed when building guest binaries.
-targets = ["x86_64-unknown-none"]
+targets = ["x86_64-unknown-none", "x86_64-unknown-linux-musl"]

--- a/src/hyperlight_host/src/hypervisor/hyperv_linux.rs
+++ b/src/hyperlight_host/src/hypervisor/hyperv_linux.rs
@@ -405,6 +405,19 @@ impl HypervLinuxDriver {
             interrupt_handle: Arc::new(LinuxInterruptHandle {
                 running: AtomicU64::new(0),
                 cancel_requested: AtomicBool::new(false),
+                #[cfg(all(
+                    target_arch = "x86_64",
+                    target_vendor = "unknown",
+                    target_os = "linux",
+                    target_env = "musl"
+                ))]
+                tid: AtomicU64::new(unsafe { libc::pthread_self() as u64 }),
+                #[cfg(not(all(
+                    target_arch = "x86_64",
+                    target_vendor = "unknown",
+                    target_os = "linux",
+                    target_env = "musl"
+                )))]
                 tid: AtomicU64::new(unsafe { libc::pthread_self() }),
                 retry_delay: config.get_interrupt_retry_delay(),
                 sig_rt_min_offset: config.get_interrupt_vcpu_sigrtmin_offset(),

--- a/src/hyperlight_host/src/hypervisor/kvm.rs
+++ b/src/hyperlight_host/src/hypervisor/kvm.rs
@@ -360,6 +360,19 @@ impl KVMDriver {
             interrupt_handle: Arc::new(LinuxInterruptHandle {
                 running: AtomicU64::new(0),
                 cancel_requested: AtomicBool::new(false),
+                #[cfg(all(
+                    target_arch = "x86_64",
+                    target_vendor = "unknown",
+                    target_os = "linux",
+                    target_env = "musl"
+                ))]
+                tid: AtomicU64::new(unsafe { libc::pthread_self() as u64 }),
+                #[cfg(not(all(
+                    target_arch = "x86_64",
+                    target_vendor = "unknown",
+                    target_os = "linux",
+                    target_env = "musl"
+                )))]
                 tid: AtomicU64::new(unsafe { libc::pthread_self() }),
                 retry_delay: config.get_interrupt_retry_delay(),
                 dropped: AtomicBool::new(false),

--- a/src/hyperlight_host/src/seccomp/guest.rs
+++ b/src/hyperlight_host/src/seccomp/guest.rs
@@ -49,7 +49,25 @@ fn syscalls_allowlist() -> Result<Vec<(i64, Vec<SeccompRule>)>> {
         // because we don't currently support registering parameterized syscalls.
         (
             libc::SYS_ioctl,
-            or![and![Cond::new(1, ArgLen::Dword, Eq, libc::TCGETS)?]],
+            or![and![Cond::new(
+                1,
+                ArgLen::Dword,
+                Eq,
+                #[cfg(all(
+                    target_arch = "x86_64",
+                    target_vendor = "unknown",
+                    target_os = "linux",
+                    target_env = "musl"
+                ))]
+                libc::TCGETS.try_into()?,
+                #[cfg(not(all(
+                    target_arch = "x86_64",
+                    target_vendor = "unknown",
+                    target_os = "linux",
+                    target_env = "musl"
+                )))]
+                libc::TCGETS,
+            )?]],
         ),
         // `futex` is needed for some tests that run in parallel (`simple_test_parallel`,
         // and `callback_test_parallel`).


### PR DESCRIPTION
This pull request introduces support for building with the `musl` libc target, updates syscall handling for compatibility, and adds conditional compilation for thread ID initialization. Below is a summary of the most important changes:

### Build System Enhancements:
* Added a new `build-with-musl-libc` target in the `Justfile` to enable building with the `musl` libc target (`x86_64-unknown-linux-musl`). This includes adding the required Rust target and building with the appropriate profile.

### Conditional Compilation for `musl`:
* Updated the `LinuxInterruptHandle` initialization in `HypervLinuxDriver` to conditionally define the `tid` field based on whether the target is `musl` or not. This ensures compatibility with the `musl` libc environment.
* Applied the same conditional logic for the `tid` field in the `KVMDriver` to maintain consistency across hypervisor implementations.

### Syscall Handling:
* Modified the `syscalls_allowlist` function to use `try_into()` for converting `libc::TCGETS` to ensure type safety and compatibility with stricter environments.