### PR TITLE
Remove duplicate derive Clone in macro

### DIFF
--- a/src/hyperlight_component_macro/src/lib.rs
+++ b/src/hyperlight_component_macro/src/lib.rs
@@ -65,7 +65,7 @@ use hyperlight_component_util::*;
 /// Hyperlight.
 #[proc_macro]
 pub fn host_bindgen(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
-    env_logger::init();
+    let _ = env_logger::try_init();
     let path: Option<syn::LitStr> = syn::parse_macro_input!(input as Option<syn::LitStr>);
     let path = path
         .map(|x| x.value().into())
@@ -88,7 +88,7 @@ pub fn host_bindgen(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
 /// into the Hyperlight host).
 #[proc_macro]
 pub fn guest_bindgen(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
-    env_logger::init();
+    let _ = env_logger::try_init();
     let path: Option<syn::LitStr> = syn::parse_macro_input!(input as Option<syn::LitStr>);
     let path = path
         .map(|x| x.value().into())

--- a/src/hyperlight_component_util/src/rtypes.rs
+++ b/src/hyperlight_component_util/src/rtypes.rs
@@ -471,7 +471,6 @@ fn emit_value_toplevel(s: &mut State, v: Option<u32>, id: Ident, vt: &Value) -> 
                     #[derive(::wasmtime::component::ComponentType)]
                     #[derive(::wasmtime::component::Lift)]
                     #[derive(::wasmtime::component::Lower)]
-                    #[derive(::core::clone::Clone)]
                     #[derive(::core::marker::Copy)]
                     #[component(enum)]
                     #[repr(u8)] // todo: should this always be u8?

--- a/src/tests/rust_guests/callbackguest/Cargo.lock
+++ b/src/tests/rust_guests/callbackguest/Cargo.lock
@@ -71,7 +71,7 @@ checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
 name = "hyperlight-common"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "flatbuffers",
@@ -81,7 +81,7 @@ dependencies = [
 
 [[package]]
 name = "hyperlight-guest"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "hyperlight-common",
@@ -90,7 +90,7 @@ dependencies = [
 
 [[package]]
 name = "hyperlight-guest-bin"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "buddy_system_allocator",
  "cc",

--- a/src/tests/rust_guests/simpleguest/Cargo.lock
+++ b/src/tests/rust_guests/simpleguest/Cargo.lock
@@ -62,7 +62,7 @@ checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
 name = "hyperlight-common"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "flatbuffers",
@@ -72,7 +72,7 @@ dependencies = [
 
 [[package]]
 name = "hyperlight-guest"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "hyperlight-common",
@@ -81,7 +81,7 @@ dependencies = [
 
 [[package]]
 name = "hyperlight-guest-bin"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "buddy_system_allocator",
  "cc",


### PR DESCRIPTION
This PR removes a duplicated `derive(Clone)` in `hyperlight-component-util` that result in a compilation error when using the `wasm_guest_bindgen` macro from `hyperlight-wasm`.

Clone is already being derived in L. 483