### PR TITLE
[host] adds init-paging feature

### DIFF
--- a/src/hyperlight_host/Cargo.toml
+++ b/src/hyperlight_host/Cargo.toml
@@ -119,7 +119,7 @@ cfg_aliases = "0.2.1"
 built = { version = "0.8.0", optional = true, features = ["chrono", "git2"] }
 
 [features]
-default = ["kvm", "mshv2", "seccomp", "build-metadata"]
+default = ["kvm", "mshv2", "seccomp", "build-metadata", "init-paging"]
 seccomp = ["dep:seccompiler"]
 function_call_metrics = []
 executable_heap = []
@@ -134,6 +134,7 @@ mshv3 = ["dep:mshv-bindings3", "dep:mshv-ioctls3"]
 gdb = ["dep:gdbstub", "dep:gdbstub_arch"]
 fuzzing = ["hyperlight-common/fuzzing"]
 build-metadata = ["dep:built"]
+init-paging = []
 
 [[bench]]
 name = "benchmarks"

--- a/src/hyperlight_host/src/hypervisor/kvm.rs
+++ b/src/hyperlight_host/src/hypervisor/kvm.rs
@@ -35,11 +35,12 @@ use super::gdb::{DebugCommChannel, DebugMsg, DebugResponse, GuestDebug, KvmDebug
 #[cfg(gdb)]
 use super::handlers::DbgMemAccessHandlerWrapper;
 use super::handlers::{MemAccessHandlerWrapper, OutBHandlerWrapper};
+#[cfg(feature = "init-paging")]
 use super::{
     CR0_AM, CR0_ET, CR0_MP, CR0_NE, CR0_PE, CR0_PG, CR0_WP, CR4_OSFXSR, CR4_OSXMMEXCPT, CR4_PAE,
-    EFER_LMA, EFER_LME, EFER_NX, EFER_SCE, HyperlightExit, Hypervisor, InterruptHandle,
-    LinuxInterruptHandle, VirtualCPU,
+    EFER_LMA, EFER_LME, EFER_NX, EFER_SCE,
 };
+use super::{HyperlightExit, Hypervisor, InterruptHandle, LinuxInterruptHandle, VirtualCPU};
 #[cfg(gdb)]
 use crate::HyperlightError;
 use crate::mem::memory_region::{MemoryRegion, MemoryRegionFlags};
@@ -390,14 +391,21 @@ impl KVMDriver {
     }
 
     #[instrument(err(Debug), skip_all, parent = Span::current(), level = "Trace")]
-    fn setup_initial_sregs(vcpu_fd: &mut VcpuFd, pml4_addr: u64) -> Result<()> {
+    fn setup_initial_sregs(vcpu_fd: &mut VcpuFd, _pml4_addr: u64) -> Result<()> {
         // setup paging and IA-32e (64-bit) mode
         let mut sregs = vcpu_fd.get_sregs()?;
-        sregs.cr3 = pml4_addr;
-        sregs.cr4 = CR4_PAE | CR4_OSFXSR | CR4_OSXMMEXCPT;
-        sregs.cr0 = CR0_PE | CR0_MP | CR0_ET | CR0_NE | CR0_AM | CR0_PG | CR0_WP;
-        sregs.efer = EFER_LME | EFER_LMA | EFER_SCE | EFER_NX;
-        sregs.cs.l = 1; // required for 64-bit mode
+        cfg_if::cfg_if! {
+            if #[cfg(feature = "init-paging")] {
+                sregs.cr3 = _pml4_addr;
+                sregs.cr4 = CR4_PAE | CR4_OSFXSR | CR4_OSXMMEXCPT;
+                sregs.cr0 = CR0_PE | CR0_MP | CR0_ET | CR0_NE | CR0_AM | CR0_PG | CR0_WP;
+                sregs.efer = EFER_LME | EFER_LMA | EFER_SCE | EFER_NX;
+                sregs.cs.l = 1; // required for 64-bit mode
+            } else {
+                sregs.cs.base = 0;
+                sregs.cs.selector = 0;
+            }
+        }
         vcpu_fd.set_sregs(&sregs)?;
         Ok(())
     }

--- a/src/hyperlight_host/src/hypervisor/mod.rs
+++ b/src/hyperlight_host/src/hypervisor/mod.rs
@@ -75,20 +75,24 @@ use self::handlers::{
 };
 use crate::mem::ptr::RawPtr;
 
-pub(crate) const CR4_PAE: u64 = 1 << 5;
-pub(crate) const CR4_OSFXSR: u64 = 1 << 9;
-pub(crate) const CR4_OSXMMEXCPT: u64 = 1 << 10;
-pub(crate) const CR0_PE: u64 = 1;
-pub(crate) const CR0_MP: u64 = 1 << 1;
-pub(crate) const CR0_ET: u64 = 1 << 4;
-pub(crate) const CR0_NE: u64 = 1 << 5;
-pub(crate) const CR0_WP: u64 = 1 << 16;
-pub(crate) const CR0_AM: u64 = 1 << 18;
-pub(crate) const CR0_PG: u64 = 1 << 31;
-pub(crate) const EFER_LME: u64 = 1 << 8;
-pub(crate) const EFER_LMA: u64 = 1 << 10;
-pub(crate) const EFER_SCE: u64 = 1;
-pub(crate) const EFER_NX: u64 = 1 << 11;
+cfg_if::cfg_if! {
+    if #[cfg(feature = "init-paging")] {
+        pub(crate) const CR4_PAE: u64 = 1 << 5;
+        pub(crate) const CR4_OSFXSR: u64 = 1 << 9;
+        pub(crate) const CR4_OSXMMEXCPT: u64 = 1 << 10;
+        pub(crate) const CR0_PE: u64 = 1;
+        pub(crate) const CR0_MP: u64 = 1 << 1;
+        pub(crate) const CR0_ET: u64 = 1 << 4;
+        pub(crate) const CR0_NE: u64 = 1 << 5;
+        pub(crate) const CR0_WP: u64 = 1 << 16;
+        pub(crate) const CR0_AM: u64 = 1 << 18;
+        pub(crate) const CR0_PG: u64 = 1 << 31;
+        pub(crate) const EFER_LME: u64 = 1 << 8;
+        pub(crate) const EFER_LMA: u64 = 1 << 10;
+        pub(crate) const EFER_SCE: u64 = 1;
+        pub(crate) const EFER_NX: u64 = 1 << 11;
+    }
+}
 
 /// These are the generic exit reasons that we can handle from a Hypervisor the Hypervisors run method is responsible for mapping from
 /// the hypervisor specific exit reasons to these generic ones

