### PR TITLE
Added capability to load extra blob data in sandbox

### DIFF
--- a/src/hyperlight_common/src/mem.rs
+++ b/src/hyperlight_common/src/mem.rs
@@ -46,6 +46,7 @@ pub struct HyperlightPEB {
     pub code_ptr: u64,
     pub input_stack: GuestMemoryRegion,
     pub output_stack: GuestMemoryRegion,
+    pub init_data: GuestMemoryRegion,
     pub guest_heap: GuestMemoryRegion,
     pub guest_stack: GuestStack,
     pub host_function_definitions: GuestMemoryRegion,

--- a/src/hyperlight_guest_bin/src/host_comm.rs
+++ b/src/hyperlight_guest_bin/src/host_comm.rs
@@ -65,6 +65,11 @@ pub fn get_host_function_details() -> HostFunctionDetails {
     handle.get_host_function_details()
 }
 
+pub fn read_n_bytes_from_user_memory(num: u64) -> Result<Vec<u8>> {
+    let handle = unsafe { GUEST_HANDLE };
+    handle.read_n_bytes_from_user_memory(num)
+}
+
 /// Print a message using the host's print function.
 ///
 /// This function requires memory to be setup to be used. In particular, the

--- a/src/hyperlight_host/src/mem/memory_region.rs
+++ b/src/hyperlight_host/src/mem/memory_region.rs
@@ -43,6 +43,10 @@ use mshv_bindings::{hv_x64_memory_intercept_message, mshv_user_mem_region};
 #[cfg(target_os = "windows")]
 use windows::Win32::System::Hypervisor::{self, WHV_MEMORY_ACCESS_TYPE};
 
+use super::mgr::{PAGE_NX, PAGE_PRESENT, PAGE_RW, PAGE_USER};
+
+pub(crate) const DEFAULT_GUEST_BLOB_MEM_FLAGS: MemoryRegionFlags = MemoryRegionFlags::READ;
+
 bitflags! {
     /// flags representing memory permission for a memory region
     #[derive(Copy, Clone, Debug, PartialEq, Eq)]
@@ -57,6 +61,30 @@ bitflags! {
         const EXECUTE = 4;
         /// identifier that this is a stack guard page
         const STACK_GUARD = 8;
+    }
+}
+
+impl MemoryRegionFlags {
+    pub(crate) fn translate_flags(&self) -> u64 {
+        let mut page_flags = 0;
+
+        page_flags |= PAGE_PRESENT; // Mark page as present
+
+        if self.contains(MemoryRegionFlags::WRITE) {
+            page_flags |= PAGE_RW; // Allow read/write
+        }
+
+        if self.contains(MemoryRegionFlags::STACK_GUARD) {
+            page_flags |= PAGE_RW; // The guard page is marked RW so that if it gets written to we can detect it in the host
+        }
+
+        if self.contains(MemoryRegionFlags::EXECUTE) {
+            page_flags |= PAGE_USER; // Allow user access
+        } else {
+            page_flags |= PAGE_NX; // Mark as non-executable if EXECUTE is not set
+        }
+
+        page_flags
     }
 }
 
@@ -129,6 +157,8 @@ pub enum MemoryRegionType {
     PageTables,
     /// The region contains the guest's code
     Code,
+    /// The region contains the guest's init data
+    InitData,
     /// The region contains the PEB
     Peb,
     /// The region contains the Host Function Definitions

--- a/src/hyperlight_host/src/sandbox/mem_mgr.rs
+++ b/src/hyperlight_host/src/sandbox/mem_mgr.rs
@@ -98,6 +98,15 @@ impl MemMgrWrapper<ExclusiveSharedMemory> {
         let mem_size = shared_mem.mem_size();
         layout.write(shared_mem, SandboxMemoryLayout::BASE_ADDRESS, mem_size)
     }
+
+    #[instrument(err(Debug), skip_all, parent = Span::current(), level= "Trace")]
+    pub(super) fn write_init_data(&mut self, user_memory: &[u8]) -> Result<()> {
+        let mgr = self.unwrap_mgr_mut();
+        let layout = mgr.layout;
+        let shared_mem = mgr.get_shared_mem_mut();
+        layout.write_init_data(shared_mem, user_memory)?;
+        Ok(())
+    }
 }
 
 impl MemMgrWrapper<HostSharedMemory> {

--- a/src/hyperlight_host/src/sandbox/outb.rs
+++ b/src/hyperlight_host/src/sandbox/outb.rs
@@ -241,9 +241,12 @@ mod tests {
 
         let new_mgr = || {
             let mut exe_info = simple_guest_exe_info().unwrap();
-            let mut mgr =
-                SandboxMemoryManager::load_guest_binary_into_memory(sandbox_cfg, &mut exe_info)
-                    .unwrap();
+            let mut mgr = SandboxMemoryManager::load_guest_binary_into_memory(
+                sandbox_cfg,
+                &mut exe_info,
+                None,
+            )
+            .unwrap();
             let mem_size = mgr.get_shared_mem_mut().mem_size();
             let layout = mgr.layout;
             let shared_mem = mgr.get_shared_mem_mut();
@@ -353,9 +356,12 @@ mod tests {
         tracing::subscriber::with_default(subscriber.clone(), || {
             let new_mgr = || {
                 let mut exe_info = simple_guest_exe_info().unwrap();
-                let mut mgr =
-                    SandboxMemoryManager::load_guest_binary_into_memory(sandbox_cfg, &mut exe_info)
-                        .unwrap();
+                let mut mgr = SandboxMemoryManager::load_guest_binary_into_memory(
+                    sandbox_cfg,
+                    &mut exe_info,
+                    None,
+                )
+                .unwrap();
                 let mem_size = mgr.get_shared_mem_mut().mem_size();
                 let layout = mgr.layout;
                 let shared_mem = mgr.get_shared_mem_mut();


### PR DESCRIPTION
This PR contains the following changes:
**(1)** Made a non-breaking change to the signature of the `UninitializedSandbox::new(...)` function. Now, instead of a `GuestBinary`, it takes a `GuestEnvironment`, which contains the usual binary + optional blob data.
**(2)** Created new user memory region to store the extra blob data and added some extra config options for it.
**(3)** Added info of the new memory region to the PEB.
**(4)** Added tests verifying added blob data.

Reviewing commit-by-commit might be best 👍 