### PR TITLE
Make MultiUseSandbox::map_file_cow public

### DIFF
--- a/src/hyperlight_host/src/sandbox/initialized_multi_use.rs
+++ b/src/hyperlight_host/src/sandbox/initialized_multi_use.rs
@@ -164,7 +164,7 @@ impl MultiUseSandbox {
     /// Returns the length of the mapping
     #[allow(dead_code)]
     #[instrument(err(Debug), skip(self, _fp, _guest_base), parent = Span::current())]
-    pub(crate) fn map_file_cow(&mut self, _fp: &Path, _guest_base: u64) -> Result<u64> {
+    pub fn map_file_cow(&mut self, _fp: &Path, _guest_base: u64) -> Result<u64> {
         #[cfg(windows)]
         log_then_return!("mmap'ing a file into the guest is not yet supported on Windows");
         #[cfg(unix)]


### PR DESCRIPTION
Hyperlight-wasm needs this here https://github.com/hyperlight-dev/hyperlight-wasm/blob/3aed4cc829cdc534d6d9928ffd3ad88f48f9d33f/src/hyperlight_wasm/src/sandbox/wasm_sandbox.rs#L65. It uses the version on the `MultiUseGuestCallContext` (which is gone now after Snapshot refactor), so we need it pub on the sandbox