### PR TITLE
Make OS_PAGE_SIZE public again

### DIFF
--- a/src/hyperlight_guest_bin/src/lib.rs
+++ b/src/hyperlight_guest_bin/src/lib.rs
@@ -63,7 +63,7 @@ pub(crate) static mut REGISTERED_GUEST_FUNCTIONS: GuestFunctionRegister =
 
 pub static mut MIN_STACK_ADDRESS: u64 = 0;
 
-static mut OS_PAGE_SIZE: u32 = 0;
+pub static mut OS_PAGE_SIZE: u32 = 0;
 
 // === Panic Handler ===
 // It looks like rust-analyzer doesn't correctly manage no_std crates,


### PR DESCRIPTION
OS_PAGE_SIZE was made private in 0.6, and we need to use it hyperlight-wasm.
This PR makes it public again.