### PR TITLE
gdb: fix issue "Debug not enabled" when `gdb` feature was enabled

### DIFF
--- a/src/hyperlight_host/src/hypervisor/hyperv_linux.rs
+++ b/src/hyperlight_host/src/hypervisor/hyperv_linux.rs
@@ -441,7 +441,9 @@ impl HypervLinuxDriver {
         // Send the interrupt handle to the GDB thread if debugging is enabled
         // This is used to allow the GDB thread to stop the vCPU
         #[cfg(gdb)]
-        hv.send_dbg_msg(DebugResponse::InterruptHandle(interrupt_handle))?;
+        if hv.debug.is_some() {
+            hv.send_dbg_msg(DebugResponse::InterruptHandle(interrupt_handle))?;
+        }
 
         Ok(hv)
     }

--- a/src/hyperlight_host/src/hypervisor/hyperv_windows.rs
+++ b/src/hyperlight_host/src/hypervisor/hyperv_windows.rs
@@ -356,7 +356,9 @@ impl HypervWindowsDriver {
         // Send the interrupt handle to the GDB thread if debugging is enabled
         // This is used to allow the GDB thread to stop the vCPU
         #[cfg(gdb)]
-        hv.send_dbg_msg(DebugResponse::InterruptHandle(interrupt_handle))?;
+        if hv.debug.is_some() {
+            hv.send_dbg_msg(DebugResponse::InterruptHandle(interrupt_handle))?;
+        }
 
         Ok(hv)
     }

--- a/src/hyperlight_host/src/hypervisor/kvm.rs
+++ b/src/hyperlight_host/src/hypervisor/kvm.rs
@@ -395,7 +395,9 @@ impl KVMDriver {
         // Send the interrupt handle to the GDB thread if debugging is enabled
         // This is used to allow the GDB thread to stop the vCPU
         #[cfg(gdb)]
-        hv.send_dbg_msg(DebugResponse::InterruptHandle(interrupt_handle))?;
+        if hv.debug.is_some() {
+            hv.send_dbg_msg(DebugResponse::InterruptHandle(interrupt_handle))?;
+        }
 
         Ok(hv)
     }

--- a/src/tests/rust_guests/witguest/Cargo.lock
+++ b/src/tests/rust_guests/witguest/Cargo.lock
@@ -178,7 +178,7 @@ dependencies = [
 
 [[package]]
 name = "hyperlight-common"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "flatbuffers",
@@ -188,7 +188,7 @@ dependencies = [
 
 [[package]]
 name = "hyperlight-component-macro"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "env_logger",
  "hyperlight-component-util",
@@ -202,7 +202,7 @@ dependencies = [
 
 [[package]]
 name = "hyperlight-component-util"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "itertools",
  "log",
@@ -215,7 +215,7 @@ dependencies = [
 
 [[package]]
 name = "hyperlight-guest"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "hyperlight-common",
@@ -224,7 +224,7 @@ dependencies = [
 
 [[package]]
 name = "hyperlight-guest-bin"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "buddy_system_allocator",
  "cc",
@@ -337,9 +337,9 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.34"
+version = "0.2.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6837b9e10d61f45f987d50808f83d1ee3d206c66acf650c3e4ae2e1f6ddedf55"
+checksum = "061c1221631e079b26479d25bbf2275bfe5917ae8419cd7e34f13bfc2aa7539a"
 dependencies = [
  "proc-macro2",
  "syn",
@@ -477,9 +477,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.103"
+version = "2.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4307e30089d6fd6aff212f2da3a1f9e32f3223b1f010fb09b7c95f90f3ca1e8"
+checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
 dependencies = [
  "proc-macro2",
  "quote",


### PR DESCRIPTION
## Description
This pull request addresses an issue with the `gdb` feature.

**_NOTE_**: Additionally, I have modified the `guest-debugging` example to use two sandboxes(one with debugging enabled and one without) to help find similar issues in the future.

## Behavior
When the `gdb` feature is turned on for `hyperlight`  and a sandbox is not configured to enable debugging, it receives `Debug not enabled` error.

## Root cause
This happens because of a message that is sent, during the Hypervisor construction phase, from the Hypervisor to the `gdb` thread.
The problem is that the signal is sent even if the sandbox has no debug enabled.
The transmission fails because there is no `gdb` thread to receive it and returns this error.

## Fix
Add a condition before sending the signal to ensure the sandbox has debugging enabled