--- a/src/hyperlight_host/src/mem/elf.rs
+++ b/src/hyperlight_host/src/mem/elf.rs
@@ -19,6 +19,9 @@ use goblin::elf::reloc::{R_AARCH64_NONE, R_AARCH64_RELATIVE};
 #[cfg(target_arch = "x86_64")]
 use goblin::elf::reloc::{R_X86_64_NONE, R_X86_64_RELATIVE};
 use goblin::elf::{Elf, ProgramHeaders, Reloc};
+#[cfg(not(feature = "init-paging"))]
+use goblin::elf32::program_header::PT_LOAD;
+#[cfg(feature = "init-paging")]
 use goblin::elf64::program_header::PT_LOAD;
 
 use crate::{Result, log_then_return, new_error};

--- a/src/hyperlight_host/src/mem/memory_region.rs
+++ b/src/hyperlight_host/src/mem/memory_region.rs
@@ -43,6 +43,7 @@ use mshv_bindings::{hv_x64_memory_intercept_message, mshv_user_mem_region};
 #[cfg(target_os = "windows")]
 use windows::Win32::System::Hypervisor::{self, WHV_MEMORY_ACCESS_TYPE};
 
+#[cfg(feature = "init-paging")]
 use super::mgr::{PAGE_NX, PAGE_PRESENT, PAGE_RW, PAGE_USER};
 
 pub(crate) const DEFAULT_GUEST_BLOB_MEM_FLAGS: MemoryRegionFlags = MemoryRegionFlags::READ;
