### PR TITLE
Restrict restoring sandboxes to snapshot taken on self

### DIFF
--- a/src/hyperlight_host/src/error.rs
+++ b/src/hyperlight_host/src/error.rs
@@ -221,6 +221,10 @@ pub enum HyperlightError {
     #[cfg(all(feature = "seccomp", target_os = "linux"))]
     SeccompFilterError(#[from] seccompiler::Error),
 
+    /// Tried to restore snapshot to a sandbox that is not the same as the one the snapshot was taken from
+    #[error("Snapshot was taken from a different sandbox")]
+    SnapshotSandboxMismatch,
+
     /// SystemTimeError
     #[error("SystemTimeError {0:?}")]
     SystemTimeError(#[from] SystemTimeError),

--- a/src/hyperlight_host/src/mem/mgr.rs
+++ b/src/hyperlight_host/src/mem/mgr.rs
@@ -263,9 +263,10 @@ where
     /// Create a snapshot with the given mapped regions
     pub(crate) fn snapshot(
         &mut self,
+        sandbox_id: u64,
         mapped_regions: Vec<MemoryRegion>,
     ) -> Result<SharedMemorySnapshot> {
-        SharedMemorySnapshot::new(&mut self.shared_mem, mapped_regions)
+        SharedMemorySnapshot::new(&mut self.shared_mem, sandbox_id, mapped_regions)
     }
 
     /// This function restores a memory snapshot from a given snapshot.


### PR DESCRIPTION
Requires #742

This PR makes sure sandboxes can only be restored to snapshots taken on the same sandbox. This restriction is currently needed because could cause corrupt state otherwise. We will eventually lift this restriction.

If you worry that the u64 will overflow, don't 😎 
