### PR TITLE
Don't log expected error on each guest function call

### DIFF
--- a/src/hyperlight_common/src/flatbuffer_wrappers/guest_error.rs
+++ b/src/hyperlight_common/src/flatbuffer_wrappers/guest_error.rs
@@ -196,7 +196,6 @@ impl GuestError {
 
 impl TryFrom<&[u8]> for GuestError {
     type Error = Error;
-    #[cfg_attr(feature = "tracing", instrument(err(Debug), skip_all, parent = Span::current(), level= "Trace"))]
     fn try_from(value: &[u8]) -> Result<Self> {
         let guest_error_fb = size_prefixed_root::<FbGuestError>(value)
             .map_err(|e| anyhow::anyhow!("Error while reading GuestError: {:?}", e))?;

--- a/src/hyperlight_host/src/mem/mgr.rs
+++ b/src/hyperlight_host/src/mem/mgr.rs
@@ -538,7 +538,6 @@ impl SandboxMemoryManager<HostSharedMemory> {
     }
 
     /// Get the guest error data
-    #[instrument(err(Debug), skip_all, parent = Span::current(), level= "Trace")]
     pub(crate) fn get_guest_error(&mut self) -> Result<GuestError> {
         self.shared_mem.try_pop_buffer_into::<GuestError>(
             self.layout.output_data_buffer_offset,

--- a/src/hyperlight_host/src/mem/shared_mem.rs
+++ b/src/hyperlight_host/src/mem/shared_mem.rs
@@ -919,7 +919,6 @@ impl HostSharedMemory {
     /// Pops the given given buffer into a `T` and returns it.
     /// NOTE! the data must be a size-prefixed flatbuffer, and
     /// buffer_start_offset must point to the beginning of the buffer
-    #[instrument(err(Debug), skip_all, parent = Span::current(), level= "Trace")]
     pub fn try_pop_buffer_into<T>(
         &mut self,
         buffer_start_offset: usize,


### PR DESCRIPTION
Currently, 3 error records gets logged for each guest function call, successful or not. This is because the way we check if an error happened is by trying to deserialize a GuestError. If this deserialization fails (which it does in case of a successful guest function call), 3 errors gets logged.  See #497 for more info.

This PR is just a short term fix. We should not rely on this "trying to deserialize an error" for error handling. I'm leaving the linked issue open, so that we can address this properly in the future.