### PR TITLE
Remove gh cli isntall from GH workflows

### DIFF
--- a/.github/workflows/Benchmarks.yml
+++ b/.github/workflows/Benchmarks.yml
@@ -47,14 +47,6 @@ jobs:
           cp ./downloaded-guest-binaries-release/dummyguest ./src/tests/rust_guests/bin/release/dummyguest
 
       ### Benchmarks ###
-      - name: Install github-cli (Linux mariner)
-        if: runner.os == 'Linux' && matrix.hypervisor == 'hyperv'
-        run: sudo dnf install gh -y
-
-      - name: Install github-cli (Linux ubuntu)
-        if: runner.os == 'Linux' && matrix.hypervisor == 'kvm'
-        run: sudo apt install gh -y
-
       - name: Fetch tags
         run: git fetch --tags origin
 

--- a/.github/workflows/dep_rust.yml
+++ b/.github/workflows/dep_rust.yml
@@ -142,15 +142,6 @@ jobs:
           RUST_LOG: debug
         run: just test-rust-crashdump ${{ matrix.config }} ${{ matrix.hypervisor == 'mshv3' && 'mshv3' || ''}}
 
-      ### Benchmarks ###
-      - name: Install github-cli (Linux mariner)
-        if: runner.os == 'Linux' && matrix.hypervisor == 'mshv'
-        run: sudo dnf install gh -y
-
-      - name: Install github-cli (Linux ubuntu)
-        if: runner.os == 'Linux' && matrix.hypervisor == 'kvm'
-        run: sudo apt install gh -y
-
       - name: Download benchmarks from "latest"
         run: just bench-download ${{ runner.os }} ${{ matrix.hypervisor }} ${{ matrix.cpu}} dev-latest # compare to prerelease
         env:


### PR DESCRIPTION
This is not required as its already installed on agents