### PR TITLE
make socket component example work

### DIFF
--- a/src/hyperlight_component_util/src/rtypes.rs
+++ b/src/hyperlight_component_util/src/rtypes.rs
@@ -386,7 +386,7 @@ fn emit_value_toplevel(s: &mut State, v: Option<u32>, id: Ident, vt: &Value) -> 
             };
             quote! {
                 #derives
-                #[derive(Debug, Clone, PartialEq)]
+                #[derive(Debug)]
                 pub struct #id #vs { #toks }
             }
         }
@@ -444,7 +444,7 @@ fn emit_value_toplevel(s: &mut State, v: Option<u32>, id: Ident, vt: &Value) -> 
             };
             quote! {
                 #derives
-                #[derive(Debug, Clone, PartialEq)]
+                #[derive(Debug)]
                 pub enum #id #vs { #toks }
             }
         }
@@ -471,7 +471,6 @@ fn emit_value_toplevel(s: &mut State, v: Option<u32>, id: Ident, vt: &Value) -> 
                     #[derive(::wasmtime::component::ComponentType)]
                     #[derive(::wasmtime::component::Lift)]
                     #[derive(::wasmtime::component::Lower)]
-                    #[derive(::core::marker::Copy)]
                     #[component(enum)]
                     #[repr(u8)] // todo: should this always be u8?
                 }
@@ -480,7 +479,7 @@ fn emit_value_toplevel(s: &mut State, v: Option<u32>, id: Ident, vt: &Value) -> 
             };
             quote! {
                 #derives
-                #[derive(Debug, Clone, PartialEq)]
+                #[derive(Debug, Copy, Clone, PartialEq)]
                 pub enum #id #vs { #toks }
             }
         }

--- a/src/hyperlight_host/tests/wit_test.rs
+++ b/src/hyperlight_host/tests/wit_test.rs
@@ -26,7 +26,44 @@ mod bindings {
     hyperlight_component_macro::host_bindgen!("../tests/rust_guests/witguest/interface.wasm");
 }
 
+use bindings::test::wit::roundtrip::{Testrecord, Testvariant};
 use bindings::*;
+
+impl PartialEq for Testrecord {
+    fn eq(&self, other: &Self) -> bool {
+        self.contents == other.contents && self.length == other.length
+    }
+}
+
+impl PartialEq for Testvariant {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Testvariant::VariantA, Testvariant::VariantA) => true,
+            (Testvariant::VariantB(s1), Testvariant::VariantB(s2)) => s1 == s2,
+            (Testvariant::VariantC(c1), Testvariant::VariantC(c2)) => c1 == c2,
+            _ => false,
+        }
+    }
+}
+
+impl Clone for Testrecord {
+    fn clone(&self) -> Self {
+        Self {
+            contents: self.contents.clone(),
+            length: self.length,
+        }
+    }
+}
+
+impl Clone for Testvariant {
+    fn clone(&self) -> Self {
+        match self {
+            Self::VariantA => Self::VariantA,
+            Self::VariantB(s) => Self::VariantB(s.clone()),
+            Self::VariantC(c) => Self::VariantC(*c),
+        }
+    }
+}
 
 struct Host {}
 

--- a/src/tests/rust_guests/witguest/Cargo.lock
+++ b/src/tests/rust_guests/witguest/Cargo.lock
@@ -178,7 +178,7 @@ dependencies = [
 
 [[package]]
 name = "hyperlight-common"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "flatbuffers",
@@ -188,7 +188,7 @@ dependencies = [
 
 [[package]]
 name = "hyperlight-component-macro"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "env_logger",
  "hyperlight-component-util",
@@ -202,7 +202,7 @@ dependencies = [
 
 [[package]]
 name = "hyperlight-component-util"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "itertools",
  "log",
@@ -215,7 +215,7 @@ dependencies = [
 
 [[package]]
 name = "hyperlight-guest"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "hyperlight-common",
@@ -224,7 +224,7 @@ dependencies = [
 
 [[package]]
 name = "hyperlight-guest-bin"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "buddy_system_allocator",
  "cc",
@@ -337,9 +337,9 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.33"
+version = "0.2.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dee91521343f4c5c6a63edd65e54f31f5c92fe8978c40a4282f8372194c6a7d"
+checksum = "6837b9e10d61f45f987d50808f83d1ee3d206c66acf650c3e4ae2e1f6ddedf55"
 dependencies = [
  "proc-macro2",
  "syn",
@@ -477,9 +477,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.102"
+version = "2.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6397daf94fa90f058bd0fd88429dd9e5738999cca8d701813c80723add80462"
+checksum = "e4307e30089d6fd6aff212f2da3a1f9e32f3223b1f010fb09b7c95f90f3ca1e8"
 dependencies = [
  "proc-macro2",
  "quote",


### PR DESCRIPTION
This PR removes the `Clone` and `PartialEq` requirement from `variant` and `record` wit types.
This change makes the `hyperlight-wasm-sockets-example` example work.
