### PR TITLE
Add macros feature to hyperlight_guest_tracing to prepare for publishing the crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1385,7 +1385,6 @@ dependencies = [
  "anyhow",
  "hyperlight-common",
  "hyperlight-guest-tracing",
- "hyperlight-guest-tracing-macro",
  "serde_json",
 ]
 
@@ -1400,7 +1399,6 @@ dependencies = [
  "hyperlight-common",
  "hyperlight-guest",
  "hyperlight-guest-tracing",
- "hyperlight-guest-tracing-macro",
  "log",
  "spin 0.10.0",
 ]
@@ -1410,6 +1408,7 @@ name = "hyperlight-guest-tracing"
 version = "0.7.0"
 dependencies = [
  "hyperlight-common",
+ "hyperlight-guest-tracing-macro",
  "spin 0.10.0",
 ]
 
@@ -1417,7 +1416,6 @@ dependencies = [
 name = "hyperlight-guest-tracing-macro"
 version = "0.7.0"
 dependencies = [
- "hyperlight-guest-tracing",
  "proc-macro2",
  "quote",
  "syn",

--- a/src/hyperlight_guest/Cargo.toml
+++ b/src/hyperlight_guest/Cargo.toml
@@ -15,9 +15,8 @@ Provides only the essential building blocks for interacting with the host enviro
 anyhow = { version = "1.0.98", default-features = false }
 serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
 hyperlight-common = { workspace = true }
-hyperlight-guest-tracing = { workspace = true, optional = true }
-hyperlight-guest-tracing-macro = { workspace = true}
+hyperlight-guest-tracing = { workspace = true, features = ["macros"] }
 
 [features]
 default = []
-trace_guest = ["dep:hyperlight-guest-tracing"]
+trace_guest = []

--- a/src/hyperlight_guest/src/exit.rs
+++ b/src/hyperlight_guest/src/exit.rs
@@ -21,22 +21,22 @@ use hyperlight_common::outb::OutBAction;
 
 /// Halt the execution of the guest and returns control to the host.
 #[inline(never)]
-#[hyperlight_guest_tracing_macro::trace_function]
+#[hyperlight_guest_tracing::trace_function]
 pub fn halt() {
     // Ensure all tracing data is flushed before halting
-    hyperlight_guest_tracing_macro::flush!();
+    hyperlight_guest_tracing::flush!();
     unsafe { asm!("hlt", options(nostack)) }
 }
 
 /// Exits the VM with an Abort OUT action and code 0.
 #[unsafe(no_mangle)]
-#[hyperlight_guest_tracing_macro::trace_function]
+#[hyperlight_guest_tracing::trace_function]
 pub extern "C" fn abort() -> ! {
     abort_with_code(&[0, 0xFF])
 }
 
 /// Exits the VM with an Abort OUT action and a specific code.
-#[hyperlight_guest_tracing_macro::trace_function]
+#[hyperlight_guest_tracing::trace_function]
 pub fn abort_with_code(code: &[u8]) -> ! {
     outb(OutBAction::Abort as u16, code);
     outb(OutBAction::Abort as u16, &[0xFF]); // send abort terminator (if not included in code)
@@ -47,7 +47,7 @@ pub fn abort_with_code(code: &[u8]) -> ! {
 ///
 /// # Safety
 /// This function is unsafe because it dereferences a raw pointer.
-#[hyperlight_guest_tracing_macro::trace_function]
+#[hyperlight_guest_tracing::trace_function]
 pub unsafe fn abort_with_code_and_message(code: &[u8], message_ptr: *const c_char) -> ! {
     unsafe {
         // Step 1: Send abort code (typically 1 byte, but `code` allows flexibility)
@@ -68,10 +68,10 @@ pub unsafe fn abort_with_code_and_message(code: &[u8], message_ptr: *const c_cha
 }
 
 /// OUT bytes to the host through multiple exits.
-#[hyperlight_guest_tracing_macro::trace_function]
+#[hyperlight_guest_tracing::trace_function]
 pub(crate) fn outb(port: u16, data: &[u8]) {
     // Ensure all tracing data is flushed before sending OUT bytes
-    hyperlight_guest_tracing_macro::flush!();
+    hyperlight_guest_tracing::flush!();
     unsafe {
         let mut i = 0;
         while i < data.len() {
@@ -88,7 +88,7 @@ pub(crate) fn outb(port: u16, data: &[u8]) {
 }
 
 /// OUT function for sending a 32-bit value to the host.
-#[hyperlight_guest_tracing_macro::trace_function]
+#[hyperlight_guest_tracing::trace_function]
 pub(crate) unsafe fn out32(port: u16, val: u32) {
     unsafe {
         asm!("out dx, eax", in("dx") port, in("eax") val, options(preserves_flags, nomem, nostack));

--- a/src/hyperlight_guest/src/guest_handle/host_comm.rs
+++ b/src/hyperlight_guest/src/guest_handle/host_comm.rs
@@ -35,7 +35,7 @@ use crate::exit::out32;
 
 impl GuestHandle {
     /// Get user memory region as bytes.
-    #[hyperlight_guest_tracing_macro::trace_function]
+    #[hyperlight_guest_tracing::trace_function]
     pub fn read_n_bytes_from_user_memory(&self, num: u64) -> Result<Vec<u8>> {
         let peb_ptr = self.peb().unwrap();
         let user_memory_region_ptr = unsafe { (*peb_ptr).init_data.ptr as *mut u8 };
@@ -64,7 +64,7 @@ impl GuestHandle {
     ///
     /// When calling `call_host_function<T>`, this function is called
     /// internally to get the return value.
-    #[hyperlight_guest_tracing_macro::trace_function]
+    #[hyperlight_guest_tracing::trace_function]
     pub fn get_host_return_value<T: TryFrom<ReturnValue>>(&self) -> Result<T> {
         let return_value = self
             .try_pop_shared_input_data_into::<ReturnValue>()
@@ -85,7 +85,7 @@ impl GuestHandle {
     ///
     /// Note: The function return value must be obtained by calling
     /// `get_host_return_value`.
-    #[hyperlight_guest_tracing_macro::trace_function]
+    #[hyperlight_guest_tracing::trace_function]
     pub fn call_host_function_without_returning_result(
         &self,
         function_name: &str,
@@ -117,7 +117,7 @@ impl GuestHandle {
     /// sends it to the host, and then retrieves the return value.
     ///
     /// The return value is deserialized into the specified type `T`.
-    #[hyperlight_guest_tracing_macro::trace_function]
+    #[hyperlight_guest_tracing::trace_function]
     pub fn call_host_function<T: TryFrom<ReturnValue>>(
         &self,
         function_name: &str,
@@ -128,7 +128,7 @@ impl GuestHandle {
         self.get_host_return_value::<T>()
     }
 
-    #[hyperlight_guest_tracing_macro::trace_function]
+    #[hyperlight_guest_tracing::trace_function]
     pub fn get_host_function_details(&self) -> HostFunctionDetails {
         let peb_ptr = self.peb().unwrap();
         let host_function_details_buffer =
@@ -145,7 +145,7 @@ impl GuestHandle {
     }
 
     /// Write an error to the shared output data buffer.
-    #[hyperlight_guest_tracing_macro::trace_function]
+    #[hyperlight_guest_tracing::trace_function]
     pub fn write_error(&self, error_code: ErrorCode, message: Option<&str>) {
         let guest_error: GuestError = GuestError::new(
             error_code,
@@ -161,7 +161,7 @@ impl GuestHandle {
     }
 
     /// Log a message with the specified log level, source, caller, source file, and line number.
-    #[hyperlight_guest_tracing_macro::trace_function]
+    #[hyperlight_guest_tracing::trace_function]
     pub fn log_message(
         &self,
         log_level: LogLevel,

--- a/src/hyperlight_guest/src/guest_handle/io.rs
+++ b/src/hyperlight_guest/src/guest_handle/io.rs
@@ -27,7 +27,7 @@ use crate::error::{HyperlightGuestError, Result};
 
 impl GuestHandle {
     /// Pops the top element from the shared input data buffer and returns it as a T
-    #[hyperlight_guest_tracing_macro::trace_function]
+    #[hyperlight_guest_tracing::trace_function]
     pub fn try_pop_shared_input_data_into<T>(&self) -> Result<T>
     where
         T: for<'a> TryFrom<&'a [u8]>,
@@ -69,7 +69,7 @@ impl GuestHandle {
         let buffer = &idb[last_element_offset_rel as usize..];
 
         // convert the buffer to T
-        let type_t = hyperlight_guest_tracing_macro::trace!(
+        let type_t = hyperlight_guest_tracing::trace!(
             "convert buffer",
             match T::try_from(buffer) {
                 Ok(t) => Ok(t),
@@ -92,7 +92,7 @@ impl GuestHandle {
     }
 
     /// Pushes the given data onto the shared output data buffer.
-    #[hyperlight_guest_tracing_macro::trace_function]
+    #[hyperlight_guest_tracing::trace_function]
     pub fn push_shared_output_data(&self, data: Vec<u8>) -> Result<()> {
         let peb_ptr = self.peb().unwrap();
         let output_stack_size = unsafe { (*peb_ptr).output_stack.size as usize };
@@ -138,7 +138,7 @@ impl GuestHandle {
         }
 
         // write the actual data
-        hyperlight_guest_tracing_macro::trace!("copy data", {
+        hyperlight_guest_tracing::trace!("copy data", {
             odb[stack_ptr_rel as usize..stack_ptr_rel as usize + data.len()].copy_from_slice(&data);
         });
 

--- a/src/hyperlight_guest_bin/Cargo.toml
+++ b/src/hyperlight_guest_bin/Cargo.toml
@@ -17,14 +17,13 @@ and third-party code used by our C-API needed to build a native hyperlight-guest
 default = ["libc", "printf"]
 libc = [] # compile musl libc
 printf = [] # compile printf
-trace_guest = ["hyperlight-common/trace_guest", "dep:hyperlight-guest-tracing", "hyperlight-guest/trace_guest"]
+trace_guest = ["hyperlight-common/trace_guest", "hyperlight-guest/trace_guest"]
 mem_profile = ["hyperlight-common/unwind_guest","hyperlight-common/mem_profile"]
 
 [dependencies]
 hyperlight-guest = { workspace = true, default-features = false }
 hyperlight-common = { workspace = true, default-features = false }
-hyperlight-guest-tracing = { workspace = true, optional = true }
-hyperlight-guest-tracing-macro = { workspace = true }
+hyperlight-guest-tracing = { workspace = true, features = ["macros"] }
 buddy_system_allocator = "0.11.0"
 log = { version = "0.4", default-features = false }
 spin = "0.10.0"

--- a/src/hyperlight_guest_bin/src/exceptions/gdt.rs
+++ b/src/hyperlight_guest_bin/src/exceptions/gdt.rs
@@ -72,7 +72,7 @@ struct GdtPointer {
 }
 
 /// Load the GDT
-#[hyperlight_guest_tracing_macro::trace_function]
+#[hyperlight_guest_tracing::trace_function]
 pub unsafe fn load_gdt() {
     unsafe {
         let gdt_ptr = GdtPointer {

--- a/src/hyperlight_guest_bin/src/exceptions/handler.rs
+++ b/src/hyperlight_guest_bin/src/exceptions/handler.rs
@@ -69,7 +69,7 @@ pub extern "C" fn hl_exception_handler(
     // call, which generates a warning because of the `abort_with_code_and_message` call which does
     // not return.
     // This is manually added to avoid the warning.
-    hyperlight_guest_tracing_macro::trace!("> hl_exception_handler");
+    hyperlight_guest_tracing::trace!("> hl_exception_handler");
 
     let ctx = stack_pointer as *mut Context;
     let exn_info = (stack_pointer + size_of::<Context>() as u64) as *mut ExceptionInfo;
@@ -101,7 +101,7 @@ pub extern "C" fn hl_exception_handler(
                 )(exception_number, exn_info, ctx, page_fault_address)
             }
         {
-            hyperlight_guest_tracing_macro::trace!("< hl_exception_handler");
+            hyperlight_guest_tracing::trace!("< hl_exception_handler");
             return;
         }
     }

--- a/src/hyperlight_guest_bin/src/exceptions/idt.rs
+++ b/src/hyperlight_guest_bin/src/exceptions/idt.rs
@@ -71,7 +71,7 @@ impl IdtEntry {
 // Architectures Software Developer's Manual).
 pub(crate) static mut IDT: [IdtEntry; 256] = unsafe { core::mem::zeroed() };
 
-#[hyperlight_guest_tracing_macro::trace_function]
+#[hyperlight_guest_tracing::trace_function]
 pub(crate) fn init_idt() {
     set_idt_entry(Exception::DivideByZero as usize, _do_excp0); // Divide by zero
     set_idt_entry(Exception::Debug as usize, _do_excp1); // Debug

--- a/src/hyperlight_guest_bin/src/exceptions/idtr.rs
+++ b/src/hyperlight_guest_bin/src/exceptions/idtr.rs
@@ -40,7 +40,7 @@ impl Idtr {
     }
 }
 
-#[hyperlight_guest_tracing_macro::trace_function]
+#[hyperlight_guest_tracing::trace_function]
 pub(crate) unsafe fn load_idt() {
     unsafe {
         init_idt();

--- a/src/hyperlight_guest_bin/src/guest_function/call.rs
+++ b/src/hyperlight_guest_bin/src/guest_function/call.rs
@@ -27,7 +27,7 @@ use crate::{GUEST_HANDLE, REGISTERED_GUEST_FUNCTIONS};
 
 type GuestFunc = fn(&FunctionCall) -> Result<Vec<u8>>;
 
-#[hyperlight_guest_tracing_macro::trace_function]
+#[hyperlight_guest_tracing::trace_function]
 pub(crate) fn call_guest_function(function_call: FunctionCall) -> Result<Vec<u8>> {
     // Validate this is a Guest Function Call
     if function_call.function_call_type() != FunctionCallType::Guest {
@@ -62,7 +62,7 @@ pub(crate) fn call_guest_function(function_call: FunctionCall) -> Result<Vec<u8>
             core::mem::transmute::<usize, GuestFunc>(function_pointer)
         };
 
-        hyperlight_guest_tracing_macro::trace!("guest_function", p_function(&function_call))
+        hyperlight_guest_tracing::trace!("guest_function", p_function(&function_call))
     } else {
         // The given function is not registered. The guest should implement a function called guest_dispatch_function to handle this.
 
@@ -73,7 +73,7 @@ pub(crate) fn call_guest_function(function_call: FunctionCall) -> Result<Vec<u8>
             fn guest_dispatch_function(function_call: FunctionCall) -> Result<Vec<u8>>;
         }
 
-        hyperlight_guest_tracing_macro::trace!("default guest function", unsafe {
+        hyperlight_guest_tracing::trace!("default guest function", unsafe {
             guest_dispatch_function(function_call)
         })
     }
@@ -83,7 +83,7 @@ pub(crate) fn call_guest_function(function_call: FunctionCall) -> Result<Vec<u8>
 // and we will leak memory as the epilogue will not be called as halt() is not going to return.
 #[unsafe(no_mangle)]
 #[inline(never)]
-#[hyperlight_guest_tracing_macro::trace_function]
+#[hyperlight_guest_tracing::trace_function]
 fn internal_dispatch_function() -> Result<()> {
     let handle = unsafe { GUEST_HANDLE };
 
@@ -104,7 +104,7 @@ fn internal_dispatch_function() -> Result<()> {
 // This is implemented as a separate function to make sure that epilogue in the internal_dispatch_function is called before the halt()
 // which if it were included in the internal_dispatch_function cause the epilogue to not be called because the halt() would not return
 // when running in the hypervisor.
-#[hyperlight_guest_tracing_macro::trace_function]
+#[hyperlight_guest_tracing::trace_function]
 pub(crate) extern "C" fn dispatch_function() {
     // The hyperlight host likes to use one partition and reset it in
     // various ways; if that has happened, there might stale TLB

--- a/src/hyperlight_guest_bin/src/lib.rs
+++ b/src/hyperlight_guest_bin/src/lib.rs
@@ -32,7 +32,7 @@ use hyperlight_common::mem::HyperlightPEB;
 use hyperlight_common::outb::OutBAction;
 use hyperlight_guest::exit::{abort_with_code_and_message, halt};
 use hyperlight_guest::guest_handle::handle::GuestHandle;
-use hyperlight_guest_tracing_macro::{trace, trace_function};
+use hyperlight_guest_tracing::{trace, trace_function};
 use log::LevelFilter;
 use spin::Once;
 

--- a/src/hyperlight_guest_bin/src/paging.rs
+++ b/src/hyperlight_guest_bin/src/paging.rs
@@ -61,6 +61,7 @@ struct MapResponse {
 ///   as such do not use concurrently with any other page table operations
 /// - TLB invalidation is not performed,
 ///   if previously-unmapped ranges are not being mapped, TLB invalidation may need to be performed afterwards.
+#[hyperlight_guest_tracing::trace_function]
 pub unsafe fn map_region(phys_base: u64, virt_base: *mut u8, len: u64) {
     let mut pml4_base: u64;
     unsafe {

--- a/src/hyperlight_guest_tracing/Cargo.toml
+++ b/src/hyperlight_guest_tracing/Cargo.toml
@@ -11,7 +11,11 @@ description = """Provides the tracing functionality for the hyperlight guest."""
 
 [dependencies]
 hyperlight-common = { workspace = true, default-features = false, features = ["trace_guest"] }
+hyperlight-guest-tracing-macro = { workspace = true, optional = true }
 spin = "0.10.0"
 
 [lints]
 workspace = true
+
+[features]
+macros = ["dep:hyperlight-guest-tracing-macro"]

--- a/src/hyperlight_guest_tracing/src/lib.rs
+++ b/src/hyperlight_guest_tracing/src/lib.rs
@@ -36,6 +36,11 @@ const MAX_NO_OF_ENTRIES: usize = 32;
 /// Maximum length of a trace message in bytes.
 pub const MAX_TRACE_MSG_LEN: usize = 64;
 
+/// Re-export the tracing macros if the feature is enabled.
+/// This allows users to use the macros without needing to import them explicitly.
+#[cfg(feature = "macros")]
+pub use hyperlight_guest_tracing_macro::*;
+
 #[derive(Debug, Copy, Clone)]
 /// Represents a trace record of a guest with a number of cycles and a message.
 pub struct TraceRecord {

--- a/src/hyperlight_guest_tracing_macro/Cargo.toml
+++ b/src/hyperlight_guest_tracing_macro/Cargo.toml
@@ -10,7 +10,6 @@ readme.workspace = true
 description = """Provides the tracing macros for the hyperlight guest, enabling structured logging and tracing capabilities."""
 
 [dependencies]
-hyperlight-guest-tracing = { workspace = true }
 proc-macro2 = "1.0"
 quote = "1.0.40"
 syn = { version = "2.0.104", features = ["full"] }

--- a/src/tests/rust_guests/callbackguest/Cargo.lock
+++ b/src/tests/rust_guests/callbackguest/Cargo.lock
@@ -86,7 +86,6 @@ dependencies = [
  "anyhow",
  "hyperlight-common",
  "hyperlight-guest-tracing",
- "hyperlight-guest-tracing-macro",
  "serde_json",
 ]
 
@@ -101,7 +100,6 @@ dependencies = [
  "hyperlight-common",
  "hyperlight-guest",
  "hyperlight-guest-tracing",
- "hyperlight-guest-tracing-macro",
  "log",
  "spin 0.10.0",
 ]
@@ -111,6 +109,7 @@ name = "hyperlight-guest-tracing"
 version = "0.7.0"
 dependencies = [
  "hyperlight-common",
+ "hyperlight-guest-tracing-macro",
  "spin 0.10.0",
 ]
 
@@ -118,7 +117,6 @@ dependencies = [
 name = "hyperlight-guest-tracing-macro"
 version = "0.7.0"
 dependencies = [
- "hyperlight-guest-tracing",
  "proc-macro2",
  "quote",
  "syn",

--- a/src/tests/rust_guests/dummyguest/Cargo.lock
+++ b/src/tests/rust_guests/dummyguest/Cargo.lock
@@ -85,7 +85,6 @@ dependencies = [
  "anyhow",
  "hyperlight-common",
  "hyperlight-guest-tracing",
- "hyperlight-guest-tracing-macro",
  "serde_json",
 ]
 
@@ -100,7 +99,6 @@ dependencies = [
  "hyperlight-common",
  "hyperlight-guest",
  "hyperlight-guest-tracing",
- "hyperlight-guest-tracing-macro",
  "log",
  "spin 0.10.0",
 ]
@@ -110,6 +108,7 @@ name = "hyperlight-guest-tracing"
 version = "0.7.0"
 dependencies = [
  "hyperlight-common",
+ "hyperlight-guest-tracing-macro",
  "spin 0.10.0",
 ]
 
@@ -117,7 +116,6 @@ dependencies = [
 name = "hyperlight-guest-tracing-macro"
 version = "0.7.0"
 dependencies = [
- "hyperlight-guest-tracing",
  "proc-macro2",
  "quote",
  "syn",

--- a/src/tests/rust_guests/simpleguest/Cargo.lock
+++ b/src/tests/rust_guests/simpleguest/Cargo.lock
@@ -77,7 +77,6 @@ dependencies = [
  "anyhow",
  "hyperlight-common",
  "hyperlight-guest-tracing",
- "hyperlight-guest-tracing-macro",
  "serde_json",
 ]
 
@@ -92,7 +91,6 @@ dependencies = [
  "hyperlight-common",
  "hyperlight-guest",
  "hyperlight-guest-tracing",
- "hyperlight-guest-tracing-macro",
  "log",
  "spin 0.10.0",
 ]
@@ -102,6 +100,7 @@ name = "hyperlight-guest-tracing"
 version = "0.7.0"
 dependencies = [
  "hyperlight-common",
+ "hyperlight-guest-tracing-macro",
  "spin 0.10.0",
 ]
 
@@ -109,7 +108,6 @@ dependencies = [
 name = "hyperlight-guest-tracing-macro"
 version = "0.7.0"
 dependencies = [
- "hyperlight-guest-tracing",
  "proc-macro2",
  "quote",
  "syn",

--- a/src/tests/rust_guests/witguest/Cargo.lock
+++ b/src/tests/rust_guests/witguest/Cargo.lock
@@ -220,7 +220,6 @@ dependencies = [
  "anyhow",
  "hyperlight-common",
  "hyperlight-guest-tracing",
- "hyperlight-guest-tracing-macro",
  "serde_json",
 ]
 
@@ -235,7 +234,6 @@ dependencies = [
  "hyperlight-common",
  "hyperlight-guest",
  "hyperlight-guest-tracing",
- "hyperlight-guest-tracing-macro",
  "log",
  "spin 0.10.0",
 ]
@@ -245,6 +243,7 @@ name = "hyperlight-guest-tracing"
 version = "0.7.0"
 dependencies = [
  "hyperlight-common",
+ "hyperlight-guest-tracing-macro",
  "spin 0.10.0",
 ]
 
@@ -252,7 +251,6 @@ dependencies = [
 name = "hyperlight-guest-tracing-macro"
 version = "0.7.0"
 dependencies = [
- "hyperlight-guest-tracing",
  "proc-macro2",
  "quote",
  "syn",


### PR DESCRIPTION
To be able to use the tracing functionality as a dependency for a guest, we need to publish the crates.
It would be best if we could only publish one crate: `hyperlight-guest-tracing`.

This PR adds a `macros` feature to the `hyperlight-guest-tracing` crate that re-exports the macros from `hyperlight-guest-tracing-macro` crate so the users don't need to have two dependencies. 