### PR TITLE
Add a scratch-backed user data region for host/guest byte exchange

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Prerelease] - Unreleased
 
+### Added
+* User data region APIs for transient host/guest byte exchange, including host read/write methods and Rust/C guest discovery helpers.
+
 ## [v0.15.0] - 2026-05-06
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ fn say_hello(name: String) -> Result<String> {
 }
 ```
 
-To get started, see the [Getting Started](./docs/getting-started.md) guide. For more details on writing guests, see [How to build a Hyperlight guest binary](./docs/how-to-build-a-hyperlight-guest-binary.md).
+To get started, see the [Getting Started](./docs/getting-started.md) guide. For more details on writing guests, see [How to build a Hyperlight guest binary](./docs/how-to-build-a-hyperlight-guest-binary.md). For execution internals, including the user data region, see [How code gets executed in a VM](./docs/hyperlight-execution-details.md).
 
 ## When to use Hyperlight
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -26,7 +26,7 @@ This project is composed internally of several components, depicted in the below
 
 * [Getting Started](./getting-started.md)
 * [Glossary](./glossary.md)
-* [How code gets executed in a VM](./hyperlight-execution-details.md)
+* [How code gets executed in a VM](./hyperlight-execution-details.md), including the user data region
 * [How to build a Hyperlight guest binary](./how-to-build-a-hyperlight-guest-binary.md)
 * [Security considerations](./security.md)
 * [Technical requirements document](./technical-requirements-document.md)

--- a/docs/hyperlight-execution-details.md
+++ b/docs/hyperlight-execution-details.md
@@ -35,6 +35,18 @@ At the highest level, Hyperlight takes roughly the following steps to create and
    1. In the former case, exit successfully
    2. In any of the latter cases, exit with a failure message
 
+## User data region
+
+Sandboxes can optionally reserve a user data region for transient host/guest byte exchange. The default capacity is zero; embedders configure a positive capacity with `SandboxConfiguration::set_user_data_size`. Fresh regions read as zeroes, and larger capacities may require increasing scratch size to satisfy the sandbox's existing scratch memory limits.
+
+When configured, the region is advertised to the guest through the PEB and can be accessed from the host with `MultiUseSandbox::write_user_data`, `MultiUseSandbox::read_user_data`, and `MultiUseSandbox::user_data_size`. Host reads and writes start at the beginning of the region and fail if the caller's buffer exceeds the configured capacity. Successful shorter writes preserve existing tail bytes, so callers should track logical payload length or clear unused bytes explicitly.
+
+The region is scratch memory, so it is not captured in snapshots. A restore clears the region, including restore performed by convenience call paths that restore the sandbox before returning to the host. Snapshot restore compatibility includes the configured capacity and reports the existing layout-mismatch error for capacity mismatches; `MultiUseSandbox::from_snapshot` rejects a caller-supplied configuration whose user data capacity differs from the snapshot layout. The intended exchange pattern is host write, mutating guest call, then host read before restore; after a failed guest call, callers should treat region contents as application-defined unless their protocol defines a successful handoff.
+
+Rust guest helpers expose bounded access to the region, including non-allocating borrowed access for larger payloads. The C guest API exposes `hl_user_data_size()` and `hl_user_data_ptr()`; C callers must use the reported size to bound copies. These APIs are helper-level bounds, not VM guard-page isolation around the region.
+
+Representative tests cover 4097-byte, 64 KiB, and 1 MiB capacities across Rust and C guests. Larger capacities should be measured for the application's expected copy and restore costs.
+
 ---
 
 _<sup>[1]</sup> nearly universal support_

--- a/docs/security-guidance-for-developers.md
+++ b/docs/security-guidance-for-developers.md
@@ -10,6 +10,7 @@ This document discusses the security requirements and best practices for service
 * All host functions that receive parameters from a guest, or operate indirectly on guest data _MUST_ be continuously fuzzed
 * Host functions _MUST NOT_ call APIs or be used to expose functionality deemed risky in a multi-tenant context
 * Guests and host processes _MUST_ use the same version of a FlatBuffer definition
+* Raw user data region bytes _MUST_ be treated as guest-controlled and validated by the host protocol before use
 
 More detailed guidance on the requirements and best practices is detailed below.
 
@@ -55,6 +56,10 @@ We emit this recommendation because there is a history of compiler bugs, which m
 ## Flatbuffers – a verifier should always be called before any decoder. In the case of failed verification, the input _MUST NOT_ be processed.
 
 For Rust code, if the return code is InvalidFlatBuffer, the input _MUST_ be rejected.
+
+## User data region – raw bytes must be validated before use
+
+The user data region intentionally bypasses the FlatBuffers call/return schema so applications can exchange large raw byte payloads. Hosts that read from the user data region _MUST_ treat those bytes as tainted guest-controlled input. Any length fields, offsets, nested formats, or semantic claims encoded in the region _MUST_ be validated by the host protocol before they are used to access memory, call host functions, or influence security-sensitive decisions. Hosts _SHOULD_ restore the sandbox or clear the full configured region between tenants or requests when stale bytes would be sensitive.
 
 ## Flatbuffers – the host process _MUST NOT_ operate on Flatbuffers from several threads.
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -14,6 +14,8 @@ Hyperlight runs all guest code inside a Virtual Machine, Each VM only has access
 
 All communication between the host and the guest is done through a shared memory buffer. Messages are serialized and deserialized using [FlatBuffers](https://flatbuffers.dev/). To minimize attack surface area, we rely on FlatBuffers to formally specify the data structures passed to/from the host and guest, and to generate serialization/deserialization code. Of course, a compromised guest can write arbitrary data to the shared memory buffer, but the host will not accept anything that does not match our strongly typed FlatBuffer [schemas](../src/schema).
 
+The optional user data region is an explicit exception to the FlatBuffers-mediated call protocol. It exposes raw bytes in shared scratch memory so embedders can define their own payload format. Hosts must treat bytes read from user data as guest-controlled, validate any application-level format before use, and clear or restore the region between security boundaries when stale bytes would be sensitive.
+
 ### Accessing host functionality from the guest
 
 Hyperlight provides a mechanism for the host to register functions that may be called from the guest. This mechanism is useful to allow developers to provide guests with strictly controlled access to functionality we don't make available by default inside the VM. This mechanism likely represents the largest attack surface area of this project.

--- a/src/hyperlight_common/src/arch/aarch64/layout.rs
+++ b/src/hyperlight_common/src/arch/aarch64/layout.rs
@@ -20,6 +20,10 @@ pub const SNAPSHOT_PT_GVA_MIN: usize = 0xffff_8000_0000_0000;
 pub const SNAPSHOT_PT_GVA_MAX: usize = 0xffff_80ff_ffff_ffff;
 pub const MAX_GPA: usize = 0x0000_000f_ffff_ffff;
 
-pub fn min_scratch_size(_input_data_size: usize, _output_data_size: usize) -> usize {
+pub fn min_scratch_size(
+    _input_data_size: usize,
+    _output_data_size: usize,
+    _user_data_size: usize,
+) -> usize {
     unimplemented!("min_scratch_size")
 }

--- a/src/hyperlight_common/src/arch/amd64/layout.rs
+++ b/src/hyperlight_common/src/arch/amd64/layout.rs
@@ -38,7 +38,11 @@ pub const MAX_GPA: usize = 0x0000_000f_ffff_ffff;
 /// - (up to) 3 pages for mapping that
 /// - Two pages for the exception stack and metadata
 /// - A page-aligned amount of memory for I/O buffers (for now)
-pub fn min_scratch_size(input_data_size: usize, output_data_size: usize) -> usize {
-    (input_data_size + output_data_size).next_multiple_of(crate::vmem::PAGE_SIZE)
+pub fn min_scratch_size(
+    input_data_size: usize,
+    output_data_size: usize,
+    user_data_size: usize,
+) -> usize {
+    (input_data_size + output_data_size + user_data_size).next_multiple_of(crate::vmem::PAGE_SIZE)
         + 12 * crate::vmem::PAGE_SIZE
 }

--- a/src/hyperlight_common/src/arch/i686/layout.rs
+++ b/src/hyperlight_common/src/arch/i686/layout.rs
@@ -24,7 +24,11 @@ pub const MAX_GPA: usize = 0xFEDF_FFFF;
 /// Minimum scratch region size: IO buffers (page-aligned) plus 12 pages
 /// for bookkeeping and the exception stack. Page table space is validated
 /// separately by `set_pt_size()`.
-pub fn min_scratch_size(input_data_size: usize, output_data_size: usize) -> usize {
-    (input_data_size + output_data_size).next_multiple_of(crate::vmem::PAGE_SIZE)
+pub fn min_scratch_size(
+    input_data_size: usize,
+    output_data_size: usize,
+    user_data_size: usize,
+) -> usize {
+    (input_data_size + output_data_size + user_data_size).next_multiple_of(crate::vmem::PAGE_SIZE)
         + 12 * crate::vmem::PAGE_SIZE
 }

--- a/src/hyperlight_common/src/mem.rs
+++ b/src/hyperlight_common/src/mem.rs
@@ -79,10 +79,13 @@ pub struct HyperlightPEB {
     /// PEB struct).
     #[cfg(feature = "nanvix-unstable")]
     pub file_mappings: GuestMemoryRegion,
+    pub user_data: GuestMemoryRegion,
 }
 
 #[cfg(test)]
 mod tests {
+    use std::mem::{offset_of, size_of};
+
     use super::*;
 
     #[test]
@@ -109,11 +112,29 @@ mod tests {
                 size: 0x9999,
                 ptr: 0xaaaa,
             },
+            user_data: GuestMemoryRegion {
+                size: 0xbbbb,
+                ptr: 0xcccc,
+            },
         };
         let bytes = bytemuck::bytes_of(&peb);
         let peb2 = *bytemuck::from_bytes::<HyperlightPEB>(bytes);
         let peb2_bytes = bytemuck::bytes_of(&peb2);
         assert_eq!(peb, peb2);
         assert_eq!(bytes, peb2_bytes);
+    }
+
+    #[test]
+    fn user_data_is_appended_to_peb() {
+        #[cfg(feature = "nanvix-unstable")]
+        assert_eq!(
+            offset_of!(HyperlightPEB, user_data),
+            size_of::<GuestMemoryRegion>() * 5
+        );
+        #[cfg(not(feature = "nanvix-unstable"))]
+        assert_eq!(
+            offset_of!(HyperlightPEB, user_data),
+            size_of::<GuestMemoryRegion>() * 4
+        );
     }
 }

--- a/src/hyperlight_guest/src/guest_handle/host_comm.rs
+++ b/src/hyperlight_guest/src/guest_handle/host_comm.rs
@@ -35,6 +35,87 @@ use crate::error::{HyperlightGuestError, Result};
 use crate::exit::out32;
 
 impl GuestHandle {
+    /// Get the configured user data region size.
+    #[instrument(skip_all, level = "Trace")]
+    pub fn user_data_size(&self) -> Result<u64> {
+        let peb_ptr = self.peb().unwrap();
+        Ok(unsafe { (*peb_ptr).user_data.size })
+    }
+
+    /// Get the configured user data region pointer.
+    #[instrument(skip_all, level = "Trace")]
+    pub fn user_data_ptr(&self) -> Result<*mut u8> {
+        let peb_ptr = self.peb().unwrap();
+        Ok(unsafe { (*peb_ptr).user_data.ptr as *mut u8 })
+    }
+
+    fn validate_user_data_len(&self, operation: &str, len: u64) -> Result<()> {
+        let capacity = self.user_data_size()?;
+        if len > capacity {
+            Err(HyperlightGuestError::new(
+                ErrorCode::GuestError,
+                format!(
+                    "User data {} length {} exceeds configured user data size {}",
+                    operation, len, capacity
+                ),
+            ))
+        } else {
+            Ok(())
+        }
+    }
+
+    fn user_data_len_to_usize(&self, operation: &str, len: u64) -> Result<usize> {
+        self.validate_user_data_len(operation, len)?;
+        usize::try_from(len).map_err(|_| {
+            HyperlightGuestError::new(
+                ErrorCode::GuestError,
+                format!("User data {} length exceeds usize::MAX", operation),
+            )
+        })
+    }
+
+    /// Borrow bytes from the configured user data region for the duration of `f`.
+    #[instrument(skip_all, level = "Trace")]
+    pub fn with_user_data<T>(&self, len: u64, f: impl FnOnce(&[u8]) -> T) -> Result<T> {
+        let len = self.user_data_len_to_usize("read", len)?;
+        // SAFETY: The host writes the PEB before guest entry, and the user_data
+        // descriptor points into the sandbox's scratch mapping. The length is
+        // checked against the advertised capacity above. This helper only
+        // creates a temporary shared borrow for the closure duration; callers
+        // that need mutation must use `with_user_data_mut`.
+        let user_data_slice = unsafe { core::slice::from_raw_parts(self.user_data_ptr()?, len) };
+        Ok(f(user_data_slice))
+    }
+
+    /// Mutably borrow bytes from the configured user data region for the duration of `f`.
+    #[instrument(skip_all, level = "Trace")]
+    pub fn with_user_data_mut<T>(&self, len: u64, f: impl FnOnce(&mut [u8]) -> T) -> Result<T> {
+        let len = self.user_data_len_to_usize("write", len)?;
+        // SAFETY: The host writes the PEB before guest entry, and the user_data
+        // descriptor points into the sandbox's scratch mapping. The length is
+        // checked against the advertised capacity above. Hyperlight guest code
+        // is single-threaded here, so this temporary mutable borrow is the
+        // official helper contract for in-guest user-data mutation; it is not a
+        // VM guard against arbitrary unsafe pointer misuse.
+        let user_data_slice =
+            unsafe { core::slice::from_raw_parts_mut(self.user_data_ptr()?, len) };
+        Ok(f(user_data_slice))
+    }
+
+    /// Read bytes from the configured user data region into a new `Vec`.
+    #[instrument(skip_all, level = "Trace")]
+    pub fn read_user_data(&self, len: u64) -> Result<Vec<u8>> {
+        self.with_user_data(len, |user_data| user_data.to_vec())
+    }
+
+    /// Write bytes to the configured user data region.
+    #[instrument(skip_all, level = "Trace")]
+    pub fn write_user_data(&self, data: &[u8]) -> Result<()> {
+        self.with_user_data_mut(data.len() as u64, |user_data| {
+            user_data.copy_from_slice(data);
+        })
+    }
+
     /// Get user memory region as bytes.
     #[instrument(skip_all, level = "Trace")]
     pub fn read_n_bytes_from_user_memory(&self, num: u64) -> Result<Vec<u8>> {

--- a/src/hyperlight_guest_bin/src/host_comm.rs
+++ b/src/hyperlight_guest_bin/src/host_comm.rs
@@ -71,6 +71,36 @@ pub fn read_n_bytes_from_user_memory(num: u64) -> Result<Vec<u8>> {
     handle.read_n_bytes_from_user_memory(num)
 }
 
+pub fn user_data_size() -> Result<u64> {
+    let handle = unsafe { GUEST_HANDLE };
+    handle.user_data_size()
+}
+
+pub fn user_data_ptr() -> Result<*mut u8> {
+    let handle = unsafe { GUEST_HANDLE };
+    handle.user_data_ptr()
+}
+
+pub fn read_user_data(len: u64) -> Result<Vec<u8>> {
+    let handle = unsafe { GUEST_HANDLE };
+    handle.read_user_data(len)
+}
+
+pub fn with_user_data<T>(len: u64, f: impl FnOnce(&[u8]) -> T) -> Result<T> {
+    let handle = unsafe { GUEST_HANDLE };
+    handle.with_user_data(len, f)
+}
+
+pub fn with_user_data_mut<T>(len: u64, f: impl FnOnce(&mut [u8]) -> T) -> Result<T> {
+    let handle = unsafe { GUEST_HANDLE };
+    handle.with_user_data_mut(len, f)
+}
+
+pub fn write_user_data(data: &[u8]) -> Result<()> {
+    let handle = unsafe { GUEST_HANDLE };
+    handle.write_user_data(data)
+}
+
 /// Print a message using the host's print function.
 ///
 /// This function requires memory to be setup to be used. In particular, the

--- a/src/hyperlight_guest_capi/src/lib.rs
+++ b/src/hyperlight_guest_capi/src/lib.rs
@@ -24,3 +24,4 @@ pub mod error;
 pub mod flatbuffer;
 pub mod logging;
 pub mod types;
+pub mod user_data;

--- a/src/hyperlight_guest_capi/src/user_data.rs
+++ b/src/hyperlight_guest_capi/src/user_data.rs
@@ -1,0 +1,34 @@
+/*
+Copyright 2025 The Hyperlight Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use core::ptr::null_mut;
+
+use hyperlight_guest_bin::host_comm::{user_data_ptr, user_data_size};
+
+/// Return the user data region capacity advertised in the PEB.
+#[unsafe(no_mangle)]
+pub extern "C" fn hl_user_data_size() -> usize {
+    user_data_size().unwrap_or(0) as usize
+}
+
+/// Return the user data region pointer advertised in the PEB.
+///
+/// C callers must bound all memory access by [`hl_user_data_size`]. This is a
+/// raw pointer into guest scratch memory, not a guard-page-isolated mapping.
+#[unsafe(no_mangle)]
+pub extern "C" fn hl_user_data_ptr() -> *mut u8 {
+    user_data_ptr().unwrap_or_else(|_| null_mut())
+}

--- a/src/hyperlight_host/benches/benchmarks.rs
+++ b/src/hyperlight_host/benches/benchmarks.rs
@@ -462,10 +462,12 @@ fn function_call_serialization_benchmark(c: &mut Criterion) {
 
 fn sample_workloads_benchmark(c: &mut Criterion) {
     let mut group = c.benchmark_group("sample_workloads");
+    const INPUT_SIZE_24K: usize = 24 * 1024;
+    const OUTPUT_SIZE_8K: usize = 8 * 1024;
 
     fn bench_24k_in_8k_out(b: &mut criterion::Bencher, guest_path: String) {
         let mut cfg = SandboxConfiguration::default();
-        cfg.set_input_data_size(25 * 1024);
+        cfg.set_input_data_size(INPUT_SIZE_24K + 1024);
 
         let mut sandbox = UninitializedSandbox::new(GuestBinary::FilePath(guest_path), Some(cfg))
             .unwrap()
@@ -473,13 +475,44 @@ fn sample_workloads_benchmark(c: &mut Criterion) {
             .unwrap();
 
         b.iter_with_setup(
-            || vec![1; 24 * 1024],
+            || vec![1; INPUT_SIZE_24K],
             |input| {
                 let ret: Vec<u8> = sandbox.call("24K_in_8K_out", (input,)).unwrap();
-                assert_eq!(ret.len(), 8 * 1024, "Expected output length to be 8K");
+                assert_eq!(ret.len(), OUTPUT_SIZE_8K, "Expected output length to be 8K");
                 std::hint::black_box(ret);
             },
         );
+    }
+
+    fn bench_24k_in_8k_out_user_data(b: &mut criterion::Bencher, guest_path: String) {
+        let mut cfg = SandboxConfiguration::default();
+        cfg.set_user_data_size(INPUT_SIZE_24K);
+        let min_scratch_size = hyperlight_common::layout::min_scratch_size(
+            SandboxConfiguration::DEFAULT_INPUT_SIZE,
+            SandboxConfiguration::DEFAULT_OUTPUT_SIZE,
+            INPUT_SIZE_24K,
+        );
+        cfg.set_scratch_size(min_scratch_size + 0x20000);
+
+        let mut sandbox = UninitializedSandbox::new(GuestBinary::FilePath(guest_path), Some(cfg))
+            .unwrap()
+            .evolve()
+            .unwrap();
+        let input = vec![1; INPUT_SIZE_24K];
+        let mut output = vec![0; OUTPUT_SIZE_8K];
+
+        b.iter(|| {
+            sandbox.write_user_data(&input).unwrap();
+            let output_len: i32 = sandbox
+                .call(
+                    "24K_in_8K_out_UserData",
+                    (INPUT_SIZE_24K as u64, OUTPUT_SIZE_8K as u64),
+                )
+                .unwrap();
+            assert_eq!(output_len as usize, OUTPUT_SIZE_8K);
+            sandbox.read_user_data(&mut output).unwrap();
+            std::hint::black_box(&output);
+        });
     }
 
     group.bench_function("24K_in_8K_out_c", |b| {
@@ -488,6 +521,14 @@ fn sample_workloads_benchmark(c: &mut Criterion) {
 
     group.bench_function("24K_in_8K_out_rust", |b| {
         bench_24k_in_8k_out(b, simple_guest_as_string().unwrap());
+    });
+
+    group.bench_function("24K_in_8K_out_user_data_c", |b| {
+        bench_24k_in_8k_out_user_data(b, c_simple_guest_as_string().unwrap());
+    });
+
+    group.bench_function("24K_in_8K_out_user_data_rust", |b| {
+        bench_24k_in_8k_out_user_data(b, simple_guest_as_string().unwrap());
     });
 
     group.finish();

--- a/src/hyperlight_host/src/mem/layout.rs
+++ b/src/hyperlight_host/src/mem/layout.rs
@@ -55,6 +55,8 @@ limitations under the License.
 //! +-------------------------------------------+ (1 page below)
 //! |              Scratch Memory               |
 //! +-------------------------------------------+
+//! |                User Data                  |
+//! +-------------------------------------------+
 //! |                Output Data                |
 //! +-------------------------------------------+
 //! |                Input Data                 |
@@ -221,6 +223,8 @@ pub(crate) struct SandboxMemoryLayout {
     pub(crate) input_data_size: usize,
     /// Output data buffer size (from SandboxConfiguration).
     pub(crate) output_data_size: usize,
+    /// User data buffer size (from SandboxConfiguration).
+    pub(crate) user_data_size: usize,
     /// The heap size of this sandbox.
     pub(crate) heap_size: usize,
     /// The size of the guest code section.
@@ -264,6 +268,10 @@ impl Debug for SandboxMemoryLayout {
         .field(
             "Output Data Size",
             &format_args!("{:#x}", self.output_data_size),
+        )
+        .field(
+            "User Data Size",
+            &format_args!("{:#x}", self.user_data_size),
         )
         .field("Scratch Size", &format_args!("{:#x}", self.scratch_size))
         .field("Snapshot Size", &format_args!("{:#x}", self.snapshot_size))
@@ -313,6 +321,7 @@ impl SandboxMemoryLayout {
         let Self {
             input_data_size,
             output_data_size,
+            user_data_size,
             heap_size,
             code_size,
             init_data_size,
@@ -323,6 +332,7 @@ impl SandboxMemoryLayout {
         } = self;
         *input_data_size == other.input_data_size
             && *output_data_size == other.output_data_size
+            && *user_data_size == other.user_data_size
             && *heap_size == other.heap_size
             && *code_size == other.code_size
             && *init_data_size == other.init_data_size
@@ -359,8 +369,12 @@ impl SandboxMemoryLayout {
         }
         let input_data_size = cfg.get_input_data_size();
         let output_data_size = cfg.get_output_data_size();
-        let min_scratch_size =
-            hyperlight_common::layout::min_scratch_size(input_data_size, output_data_size);
+        let user_data_size = cfg.get_user_data_size();
+        let min_scratch_size = hyperlight_common::layout::min_scratch_size(
+            input_data_size,
+            output_data_size,
+            user_data_size,
+        );
         if scratch_size < min_scratch_size {
             return Err(MemoryRequestTooSmall(scratch_size, min_scratch_size));
         }
@@ -368,6 +382,7 @@ impl SandboxMemoryLayout {
         let mut ret = Self {
             input_data_size,
             output_data_size,
+            user_data_size,
             heap_size,
             code_size,
             init_data_size,
@@ -440,6 +455,26 @@ impl SandboxMemoryLayout {
         self.input_data_size
     }
 
+    /// Get the guest virtual address of the start of user data.
+    #[instrument(skip_all, parent = Span::current(), level= "Trace")]
+    pub(crate) fn get_user_data_buffer_gva(&self) -> u64 {
+        hyperlight_common::layout::scratch_base_gva(self.scratch_size)
+            + self.get_user_data_buffer_scratch_host_offset() as u64
+    }
+
+    /// Get the offset into the host scratch buffer of the start of
+    /// the user data.
+    #[instrument(skip_all, parent = Span::current(), level= "Trace")]
+    pub(crate) fn get_user_data_buffer_scratch_host_offset(&self) -> usize {
+        self.input_data_size + self.output_data_size
+    }
+
+    /// Get the size of the user data buffer.
+    #[instrument(skip_all, parent = Span::current(), level= "Trace")]
+    pub(crate) fn user_data_size(&self) -> usize {
+        self.user_data_size
+    }
+
     /// Get the guest virtual address of the start of input data
     #[instrument(skip_all, parent = Span::current(), level= "Trace")]
     fn get_input_data_buffer_gva(&self) -> u64 {
@@ -457,7 +492,7 @@ impl SandboxMemoryLayout {
     /// location where page tables will be eagerly copied on restore
     #[instrument(skip_all, parent = Span::current(), level= "Trace")]
     pub(crate) fn get_pt_base_scratch_offset(&self) -> usize {
-        (self.input_data_size + self.output_data_size)
+        (self.input_data_size + self.output_data_size + self.user_data_size)
             .next_multiple_of(hyperlight_common::vmem::PAGE_SIZE)
     }
 
@@ -548,6 +583,7 @@ impl SandboxMemoryLayout {
         let min_fixed_scratch = hyperlight_common::layout::min_scratch_size(
             self.input_data_size,
             self.output_data_size,
+            self.user_data_size,
         );
         let min_scratch = min_fixed_scratch + size;
         if self.scratch_size < min_scratch {
@@ -696,6 +732,10 @@ impl SandboxMemoryLayout {
                 size: self.output_data_size as u64,
                 ptr: self.get_output_data_buffer_gva(),
             },
+            user_data: GuestMemoryRegion {
+                size: self.user_data_size() as u64,
+                ptr: self.get_user_data_buffer_gva(),
+            },
             init_data: GuestMemoryRegion {
                 size: (self.get_unaligned_memory_size() - self.init_data_offset()) as u64,
                 ptr: guest_base + self.init_data_offset() as u64,
@@ -818,6 +858,80 @@ mod tests {
     }
 
     #[test]
+    fn user_data_defaults_to_zero_without_moving_pt_base() {
+        let cfg = SandboxConfiguration::default();
+        let layout = SandboxMemoryLayout::new(cfg, 4096, 0, None).unwrap();
+        assert_eq!(0, layout.user_data_size());
+        assert_eq!(
+            cfg.get_input_data_size() + cfg.get_output_data_size(),
+            layout.get_pt_base_scratch_offset()
+        );
+        assert_eq!(
+            cfg.get_input_data_size() + cfg.get_output_data_size(),
+            layout.get_user_data_buffer_scratch_host_offset()
+        );
+    }
+
+    #[test]
+    fn user_data_offset_gva_and_pt_base_follow_input_and_output() {
+        for user_data_size in [4097, 64 * 1024, 1024 * 1024] {
+            let mut cfg = SandboxConfiguration::default();
+            cfg.set_user_data_size(user_data_size);
+            let min_scratch = hyperlight_common::layout::min_scratch_size(
+                cfg.get_input_data_size(),
+                cfg.get_output_data_size(),
+                cfg.get_user_data_size(),
+            );
+            cfg.set_scratch_size(min_scratch);
+
+            let layout = SandboxMemoryLayout::new(cfg, 4096, 0, None).unwrap();
+            let expected_user_data_offset = cfg.get_input_data_size() + cfg.get_output_data_size();
+            assert_eq!(
+                expected_user_data_offset,
+                layout.get_user_data_buffer_scratch_host_offset()
+            );
+            assert_eq!(
+                hyperlight_common::layout::scratch_base_gva(layout.get_scratch_size())
+                    + expected_user_data_offset as u64,
+                layout.get_user_data_buffer_gva()
+            );
+            assert_eq!(
+                (expected_user_data_offset + cfg.get_user_data_size())
+                    .next_multiple_of(PAGE_SIZE_USIZE),
+                layout.get_pt_base_scratch_offset()
+            );
+        }
+    }
+
+    #[test]
+    fn user_data_size_participates_in_min_scratch_size() {
+        let mut cfg = SandboxConfiguration::default();
+        let min_without_user_data = hyperlight_common::layout::min_scratch_size(
+            cfg.get_input_data_size(),
+            cfg.get_output_data_size(),
+            0,
+        );
+        cfg.set_user_data_size(4097);
+        cfg.set_scratch_size(min_without_user_data);
+
+        assert!(matches!(
+            SandboxMemoryLayout::new(cfg, 4096, 0, None).unwrap_err(),
+            MemoryRequestTooSmall(..)
+        ));
+    }
+
+    #[test]
+    fn large_user_data_requires_sufficient_scratch_size() {
+        let mut cfg = SandboxConfiguration::default();
+        cfg.set_user_data_size(1024 * 1024);
+
+        assert!(matches!(
+            SandboxMemoryLayout::new(cfg, 4096, 0, None).unwrap_err(),
+            MemoryRequestTooSmall(..)
+        ));
+    }
+
+    #[test]
     fn is_compatible_with_identical_layouts() {
         let cfg = SandboxConfiguration::default();
         let a = SandboxMemoryLayout::new(cfg, 4096, 0, None).unwrap();
@@ -849,6 +963,7 @@ mod tests {
         let mutators: &[fn(&mut SandboxMemoryLayout)] = &[
             |l| l.input_data_size += PAGE_SIZE_USIZE,
             |l| l.output_data_size += PAGE_SIZE_USIZE,
+            |l| l.user_data_size += PAGE_SIZE_USIZE,
             |l| l.heap_size += PAGE_SIZE_USIZE,
             |l| l.code_size += PAGE_SIZE_USIZE,
             |l| l.init_data_size += PAGE_SIZE_USIZE,

--- a/src/hyperlight_host/src/mem/mgr.rs
+++ b/src/hyperlight_host/src/mem/mgr.rs
@@ -378,6 +378,41 @@ impl SandboxMemoryManager<ExclusiveSharedMemory> {
 }
 
 impl SandboxMemoryManager<HostSharedMemory> {
+    /// Get the configured user data region size.
+    #[instrument(skip_all, parent = Span::current(), level= "Trace")]
+    pub(crate) fn user_data_size(&self) -> usize {
+        self.layout.user_data_size()
+    }
+
+    fn validate_user_data_len(&self, operation: &str, len: usize) -> Result<()> {
+        let capacity = self.user_data_size();
+        if len > capacity {
+            return Err(new_error!(
+                "user data {} length {} exceeds configured user data size {}",
+                operation,
+                len,
+                capacity
+            ));
+        }
+        Ok(())
+    }
+
+    /// Copy bytes into the configured user data region.
+    #[instrument(err(Debug), skip_all, parent = Span::current(), level= "Trace")]
+    pub(crate) fn write_user_data(&mut self, data: &[u8]) -> Result<()> {
+        self.validate_user_data_len("write", data.len())?;
+        self.scratch_mem
+            .copy_from_slice(data, self.layout.get_user_data_buffer_scratch_host_offset())
+    }
+
+    /// Copy bytes from the configured user data region.
+    #[instrument(err(Debug), skip_all, parent = Span::current(), level= "Trace")]
+    pub(crate) fn read_user_data(&mut self, out: &mut [u8]) -> Result<()> {
+        self.validate_user_data_len("read", out.len())?;
+        self.scratch_mem
+            .copy_to_slice(out, self.layout.get_user_data_buffer_scratch_host_offset())
+    }
+
     /// Write a [`FileMappingInfo`] entry into the PEB's preallocated array.
     ///
     /// Reads the current entry count from the PEB, validates that the
@@ -858,6 +893,124 @@ impl SandboxMemoryManager<HostSharedMemory> {
                 Ok(result)
             })
         })??
+    }
+}
+
+#[cfg(test)]
+mod user_data_tests {
+    use hyperlight_common::mem::PAGE_SIZE_USIZE;
+
+    use super::*;
+    use crate::sandbox::SandboxConfiguration;
+    use crate::sandbox::snapshot::NextAction;
+
+    fn build_host_manager(user_data_size: usize) -> SandboxMemoryManager<HostSharedMemory> {
+        let mut cfg = SandboxConfiguration::default();
+        cfg.set_user_data_size(user_data_size);
+        let min_scratch_size = hyperlight_common::layout::min_scratch_size(
+            cfg.get_input_data_size(),
+            cfg.get_output_data_size(),
+            cfg.get_user_data_size(),
+        );
+        cfg.set_scratch_size(min_scratch_size);
+
+        let layout = SandboxMemoryLayout::new(cfg, PAGE_SIZE_USIZE, 0, None).unwrap();
+        #[cfg(not(unshared_snapshot_mem))]
+        let shared_mem =
+            ReadonlySharedMemory::from_bytes(&vec![0; PAGE_SIZE_USIZE], PAGE_SIZE_USIZE).unwrap();
+        #[cfg(unshared_snapshot_mem)]
+        let shared_mem = ExclusiveSharedMemory::new(PAGE_SIZE_USIZE).unwrap();
+        let scratch_mem = ExclusiveSharedMemory::new(layout.get_scratch_size()).unwrap();
+
+        SandboxMemoryManager::new(layout, shared_mem, scratch_mem, NextAction::None)
+            .build()
+            .unwrap()
+            .0
+    }
+
+    #[test]
+    fn user_data_size_reports_configured_capacity() {
+        for user_data_size in [0, 1, 4097, 64 * 1024, 1024 * 1024] {
+            let mgr = build_host_manager(user_data_size);
+            assert_eq!(user_data_size, mgr.user_data_size());
+        }
+    }
+
+    #[test]
+    fn fresh_user_data_reads_as_zero() {
+        let mut mgr = build_host_manager(4097);
+        let mut out = vec![0xff; mgr.user_data_size()];
+
+        mgr.read_user_data(&mut out).unwrap();
+
+        assert!(out.iter().all(|byte| *byte == 0));
+    }
+
+    #[test]
+    fn user_data_read_write_boundaries_are_enforced() {
+        let mut zero_capacity_mgr = build_host_manager(0);
+        zero_capacity_mgr.write_user_data(&[]).unwrap();
+        zero_capacity_mgr.read_user_data(&mut []).unwrap();
+        assert!(zero_capacity_mgr.write_user_data(&[1]).is_err());
+        assert!(zero_capacity_mgr.read_user_data(&mut [0]).is_err());
+
+        let mut mgr = build_host_manager(4097);
+        let data: Vec<u8> = (0..mgr.user_data_size()).map(|i| (i % 251) as u8).collect();
+        let mut out = vec![0; data.len()];
+        mgr.write_user_data(&data).unwrap();
+        mgr.read_user_data(&mut out).unwrap();
+        assert_eq!(data, out);
+
+        assert!(
+            mgr.write_user_data(&vec![0; mgr.user_data_size() + 1])
+                .is_err()
+        );
+        assert!(
+            mgr.read_user_data(&mut vec![0; mgr.user_data_size() + 1])
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn oversized_user_data_write_is_atomic() {
+        let mut mgr = build_host_manager(4097);
+        let initial = vec![0xaa; mgr.user_data_size()];
+        mgr.write_user_data(&initial).unwrap();
+
+        let sentinel_offset =
+            mgr.layout.get_user_data_buffer_scratch_host_offset() + mgr.user_data_size();
+        let sentinel = [0x55; 16];
+        mgr.scratch_mem
+            .copy_from_slice(&sentinel, sentinel_offset)
+            .unwrap();
+
+        let err = mgr.write_user_data(&vec![0xbb; mgr.user_data_size() + 1]);
+        assert!(err.is_err());
+
+        let mut current = vec![0; mgr.user_data_size()];
+        mgr.read_user_data(&mut current).unwrap();
+        assert_eq!(initial, current);
+
+        let mut current_sentinel = [0; 16];
+        mgr.scratch_mem
+            .copy_to_slice(&mut current_sentinel, sentinel_offset)
+            .unwrap();
+        assert_eq!(sentinel, current_sentinel);
+    }
+
+    #[test]
+    fn shorter_user_data_write_preserves_tail() {
+        let mut mgr = build_host_manager(4097);
+        let initial = vec![0xaa; mgr.user_data_size()];
+        mgr.write_user_data(&initial).unwrap();
+
+        let shorter = vec![0xbb; 16];
+        mgr.write_user_data(&shorter).unwrap();
+
+        let mut current = vec![0; mgr.user_data_size()];
+        mgr.read_user_data(&mut current).unwrap();
+        assert_eq!(&shorter, &current[..shorter.len()]);
+        assert!(current[shorter.len()..].iter().all(|byte| *byte == 0xaa));
     }
 }
 

--- a/src/hyperlight_host/src/sandbox/config.rs
+++ b/src/hyperlight_host/src/sandbox/config.rs
@@ -50,6 +50,9 @@ pub struct SandboxConfiguration {
     /// The size of the memory buffer that is made available for input to the
     /// Guest Binary
     output_data_size: usize,
+    /// The size of the memory buffer that is made available for user data
+    /// shared between the host and Guest Binary.
+    user_data_size: usize,
     /// The heap size to use in the guest sandbox. If set to 0, the heap
     /// size will be determined from the PE file header
     ///
@@ -85,6 +88,8 @@ impl SandboxConfiguration {
     pub const DEFAULT_OUTPUT_SIZE: usize = 0x4000;
     /// The minimum size of output data
     pub const MIN_OUTPUT_SIZE: usize = 0x2000;
+    /// The default size of user data.
+    pub const DEFAULT_USER_DATA_SIZE: usize = 0;
     /// The default interrupt retry delay
     pub const DEFAULT_INTERRUPT_RETRY_DELAY: Duration = Duration::from_micros(500);
     /// The default signal offset from `SIGRTMIN` used to determine the signal number for interrupting
@@ -100,6 +105,7 @@ impl SandboxConfiguration {
     fn new(
         input_data_size: usize,
         output_data_size: usize,
+        user_data_size: usize,
         heap_size_override: Option<u64>,
         scratch_size: usize,
         interrupt_retry_delay: Duration,
@@ -110,6 +116,7 @@ impl SandboxConfiguration {
         Self {
             input_data_size: max(input_data_size, Self::MIN_INPUT_SIZE),
             output_data_size: max(output_data_size, Self::MIN_OUTPUT_SIZE),
+            user_data_size,
             heap_size_override: heap_size_override.unwrap_or(0),
             scratch_size,
             interrupt_retry_delay,
@@ -133,6 +140,16 @@ impl SandboxConfiguration {
     #[instrument(skip_all, parent = Span::current(), level= "Trace")]
     pub fn set_output_data_size(&mut self, output_data_size: usize) {
         self.output_data_size = max(output_data_size, Self::MIN_OUTPUT_SIZE);
+    }
+
+    /// Set the size of the memory buffer that is made available for user data shared
+    /// between the host and guest.
+    ///
+    /// Large values may require increasing [`set_scratch_size`](Self::set_scratch_size)
+    /// so scratch memory can hold the input, output, and user data buffers.
+    #[instrument(skip_all, parent = Span::current(), level= "Trace")]
+    pub fn set_user_data_size(&mut self, user_data_size: usize) {
+        self.user_data_size = user_data_size;
     }
 
     /// Set the heap size to use in the guest sandbox. If set to 0, the heap size will be determined from the PE file header
@@ -205,6 +222,11 @@ impl SandboxConfiguration {
     }
 
     #[instrument(skip_all, parent = Span::current(), level= "Trace")]
+    pub(crate) fn get_user_data_size(&self) -> usize {
+        self.user_data_size
+    }
+
+    #[instrument(skip_all, parent = Span::current(), level= "Trace")]
     pub(crate) fn get_scratch_size(&self) -> usize {
         self.scratch_size
     }
@@ -247,6 +269,7 @@ impl Default for SandboxConfiguration {
         Self::new(
             Self::DEFAULT_INPUT_SIZE,
             Self::DEFAULT_OUTPUT_SIZE,
+            Self::DEFAULT_USER_DATA_SIZE,
             None,
             Self::DEFAULT_SCRATCH_SIZE,
             Self::DEFAULT_INTERRUPT_RETRY_DELAY,
@@ -268,10 +291,12 @@ mod tests {
         const HEAP_SIZE_OVERRIDE: u64 = 0x50000;
         const INPUT_DATA_SIZE_OVERRIDE: usize = 0x4000;
         const OUTPUT_DATA_SIZE_OVERRIDE: usize = 0x4001;
+        const USER_DATA_SIZE_OVERRIDE: usize = 0x1234;
         const SCRATCH_SIZE_OVERRIDE: usize = 0x60000;
         let mut cfg = SandboxConfiguration::new(
             INPUT_DATA_SIZE_OVERRIDE,
             OUTPUT_DATA_SIZE_OVERRIDE,
+            USER_DATA_SIZE_OVERRIDE,
             Some(HEAP_SIZE_OVERRIDE),
             SCRATCH_SIZE_OVERRIDE,
             SandboxConfiguration::DEFAULT_INTERRUPT_RETRY_DELAY,
@@ -293,6 +318,7 @@ mod tests {
         assert_eq!(0x40000, cfg.scratch_size);
         assert_eq!(INPUT_DATA_SIZE_OVERRIDE, cfg.input_data_size);
         assert_eq!(OUTPUT_DATA_SIZE_OVERRIDE, cfg.output_data_size);
+        assert_eq!(USER_DATA_SIZE_OVERRIDE, cfg.user_data_size);
     }
 
     #[test]
@@ -300,6 +326,7 @@ mod tests {
         let mut cfg = SandboxConfiguration::new(
             SandboxConfiguration::MIN_INPUT_SIZE - 1,
             SandboxConfiguration::MIN_OUTPUT_SIZE - 1,
+            SandboxConfiguration::DEFAULT_USER_DATA_SIZE,
             None,
             SandboxConfiguration::DEFAULT_SCRATCH_SIZE,
             SandboxConfiguration::DEFAULT_INTERRUPT_RETRY_DELAY,
@@ -312,12 +339,27 @@ mod tests {
         assert_eq!(SandboxConfiguration::MIN_INPUT_SIZE, cfg.input_data_size);
         assert_eq!(SandboxConfiguration::MIN_OUTPUT_SIZE, cfg.output_data_size);
         assert_eq!(0, cfg.heap_size_override);
+        assert_eq!(
+            SandboxConfiguration::DEFAULT_USER_DATA_SIZE,
+            cfg.user_data_size
+        );
 
         cfg.set_input_data_size(SandboxConfiguration::MIN_INPUT_SIZE - 1);
         cfg.set_output_data_size(SandboxConfiguration::MIN_OUTPUT_SIZE - 1);
+        cfg.set_user_data_size(1);
 
         assert_eq!(SandboxConfiguration::MIN_INPUT_SIZE, cfg.input_data_size);
         assert_eq!(SandboxConfiguration::MIN_OUTPUT_SIZE, cfg.output_data_size);
+        assert_eq!(1, cfg.user_data_size);
+    }
+
+    #[test]
+    fn user_data_size_accepts_representative_capacities() {
+        let mut cfg = SandboxConfiguration::default();
+        for size in [4097, 64 * 1024, 1024 * 1024] {
+            cfg.set_user_data_size(size);
+            assert_eq!(size, cfg.get_user_data_size());
+        }
     }
 
     mod proptests {
@@ -340,6 +382,13 @@ mod tests {
                 let mut cfg = SandboxConfiguration::default();
                 cfg.set_output_data_size(size);
                 prop_assert_eq!(size, cfg.get_output_data_size());
+            }
+
+            #[test]
+            fn user_data_size(size in 0usize..=SandboxConfiguration::MIN_OUTPUT_SIZE * 10) {
+                let mut cfg = SandboxConfiguration::default();
+                cfg.set_user_data_size(size);
+                prop_assert_eq!(size, cfg.get_user_data_size());
             }
 
 

--- a/src/hyperlight_host/src/sandbox/initialized_multi_use.rs
+++ b/src/hyperlight_host/src/sandbox/initialized_multi_use.rs
@@ -139,6 +139,65 @@ impl MultiUseSandbox {
         self.pt_root_finder = Some(finder);
     }
 
+    /// Return the configured size, in bytes, of this sandbox's user data region.
+    ///
+    /// The default is `0`, which means the region has no writable or readable
+    /// capacity. The user data region is transient scratch memory: it is not
+    /// captured in snapshots and is cleared by restore.
+    #[instrument(skip_all, parent = Span::current(), level = "Trace")]
+    pub fn user_data_size(&self) -> usize {
+        self.mem_mgr.user_data_size()
+    }
+
+    /// Copy `data` into the sandbox's user data region from the beginning of the
+    /// region.
+    ///
+    /// The full slice must fit within [`user_data_size`](Self::user_data_size);
+    /// oversized writes return an error before modifying the region. Guest code
+    /// can observe these bytes during a mutating call, but convenience call paths
+    /// that restore the sandbox before the host reads will clear the region.
+    /// Successful writes do not clear bytes after `data.len()`; callers that use
+    /// variable-length payloads should track their logical length or clear the
+    /// remaining region explicitly.
+    ///
+    /// This is distinct from init-data/user-memory helpers: user data lives in
+    /// transient scratch memory and is not part of snapshot state.
+    ///
+    /// ## Poisoned Sandbox
+    ///
+    /// This method returns [`crate::HyperlightError::PoisonedSandbox`] if the
+    /// sandbox is currently poisoned. Use [`restore`](Self::restore) to recover.
+    #[instrument(err(Debug), skip_all, parent = Span::current(), level = "Trace")]
+    pub fn write_user_data(&mut self, data: &[u8]) -> Result<()> {
+        if self.poisoned {
+            return Err(crate::HyperlightError::PoisonedSandbox);
+        }
+        self.mem_mgr.write_user_data(data)
+    }
+
+    /// Copy bytes from the sandbox's user data region into `out` from the
+    /// beginning of the region.
+    ///
+    /// The full output buffer must fit within
+    /// [`user_data_size`](Self::user_data_size). Reads larger than the configured
+    /// capacity return an error rather than exposing adjacent scratch memory.
+    /// Guest mutations are observable only until a restore clears scratch memory.
+    ///
+    /// This is distinct from init-data/user-memory helpers: user data lives in
+    /// transient scratch memory and is not part of snapshot state.
+    ///
+    /// ## Poisoned Sandbox
+    ///
+    /// This method returns [`crate::HyperlightError::PoisonedSandbox`] if the
+    /// sandbox is currently poisoned. Use [`restore`](Self::restore) to recover.
+    #[instrument(err(Debug), skip_all, parent = Span::current(), level = "Trace")]
+    pub fn read_user_data(&mut self, out: &mut [u8]) -> Result<()> {
+        if self.poisoned {
+            return Err(crate::HyperlightError::PoisonedSandbox);
+        }
+        self.mem_mgr.read_user_data(out)
+    }
+
     /// Create a `MultiUseSandbox` directly from a [`Snapshot`],
     /// bypassing [`UninitializedSandbox`](crate::UninitializedSandbox)
     /// and [`evolve()`](crate::UninitializedSandbox::evolve).
@@ -157,9 +216,10 @@ impl MultiUseSandbox {
     /// An optional [`SandboxConfiguration`](crate::sandbox::SandboxConfiguration)
     /// can be supplied to override runtime settings such as timeouts and
     /// interrupt behavior. Memory layout fields
-    /// (`input_data_size`, `output_data_size`, `heap_size`, `scratch_size`)
-    /// are always taken from the snapshot. Any values supplied in
-    /// `config` for those fields are ignored.
+    /// (`input_data_size`, `output_data_size`, `heap_size`, `scratch_size`) are
+    /// always taken from the snapshot. Any values supplied in `config` for those
+    /// fields are ignored. If `config` supplies a `user_data_size`, it must match
+    /// the snapshot layout.
     ///
     /// # Examples
     ///
@@ -212,10 +272,14 @@ impl MultiUseSandbox {
         let caller_supplied_config = config.is_some();
         let mut config = config.unwrap_or_default();
         if caller_supplied_config {
+            if config.get_user_data_size() != snapshot.layout().user_data_size {
+                return Err(HyperlightError::SnapshotLayoutMismatch);
+            }
             warn_on_layout_override(&config, snapshot.layout());
         }
         config.set_input_data_size(snapshot.layout().input_data_size);
         config.set_output_data_size(snapshot.layout().output_data_size);
+        config.set_user_data_size(snapshot.layout().user_data_size);
         config.set_heap_size(snapshot.layout().heap_size as u64);
         config.set_scratch_size(snapshot.layout().get_scratch_size());
         let load_info = snapshot.load_info();
@@ -1120,6 +1184,11 @@ fn warn_on_layout_override(
             snapshot.output_data_size as u64,
         ),
         (
+            "user_data_size",
+            caller.get_user_data_size() as u64,
+            snapshot.user_data_size as u64,
+        ),
+        (
             "heap_size",
             caller.get_heap_size(),
             snapshot.heap_size as u64,
@@ -1155,6 +1224,36 @@ mod tests {
     use crate::mem::shared_mem::{ExclusiveSharedMemory, GuestSharedMemory, SharedMemory as _};
     use crate::sandbox::SandboxConfiguration;
     use crate::{GuestBinary, HyperlightError, MultiUseSandbox, Result, UninitializedSandbox};
+
+    fn user_data_test_config(user_data_size: usize) -> SandboxConfiguration {
+        let min_scratch_size = hyperlight_common::layout::min_scratch_size(
+            SandboxConfiguration::DEFAULT_INPUT_SIZE,
+            SandboxConfiguration::DEFAULT_OUTPUT_SIZE,
+            user_data_size,
+        );
+        user_data_test_config_with_scratch_size(user_data_size, min_scratch_size + 0x20000)
+    }
+
+    fn user_data_test_config_with_scratch_size(
+        user_data_size: usize,
+        scratch_size: usize,
+    ) -> SandboxConfiguration {
+        let mut cfg = SandboxConfiguration::default();
+        cfg.set_user_data_size(user_data_size);
+        cfg.set_scratch_size(scratch_size);
+        cfg
+    }
+
+    fn user_data_test_sandbox(user_data_size: usize) -> MultiUseSandbox {
+        let path = simple_guest_as_string().unwrap();
+        UninitializedSandbox::new(
+            GuestBinary::FilePath(path),
+            Some(user_data_test_config(user_data_size)),
+        )
+        .unwrap()
+        .evolve()
+        .unwrap()
+    }
 
     #[test]
     fn poison() {
@@ -1343,6 +1442,7 @@ mod tests {
         let min_scratch = hyperlight_common::layout::min_scratch_size(
             cfg.get_input_data_size(),
             cfg.get_output_data_size(),
+            cfg.get_user_data_size(),
         );
         cfg.set_scratch_size(min_scratch + 0x10000 + 0x10000);
 
@@ -1773,6 +1873,119 @@ mod tests {
         assert_eq!(target.call::<i32>("GetStatic", ()).unwrap(), 108);
         target.restore(good_snapshot).unwrap();
         assert_eq!(target.call::<i32>("GetStatic", ()).unwrap(), 8);
+    }
+
+    #[test]
+    fn restore_user_data_clears_region_and_leaves_sandbox_usable() {
+        const USER_DATA_SIZE: usize = 4097;
+        let mut sandbox = user_data_test_sandbox(USER_DATA_SIZE);
+        sandbox
+            .write_user_data(&vec![0xaa; USER_DATA_SIZE])
+            .unwrap();
+        let snapshot = sandbox.snapshot().unwrap();
+
+        sandbox
+            .write_user_data(&vec![0xbb; USER_DATA_SIZE])
+            .unwrap();
+        sandbox.restore(snapshot).unwrap();
+
+        let mut out = vec![0xff; USER_DATA_SIZE];
+        sandbox.read_user_data(&mut out).unwrap();
+        assert!(out.iter().all(|byte| *byte == 0));
+        assert_eq!(sandbox.call::<i32>("GetStatic", ()).unwrap(), 0);
+    }
+
+    #[test]
+    fn restore_user_data_cleared_by_deprecated_restoring_call_path() {
+        const USER_DATA_SIZE: usize = 4097;
+        let mut sandbox = user_data_test_sandbox(USER_DATA_SIZE);
+        sandbox
+            .write_user_data(&vec![0xaa; USER_DATA_SIZE])
+            .unwrap();
+
+        #[allow(deprecated)]
+        let _: i32 = sandbox
+            .call_guest_function_by_name("GetStatic", ())
+            .unwrap();
+
+        let mut out = vec![0xff; USER_DATA_SIZE];
+        sandbox.read_user_data(&mut out).unwrap();
+        assert!(out.iter().all(|byte| *byte == 0));
+        assert_eq!(sandbox.call::<i32>("GetStatic", ()).unwrap(), 0);
+    }
+
+    #[test]
+    fn restore_user_data_rejects_capacity_mismatch() {
+        let shared_scratch_size = hyperlight_common::layout::min_scratch_size(
+            SandboxConfiguration::DEFAULT_INPUT_SIZE,
+            SandboxConfiguration::DEFAULT_OUTPUT_SIZE,
+            64 * 1024,
+        ) + 0x20000;
+        let path = simple_guest_as_string().unwrap();
+        let mut source = UninitializedSandbox::new(
+            GuestBinary::FilePath(path),
+            Some(user_data_test_config_with_scratch_size(
+                4097,
+                shared_scratch_size,
+            )),
+        )
+        .unwrap()
+        .evolve()
+        .unwrap();
+        let path = simple_guest_as_string().unwrap();
+        let mut target = UninitializedSandbox::new(
+            GuestBinary::FilePath(path),
+            Some(user_data_test_config_with_scratch_size(
+                64 * 1024,
+                shared_scratch_size,
+            )),
+        )
+        .unwrap()
+        .evolve()
+        .unwrap();
+
+        let snapshot = source.snapshot().unwrap();
+        let err = target.restore(snapshot);
+        assert!(matches!(err, Err(HyperlightError::SnapshotLayoutMismatch)));
+
+        assert_eq!(target.call::<i32>("GetStatic", ()).unwrap(), 0);
+    }
+
+    #[test]
+    fn restore_user_data_from_snapshot_rejects_capacity_mismatch() {
+        let mut source = user_data_test_sandbox(4097);
+        let snapshot = source.snapshot().unwrap();
+        let err = MultiUseSandbox::from_snapshot(
+            snapshot,
+            crate::HostFunctions::default(),
+            Some(user_data_test_config(64 * 1024)),
+        );
+
+        assert!(matches!(err, Err(HyperlightError::SnapshotLayoutMismatch)));
+    }
+
+    #[test]
+    fn restore_user_data_from_snapshot_starts_zeroed_and_guest_visible() {
+        const USER_DATA_SIZE: usize = 4097;
+        let mut source = user_data_test_sandbox(USER_DATA_SIZE);
+        source.write_user_data(&vec![0xaa; USER_DATA_SIZE]).unwrap();
+        let snapshot = source.snapshot().unwrap();
+
+        let mut sandbox =
+            MultiUseSandbox::from_snapshot(snapshot, crate::HostFunctions::default(), None)
+                .unwrap();
+
+        assert_eq!(USER_DATA_SIZE, sandbox.user_data_size());
+        let mut out = vec![0xff; USER_DATA_SIZE];
+        sandbox.read_user_data(&mut out).unwrap();
+        assert!(out.iter().all(|byte| *byte == 0));
+
+        let guest_size: u64 = sandbox.call("UserDataSize", ()).unwrap();
+        assert_eq!(USER_DATA_SIZE, guest_size as usize);
+        let guest_sees_zeroes: bool = sandbox
+            .call("VerifyUserDataZeros", USER_DATA_SIZE as u64)
+            .unwrap();
+        assert!(guest_sees_zeroes);
     }
 
     /// `snapshot.regions()` is empty post-compaction, so restore

--- a/src/hyperlight_host/tests/sandbox_host_tests.rs
+++ b/src/hyperlight_host/tests/sandbox_host_tests.rs
@@ -26,8 +26,28 @@ use hyperlight_testing::simple_guest_as_string;
 pub mod common; // pub to disable dead_code warning
 use crate::common::{
     with_all_sandboxes, with_all_sandboxes_cfg, with_all_sandboxes_with_writer,
-    with_all_uninit_sandboxes,
+    with_all_uninit_sandboxes, with_rust_sandbox_cfg,
 };
+
+fn user_data_test_config(user_data_size: usize) -> SandboxConfiguration {
+    let mut cfg = SandboxConfiguration::default();
+    cfg.set_user_data_size(user_data_size);
+    let min_scratch_size = hyperlight_common::layout::min_scratch_size(
+        SandboxConfiguration::DEFAULT_INPUT_SIZE,
+        SandboxConfiguration::DEFAULT_OUTPUT_SIZE,
+        user_data_size,
+    );
+    cfg.set_scratch_size(min_scratch_size + 0x20000);
+    cfg
+}
+
+fn user_data_payload(len: usize) -> Vec<u8> {
+    (0..len).map(|i| (i % 251) as u8).collect()
+}
+
+fn transformed_user_data_payload(payload: &[u8]) -> Vec<u8> {
+    payload.iter().map(|byte| byte.wrapping_add(1)).collect()
+}
 
 #[test]
 fn pass_byte_array() {
@@ -224,6 +244,87 @@ fn small_scratch_sandbox() {
         a.unwrap_err(),
         HyperlightError::MemoryRequestTooSmall(..)
     ));
+}
+
+#[test]
+fn user_data_roundtrip_with_rust_and_c_guests() {
+    for user_data_size in [0, 1, 4097, 64 * 1024, 1024 * 1024] {
+        let cfg = user_data_test_config(user_data_size);
+        with_all_sandboxes_cfg(Some(cfg), |mut sandbox| {
+            assert_eq!(user_data_size, sandbox.user_data_size());
+
+            let guest_size: u64 = sandbox.call("UserDataSize", ()).unwrap();
+            assert_eq!(user_data_size, guest_size as usize);
+
+            let guest_address: u64 = sandbox.call("UserDataAddress", ()).unwrap();
+            assert_ne!(0, guest_address);
+
+            let guest_sees_zeroes: bool = sandbox
+                .call("VerifyUserDataZeros", user_data_size as u64)
+                .unwrap();
+            assert!(guest_sees_zeroes);
+
+            let payload = user_data_payload(user_data_size);
+            sandbox.write_user_data(&payload).unwrap();
+
+            if user_data_size <= 4097 {
+                let read_back: Vec<u8> = sandbox
+                    .call("ReadUserData", (user_data_size as u64, payload.clone()))
+                    .unwrap();
+                assert_eq!(payload, read_back);
+            }
+
+            let transformed_len: i32 = sandbox
+                .call("TransformUserData", user_data_size as u64)
+                .unwrap();
+            assert_eq!(user_data_size, transformed_len as usize);
+
+            let mut out = vec![0; user_data_size];
+            sandbox.read_user_data(&mut out).unwrap();
+            assert_eq!(transformed_user_data_payload(&payload), out);
+
+            let half_len = user_data_size / 2;
+            let half_payload = user_data_payload(half_len);
+            sandbox.write_user_data(&half_payload).unwrap();
+            let transformed_len: i32 = sandbox.call("TransformUserData", half_len as u64).unwrap();
+            assert_eq!(half_len, transformed_len as usize);
+
+            let mut half_out = vec![0; half_len];
+            sandbox.read_user_data(&mut half_out).unwrap();
+            assert_eq!(transformed_user_data_payload(&half_payload), half_out);
+        });
+    }
+}
+
+#[test]
+fn user_data_guest_capacity_plus_one_is_rejected() {
+    for user_data_size in [0, 4097] {
+        let cfg = user_data_test_config(user_data_size);
+        with_all_sandboxes_cfg(Some(cfg), |mut sandbox| {
+            let result = sandbox.call::<i32>("TransformUserData", (user_data_size + 1) as u64);
+            match result {
+                Ok(-1) => {}
+                Err(HyperlightError::GuestError(_, _)) => {}
+                other => panic!("expected guest capacity rejection, got {other:?}"),
+            }
+        });
+    }
+}
+
+#[test]
+fn user_data_failed_guest_call_leaves_application_defined_contents() {
+    let cfg = user_data_test_config(4097);
+    with_rust_sandbox_cfg(cfg, |mut sandbox| {
+        let payload = vec![1, 2, 3];
+        sandbox.write_user_data(&payload).unwrap();
+
+        let err = sandbox.call::<i32>("TransformUserDataAndFail", payload.len() as u64);
+        assert!(matches!(err, Err(HyperlightError::GuestError(_, _))));
+
+        let mut out = vec![0; payload.len()];
+        sandbox.read_user_data(&mut out).unwrap();
+        assert_eq!(vec![2, 2, 3], out);
+    });
 }
 
 #[test]

--- a/src/tests/c_guests/c_simpleguest/main.c
+++ b/src/tests/c_guests/c_simpleguest/main.c
@@ -218,6 +218,55 @@ hl_Vec *get_size_prefixed_buffer(const hl_FunctionCall* params) {
   return hl_flatbuffer_result_from_Bytes(input.data, input.len);
 }
 
+uint64_t user_data_size(void) {
+  return (uint64_t)hl_user_data_size();
+}
+
+uint64_t user_data_address(void) {
+  return (uint64_t)(uintptr_t)hl_user_data_ptr();
+}
+
+bool verify_user_data_zeros(uint64_t len) {
+  uint8_t *user_data = hl_user_data_ptr();
+  size_t user_data_size = hl_user_data_size();
+  if (len > user_data_size) {
+    return false;
+  }
+  for (uint64_t i = 0; i < len; i++) {
+    if (user_data[i] != 0) {
+      return false;
+    }
+  }
+  return true;
+}
+
+int transform_user_data(uint64_t len) {
+  uint8_t *user_data = hl_user_data_ptr();
+  size_t user_data_size = hl_user_data_size();
+  if (len > user_data_size) {
+    hl_set_error(hl_ErrorCode_GuestError, "User data transform length exceeds capacity");
+    return -1;
+  }
+  for (uint64_t i = 0; i < len; i++) {
+    user_data[i] = (uint8_t)(user_data[i] + 1);
+  }
+  return (int)len;
+}
+
+hl_Vec *read_user_data(const hl_FunctionCall* params) {
+  uint64_t len = params->parameters[0].value.ULong;
+  hl_Vec expected = params->parameters[1].value.VecBytes;
+  uint8_t *user_data = hl_user_data_ptr();
+  size_t user_data_size = hl_user_data_size();
+  if (len > user_data_size || expected.len != len ||
+      memcmp(user_data, expected.data, len) != 0) {
+    uint8_t empty = 0;
+    hl_set_error(hl_ErrorCode_GuestError, "User data does not contain the expected data");
+    return hl_flatbuffer_result_from_Bytes(&empty, 0);
+  }
+  return hl_flatbuffer_result_from_Bytes(user_data, len);
+}
+
 int guest_abort_with_code(int32_t code) {
   hl_abort_with_code(code);
   return -1;
@@ -243,6 +292,19 @@ hl_Vec *twenty_four_k_in_eight_k_out(const hl_FunctionCall* params) {
   hl_Vec input = params->parameters[0].value.VecBytes;
   assert(input.len == 24 * 1024);
   return hl_flatbuffer_result_from_Bytes(input.data, 8 * 1024);
+}
+
+int twenty_four_k_in_eight_k_out_user_data(uint64_t input_len, uint64_t output_len) {
+  uint8_t *user_data = hl_user_data_ptr();
+  size_t user_data_size = hl_user_data_size();
+  if (input_len != 24 * 1024 || output_len != 8 * 1024 ||
+      input_len > user_data_size) {
+    hl_set_error(hl_ErrorCode_GuestError, "Expected 24K input and 8K output sizes");
+    return -1;
+  }
+  volatile uint8_t first_output_byte = user_data[0];
+  (void)first_output_byte;
+  return (int)output_len;
 }
 
 int guest_function(const char *from_host) {
@@ -360,11 +422,16 @@ HYPERLIGHT_WRAP_FUNCTION(print_eleven_args, Int, 11, String, Int, Long, String, 
 HYPERLIGHT_WRAP_FUNCTION(echo_float, Float, 1, Float)
 HYPERLIGHT_WRAP_FUNCTION(echo_double, Double, 1, Double)
 HYPERLIGHT_WRAP_FUNCTION(set_static, Int, 0)
+HYPERLIGHT_WRAP_FUNCTION(user_data_size, ULong, 0)
+HYPERLIGHT_WRAP_FUNCTION(user_data_address, ULong, 0)
+HYPERLIGHT_WRAP_FUNCTION(verify_user_data_zeros, Bool, 1, ULong)
+HYPERLIGHT_WRAP_FUNCTION(transform_user_data, Int, 1, ULong)
 // HYPERLIGHT_WRAP_FUNCTION(get_size_prefixed_buffer, Int, 1, VecBytes) is not valid for functions that return VecBytes
 HYPERLIGHT_WRAP_FUNCTION(guest_abort_with_msg, Int, 2, Int, String)
 HYPERLIGHT_WRAP_FUNCTION(guest_abort_with_code, Int, 1, Int)
 HYPERLIGHT_WRAP_FUNCTION(execute_on_stack, Int, 0)
 HYPERLIGHT_WRAP_FUNCTION(log_message, Int, 2, String, Long)
+HYPERLIGHT_WRAP_FUNCTION(twenty_four_k_in_eight_k_out_user_data, Int, 2, ULong, ULong)
 // HYPERLIGHT_WRAP_FUNCTION(twenty_four_k_in_eight_k_out, VecBytes, 1, VecBytes) is not valid for functions that return VecBytes
 
 void hyperlight_main(void)
@@ -399,9 +466,14 @@ void hyperlight_main(void)
     HYPERLIGHT_REGISTER_FUNCTION("EchoFloat", echo_float);
     HYPERLIGHT_REGISTER_FUNCTION("EchoDouble", echo_double);
     HYPERLIGHT_REGISTER_FUNCTION("SetStatic", set_static);
+    HYPERLIGHT_REGISTER_FUNCTION("UserDataSize", user_data_size);
+    HYPERLIGHT_REGISTER_FUNCTION("UserDataAddress", user_data_address);
+    HYPERLIGHT_REGISTER_FUNCTION("VerifyUserDataZeros", verify_user_data_zeros);
+    HYPERLIGHT_REGISTER_FUNCTION("TransformUserData", transform_user_data);
     // HYPERLIGHT_REGISTER_FUNCTION macro does not work for functions that return VecBytes,
     // so we use hl_register_function_definition directly
     hl_register_function_definition("GetSizePrefixedBuffer", get_size_prefixed_buffer, 1, (hl_ParameterType[]){hl_ParameterType_VecBytes}, hl_ReturnType_VecBytes);
+    hl_register_function_definition("ReadUserData", read_user_data, 2, (hl_ParameterType[]){hl_ParameterType_ULong, hl_ParameterType_VecBytes}, hl_ReturnType_VecBytes);
     HYPERLIGHT_REGISTER_FUNCTION("GuestAbortWithCode", guest_abort_with_code);
     HYPERLIGHT_REGISTER_FUNCTION("GuestAbortWithMessage", guest_abort_with_msg);
     HYPERLIGHT_REGISTER_FUNCTION("ExecuteOnStack", execute_on_stack);
@@ -409,6 +481,7 @@ void hyperlight_main(void)
     // HYPERLIGHT_REGISTER_FUNCTION macro does not work for functions that return VecBytes,
     // so we use hl_register_function_definition directly
     hl_register_function_definition("24K_in_8K_out", twenty_four_k_in_eight_k_out, 1, (hl_ParameterType[]){hl_ParameterType_VecBytes}, hl_ReturnType_VecBytes);
+    HYPERLIGHT_REGISTER_FUNCTION("24K_in_8K_out_UserData", twenty_four_k_in_eight_k_out_user_data);
 }
 
 // This dispatch function is only used when the host dispatches a guest function

--- a/src/tests/rust_guests/simpleguest/src/main.rs
+++ b/src/tests/rust_guests/simpleguest/src/main.rs
@@ -50,7 +50,8 @@ use hyperlight_guest_bin::guest_function::definition::{GuestFunc, GuestFunctionD
 use hyperlight_guest_bin::guest_function::register::register_function;
 use hyperlight_guest_bin::host_comm::{
     call_host_function, call_host_function_without_returning_result, get_host_return_value_raw,
-    print_output_with_host_print, read_n_bytes_from_user_memory,
+    print_output_with_host_print, read_n_bytes_from_user_memory, read_user_data, user_data_ptr,
+    user_data_size, with_user_data_mut,
 };
 use hyperlight_guest_bin::memory::malloc;
 use hyperlight_guest_bin::{GUEST_HANDLE, guest_function, guest_logger, host_function};
@@ -696,6 +697,22 @@ fn twenty_four_k_in_eight_k_out(input: Vec<u8>) -> Vec<u8> {
     input[..8 * 1024].to_vec()
 }
 
+#[guest_function("24K_in_8K_out_UserData")]
+fn twenty_four_k_in_eight_k_out_user_data(input_len: u64, output_len: u64) -> Result<i32> {
+    if input_len != 24 * 1024 || output_len != 8 * 1024 {
+        return Err(HyperlightGuestError::new(
+            ErrorCode::GuestError,
+            "Expected 24K input and 8K output sizes".to_string(),
+        ));
+    }
+
+    with_user_data_mut(input_len, |bytes| {
+        let output_len = output_len as usize;
+        black_box(&bytes[..output_len]);
+        output_len as i32
+    })
+}
+
 #[guest_function("CallGivenParamlessHostFuncThatReturnsI64")]
 fn call_given_paramless_hostfunc_that_returns_i64(hostfuncname: String) -> Result<i64> {
     call_host_function::<i64>(&hostfuncname, None, ReturnType::Long)
@@ -747,6 +764,56 @@ fn read_from_user_memory(num: u64, expected: Vec<u8>) -> Result<Vec<u8>> {
     }
 
     Ok(bytes)
+}
+
+#[guest_function("UserDataSize")]
+fn get_user_data_size() -> Result<u64> {
+    user_data_size()
+}
+
+#[guest_function("UserDataAddress")]
+fn get_user_data_address() -> Result<u64> {
+    Ok(user_data_ptr()? as u64)
+}
+
+#[guest_function("VerifyUserDataZeros")]
+fn verify_user_data_zeros(len: u64) -> Result<bool> {
+    with_user_data_mut(len, |bytes| bytes.iter().all(|byte| *byte == 0))
+}
+
+#[guest_function("TransformUserData")]
+fn transform_user_data(len: u64) -> Result<i32> {
+    with_user_data_mut(len, |bytes| {
+        for byte in bytes.iter_mut() {
+            *byte = byte.wrapping_add(1);
+        }
+        bytes.len() as i32
+    })
+}
+
+#[guest_function("ReadUserData")]
+fn read_user_data_guest(len: u64, expected: Vec<u8>) -> Result<Vec<u8>> {
+    let bytes = read_user_data(len)?;
+    if bytes != expected {
+        return Err(HyperlightGuestError::new(
+            ErrorCode::GuestError,
+            "User data does not contain the expected data".to_string(),
+        ));
+    }
+    Ok(bytes)
+}
+
+#[guest_function("TransformUserDataAndFail")]
+fn transform_user_data_and_fail(len: u64) -> Result<i32> {
+    with_user_data_mut(len, |bytes| {
+        if let Some(first) = bytes.first_mut() {
+            *first = first.wrapping_add(1);
+        }
+    })?;
+    Err(HyperlightGuestError::new(
+        ErrorCode::GuestError,
+        "User data transformed before failing".to_string(),
+    ))
 }
 
 #[guest_function("ReadMappedBuffer")]


### PR DESCRIPTION
Problem:
Hyperlight embedders that move larger byte payloads across the host/guest boundary currently have to choose between two poor fits. The normal function-call path serializes parameters and returns through FlatBuffers-backed input/output stacks, which is a good contract for structured arguments but adds serialization/deserialization and stack-buffer overhead for large byte arrays. The init-data/user-memory path is also not appropriate as a mutable per-call exchange buffer: init data belongs to snapshot-backed guest state, and after copy-on-write snapshots the live guest-written bytes may no longer be readable by a simple host memcpy from the original shared region.

The missing primitive was an opt-in, bounded, host-addressable scratch buffer whose lifecycle matches transient per-call data: the host can write bytes, the guest can read or mutate them in place, the host can read the result, and restore clears the buffer because scratch is not snapshot state.

What changed:
This change adds a User Data region as a fixed-capacity slab in scratch memory, placed after the existing input and output buffers and before the copied page-table / allocator area. The capacity is configured with `SandboxConfiguration::set_user_data_size`, defaults to zero, participates in scratch minimum-size checks, and is included in layout compatibility so snapshots cannot be restored into a sandbox with a mismatched user-data capacity.

The region is advertised to guests through the PEB as a `GuestMemoryRegion`. Host code gets `MultiUseSandbox::user_data_size`, `write_user_data`, and `read_user_data`. Rust guests get capacity/pointer helpers plus bounded read/write helpers and non-allocating borrowed access helpers for larger payloads. C guests get `hl_user_data_size()` and `hl_user_data_ptr()`, intentionally exposing pointer-and-capacity metadata for caller-bounded raw access.

The implementation preserves the default behavior for existing users: capacity zero means no usable region, no additional public action is required, and the input/output buffer layout is unchanged except for the appended zero-sized user-data descriptor. When a positive capacity is configured, scratch sizing must be large enough to hold input, output, user data, fixed scratch overhead, and copied page tables.

Lifecycle and API contract:
The supported exchange pattern is: host writes bytes with `write_user_data`, guest code reads or mutates the region during a mutating/non-restoring call, then the host reads bytes with `read_user_data` before any restore. Restore clears scratch, so user data is cleared both on explicit restore and through convenience call paths that snapshot/restore around the call.

Host reads and writes start at offset zero and are whole-buffer operations from the caller's perspective. Oversized reads/writes fail before accessing adjacent scratch memory. Successful shorter writes intentionally preserve bytes after `data.len()` rather than clearing the tail. This keeps the region a raw application-managed buffer; callers that use variable-length payloads must track logical length or explicitly clear unused bytes when stale tail bytes would matter.

`MultiUseSandbox::from_snapshot` treats user-data capacity as a layout compatibility field rather than as an ignored runtime override. If the caller supplies a config whose user-data capacity differs from the snapshot layout, construction fails with the existing snapshot-layout mismatch error. This matches restore behavior and avoids surprising reuse of snapshots under incompatible raw-buffer contracts.

Security considerations and justification:
The feature stays within Hyperlight's hypervisor isolation model: the guest still only sees memory already mapped into the VM, and the host APIs bound all host copies by configured capacity. Rust guest helpers also check the PEB-advertised capacity before producing borrowed or owned access. The C API is deliberately lower-level: it exposes a raw pointer plus capacity and documents that C callers must bound their own memory operations.

The important security model change is that user data is a raw byte channel, not a FlatBuffers-verified call/return message. Bytes read by the host from user data must be treated as guest-controlled and validated by the embedder's application protocol before influencing memory access, host function calls, authorization decisions, or other security-sensitive behavior. The security docs and developer guidance now call this out explicitly.

Because short writes preserve the tail, stale bytes can leak between logical requests if an embedder reuses a sandbox and reads beyond the current logical payload length. This is an intentional raw-buffer semantic, but it is documented and tested. Embedders with tenant/request boundaries should restore, clear the full region, or maintain an application-level length field and never expose bytes past it.

The feature does not add VM/page-level guard isolation around user data. That was considered, but it would require separate mappings or page-permission changes rather than reusing the existing scratch slot. For the first release, the chosen security boundary is helper/API-level bounds over scratch memory, matching Hyperlight's existing scratch-buffer model.

Performance comparison:
A sibling sample-workload benchmark was added for the existing 24 KiB input / 8 KiB output workload. The original benchmark passes a 24 KiB byte vector through the FlatBuffers call path and returns an 8 KiB byte vector. The new sibling benchmark writes the 24 KiB input through `write_user_data`, calls a guest function that reads the region in place and reports an 8 KiB logical output, then reads the 8 KiB result with `read_user_data`.

A quick local Criterion run with `cargo bench -p hyperlight-host --bench benchmarks -- sample_workloads --warm-up-time 1 --measurement-time 2 --sample-size 10` showed:

    - FlatBuffers C guest: about 89.9 microseconds per call
    - FlatBuffers Rust guest: about 90.5 microseconds per call
    - User data C guest: about 69.2 microseconds per call
    - User data Rust guest: about 72.4 microseconds per call

That run shows the user-data path roughly 20-23 microseconds faster for this sample workload. The exact number is environment-dependent, but the direction matches the design goal: avoid FlatBuffers serialization of large byte payloads while keeping the unavoidable VM call overhead.

Alternatives considered:
1. Keep using init data with CoW-aware host reads. This was rejected because init data is snapshot-backed guest state, not transient per-call I/O. Making host reads follow CoW page-table state would add page walking and CR3/cache complexity, and would continue to blur the semantic boundary between snapshot state and scratch exchange data.
2. Exclude or special-case GuestBlob/init data from snapshots. This was rejected as too invasive: init data lives in the primary snapshot region, and carving out a writable non-snapshotted subregion would affect memory layout, snapshot construction, restore behavior, compatibility checks, and VM mappings for all users.
3. Use writable `map_region` or a separate mapping slot. This was rejected for the first cut because writable mappings are not the existing supported pattern, require separate lifecycle and memory-slot handling, and are heavier than reusing scratch memory that is already host-addressable and guest-visible.
4. Split the feature into two directional raw regions: host-write/guest-read and guest-write/host-read. This was considered in planning and rejected for this change because the primary use case is in-place transformation of a shared byte buffer. The split design gives clearer ownership for request/response protocols but doubles configuration, layout, PEB, helper, compatibility, and test surface area; it also still would not provide VM-enforced directional permissions without a larger mapping redesign.
5. Zero-fill the tail on every successful short host write. This was rejected in favor of raw buffer semantics. Preserving the tail avoids hidden work and lets applications manage subregion layout themselves. The trade-off is documented clearly: callers must track logical length or explicitly clear when stale bytes matter.
6. Provide only an allocating Rust guest read helper. This was rejected for large/hot paths after review. The final Rust guest surface includes non-allocating closure-based accessors so guests can inspect or mutate large configured regions without allocating a full `Vec` in the guest heap; the allocating helper remains as a convenience for smaller reads.

Validation:
The implementation includes configuration and layout tests for zero, one-byte, non-page-aligned 4097-byte, 64 KiB, and 1 MiB capacities. Host memory-manager tests cover fresh-zero reads, exact read/write, oversized read/write rejection, atomic oversized-write failure, and preserved tail behavior after short writes. Integration tests exercise Rust and C guests for capacity discovery, guest-visible zeroes, host-to-guest-to-host mutation, half-capacity mutation, capacity+1 rejection, and failed-call semantics. Restore tests cover explicit restore clearing, deprecated convenience-call restore clearing, capacity mismatch rejection, and `from_snapshot` behavior.

Verification performed during the change included formatting with the repository rustfmt toolchain, debug and release builds, all-target/all-feature clippy, Rust and C guest builds in debug and release, targeted debug and release user-data tests, i686 checks, and a final Society-of-Thought review with follow-up fixes for snapshot compatibility, stale-tail documentation, guest capacity+1 coverage, non-allocating guest helpers, scratch-sizing documentation, and security guidance.