@@ -65,6 +66,7 @@ bitflags! {
 }
 
 impl MemoryRegionFlags {
+    #[cfg(feature = "init-paging")]
     pub(crate) fn translate_flags(&self) -> u64 {
         let mut page_flags = 0;
 

--- a/src/hyperlight_host/src/mem/mgr.rs
+++ b/src/hyperlight_host/src/mem/mgr.rs
@@ -28,6 +28,7 @@ use tracing::{Span, instrument};
 
 use super::exe::ExeInfo;
 use super::layout::SandboxMemoryLayout;
+#[cfg(feature = "init-paging")]
 use super::memory_region::{DEFAULT_GUEST_BLOB_MEM_FLAGS, MemoryRegion, MemoryRegionType};
 use super::ptr::{GuestPtr, RawPtr};
 use super::ptr_offset::Offset;
@@ -36,21 +37,25 @@ use super::shared_mem_snapshot::SharedMemorySnapshot;
 use crate::HyperlightError::NoMemorySnapshot;
 use crate::sandbox::SandboxConfiguration;
 use crate::sandbox::uninitialized::GuestBlob;
-use crate::{HyperlightError, Result, log_then_return, new_error};
+use crate::{Result, log_then_return, new_error};
 
-/// Paging Flags
-///
-/// See the following links explaining paging, also see paging-development-notes.md in docs:
-///
-/// * Very basic description: https://stackoverflow.com/a/26945892
-/// * More in-depth descriptions: https://wiki.osdev.org/Paging
-pub(crate) const PAGE_PRESENT: u64 = 1; // Page is Present
-pub(crate) const PAGE_RW: u64 = 1 << 1; // Page is Read/Write (if not set page is read only so long as the WP bit in CR0 is set to 1 - which it is in Hyperlight)
-pub(crate) const PAGE_USER: u64 = 1 << 2; // User/Supervisor (if this bit is set then the page is accessible by user mode code)
-pub(crate) const PAGE_NX: u64 = 1 << 63; // Execute Disable (if this bit is set then data in the page cannot be executed)
+cfg_if::cfg_if! {
+    if #[cfg(feature = "init-paging")] {
+        /// Paging Flags
+        ///
+        /// See the following links explaining paging, also see paging-development-notes.md in docs:
+        ///
+        /// * Very basic description: https://stackoverflow.com/a/26945892
+        /// * More in-depth descriptions: https://wiki.osdev.org/Paging
+        pub(crate) const PAGE_PRESENT: u64 = 1; // Page is Present
+        pub(crate) const PAGE_RW: u64 = 1 << 1; // Page is Read/Write (if not set page is read only so long as the WP bit in CR0 is set to 1 - which it is in Hyperlight)
+        pub(crate) const PAGE_USER: u64 = 1 << 2; // User/Supervisor (if this bit is set then the page is accessible by user mode code)
+        pub(crate) const PAGE_NX: u64 = 1 << 63; // Execute Disable (if this bit is set then data in the page cannot be executed)`
+        // The amount of memory that can be mapped per page table
+        pub(super) const AMOUNT_OF_MEMORY_PER_PT: usize = 0x200_000;
+    }
+}
 
-// The amount of memory that can be mapped per page table
-pub(super) const AMOUNT_OF_MEMORY_PER_PT: usize = 0x200_000;
 /// Read/write permissions flag for the 64-bit PDE
 /// The page size for the 64-bit PDE
 /// The size of stack guard cookies
@@ -104,6 +109,7 @@ where
     // TODO: This should perhaps happen earlier and use an
     // ExclusiveSharedMemory from the beginning.
     #[instrument(err(Debug), skip_all, parent = Span::current(), level= "Trace")]
+    #[cfg(feature = "init-paging")]
     pub(crate) fn set_up_shared_memory(
         &mut self,
         mem_size: u64,
@@ -202,13 +208,14 @@ where
                 std::slice::from_raw_parts(pte_buffer.as_ptr() as *const u8, pte_buffer.len() * 8)
             };
             shared_mem.copy_from_slice(pte_bytes, SandboxMemoryLayout::PT_OFFSET)?;
-            Ok::<(), HyperlightError>(())
+            Ok::<(), crate::HyperlightError>(())
         })??;
 
         Ok(rsp)
     }
 
     /// Optimized page flags getter that maintains state for sequential access patterns
+    #[cfg(feature = "init-paging")]
     fn get_page_flags(
         p: usize,
         i: usize,


### PR DESCRIPTION
This is an extra feature flag that allows disabling our paging setup (when removed). This is needed to further enable custom guests and should not impact any of our current workloads. init-paging is on by default.