### PR TITLE
Switch 'deny' lints to 'warn'

### DIFF
--- a/src/hyperlight_host/src/lib.rs
+++ b/src/hyperlight_host/src/lib.rs
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-#![deny(dead_code, missing_docs, unused_mut)]
+#![warn(dead_code, missing_docs, unused_mut)]
 //! This crate contains an SDK that is used to execute specially-
 // compiled binaries within a very lightweight hypervisor environment.
 

--- a/src/hyperlight_host/src/sandbox/hypervisor.rs
+++ b/src/hyperlight_host/src/sandbox/hypervisor.rs
@@ -77,3 +77,9 @@ pub(crate) enum HypervisorType {
     #[cfg(target_os = "windows")]
     Whp,
 }
+
+// Compiler error if no hypervisor type is available
+#[cfg(not(any(kvm, mshv, target_os = "windows")))]
+compile_error!(
+    "No hypervisor type is available for the current platform. Please enable either the `kvm` or `mshv` cargo feature."
+);


### PR DESCRIPTION
These `deny` lints can be annoying during local development as it prevents your code from compiling while iterating. Switching to `warn` instead shouldn't have any negative impact on quality, since clippy will still catch all warnings which will still prevent PRs from being merged.

I added (back) a compiler error if neither hypervisor feature is enabled, as that is required by a test `just test-compilation-fail`. It was removed when in-process mode was added to Linux, but never re-added when in-process mode was removed. I think it's important that this is a compiler error and not a runtime error as Hyperlight is useless without an enabled hypervisor. (At runtime the error would otherwise be surfaced as a NoHypervisorFound error)