### PR TITLE
Allow hyperlight_guest_bin to compile with windows target.

### DIFF
--- a/src/hyperlight_guest_bin/third_party/musl/src/setjmp/x86_64/longjmp.s
+++ b/src/hyperlight_guest_bin/third_party/musl/src/setjmp/x86_64/longjmp.s
@@ -1,8 +1,6 @@
 /* Copyright 2011-2012 Nicholas J. Kain, licensed under standard MIT license */
 .global _longjmp
 .global longjmp
-.type _longjmp,@function
-.type longjmp,@function
 _longjmp:
 longjmp:
 	xor %eax,%eax

--- a/src/hyperlight_guest_bin/third_party/musl/src/setjmp/x86_64/setjmp.s
+++ b/src/hyperlight_guest_bin/third_party/musl/src/setjmp/x86_64/setjmp.s
@@ -2,9 +2,6 @@
 .global __setjmp
 .global _setjmp
 .global setjmp
-.type __setjmp,@function
-.type _setjmp,@function
-.type setjmp,@function
 __setjmp:
 _setjmp:
 setjmp:


### PR DESCRIPTION
`.type x,@function` directives are unsupported on windows toolchain and assembler.

Patch similar to this one has been done before https://github.com/hyperlight-dev/hyperlight/pull/104/commits/42ee008bb0df9f4ce5d380f1eafa79e61a2233c8, but was not applied when setjmp was brought back in https://github.com/hyperlight-dev/hyperlight/pull/499

This was never caught before because hyperlight_guest_bin is used with a windows toolchain. I only noticed it because rust-analyzer complains when I use my windows machine.
