### PR TITLE
Update Rust version to 1.86

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -52,7 +52,7 @@ RUN SNIPPET="export PROMPT_COMMAND='history -a' && export HISTFILE=/commandhisto
 
 USER $USER
 
-ARG RUST_TOOLCHAIN=1.85
+ARG RUST_TOOLCHAIN=1.86
 
 # Install rust
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y \

--- a/.github/workflows/Benchmarks.yml
+++ b/.github/workflows/Benchmarks.yml
@@ -30,7 +30,7 @@ jobs:
 
       - uses: hyperlight-dev/ci-setup-workflow@v1.5.0
         with:
-          rust-toolchain: "1.85"
+          rust-toolchain: "1.86"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/CargoAudit.yml
+++ b/.github/workflows/CargoAudit.yml
@@ -19,7 +19,7 @@ jobs:
       # TODO: Once the runner image is updated to include the necessary tools (without downloading), we can switch to the common workflow.
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: "1.85"
+          toolchain: "1.86"
                  
       - uses: rustsec/audit-check@v2.0.0
         with:

--- a/.github/workflows/CargoPublish.yml
+++ b/.github/workflows/CargoPublish.yml
@@ -34,7 +34,7 @@ jobs:
 
       - uses: hyperlight-dev/ci-setup-workflow@v1.5.0
         with:
-          rust-toolchain: "1.85"
+          rust-toolchain: "1.86"
 
       - name: Check crate versions
         shell: bash

--- a/.github/workflows/CreateDevcontainerImage.yml
+++ b/.github/workflows/CreateDevcontainerImage.yml
@@ -16,7 +16,7 @@ env:
   USER: vscode
   GROUP: vscode
   LLVM_VERSION: 17
-  RUST_TOOLCHAIN_DEFAULT: 1.85
+  RUST_TOOLCHAIN_DEFAULT: 1.86
   RUST_TOOLCHAIN_FILE: rust-toolchain.toml
 
 # There is a single job in this workflow. It's configured to run on the latest available version of Ubuntu.

--- a/.github/workflows/CreateRelease.yml
+++ b/.github/workflows/CreateRelease.yml
@@ -23,7 +23,7 @@ jobs:
 
       - uses: hyperlight-dev/ci-setup-workflow@v1.5.0
         with:
-          rust-toolchain: "1.85"
+          rust-toolchain: "1.86"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -43,7 +43,7 @@ jobs:
 
       - uses: hyperlight-dev/ci-setup-workflow@v1.5.0
         with:
-          rust-toolchain: "1.85"
+          rust-toolchain: "1.86"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -102,7 +102,7 @@ jobs:
 
       - uses: hyperlight-dev/ci-setup-workflow@v1.5.0
         with:
-          rust-toolchain: "1.85"
+          rust-toolchain: "1.86"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -28,6 +28,6 @@ jobs:
 
       - uses: hyperlight-dev/ci-setup-workflow@v1.5.0
         with:
-          rust-toolchain: "1.85" 
+          rust-toolchain: "1.86" 
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dep_build_guest_binaries.yml
+++ b/.github/workflows/dep_build_guest_binaries.yml
@@ -33,7 +33,7 @@ jobs:
 
       - uses: hyperlight-dev/ci-setup-workflow@v1.5.0
         with:
-          rust-toolchain: "1.85"
+          rust-toolchain: "1.86"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/dep_fuzzing.yml
+++ b/.github/workflows/dep_fuzzing.yml
@@ -34,7 +34,7 @@ jobs:
 
       - uses: hyperlight-dev/ci-setup-workflow@v1.5.0
         with:
-          rust-toolchain: "1.85"
+          rust-toolchain: "1.86"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/dep_rust.yml
+++ b/.github/workflows/dep_rust.yml
@@ -48,7 +48,7 @@ jobs:
 
       - uses: hyperlight-dev/ci-setup-workflow@v1.5.0
         with:
-          rust-toolchain: "1.85" 
+          rust-toolchain: "1.86" 
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -100,7 +100,7 @@ jobs:
 
       - uses: hyperlight-dev/ci-setup-workflow@v1.5.0
         with:
-          rust-toolchain: "1.85" 
+          rust-toolchain: "1.86" 
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ exclude = [
 [workspace.package]
 version = "0.7.0"
 edition = "2024"
-rust-version = "1.85"
+rust-version = "1.86"
 license = "Apache-2.0"
 homepage = "https://github.com/hyperlight-dev/hyperlight"
 repository = "https://github.com/hyperlight-dev/hyperlight"

--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ After having an environment with a hypervisor setup, running the example has the
 
 1. On Linux or WSL, you'll most likely need build essential. For Ubuntu, run `sudo apt install build-essential`. For
    Azure Linux, run `sudo dnf install build-essential`.
-2. [Rust](https://www.rust-lang.org/tools/install). Install toolchain v1.85 or later.
+2. [Rust](https://www.rust-lang.org/tools/install). Install toolchain v1.86 or later.
 3. [just](https://github.com/casey/just). `cargo install just` On Windows you also need [pwsh](https://learn.microsoft.com/en-us/powershell/scripting/install/installing-powershell-on-windows?view=powershell-7.4).
 4. [clang and LLVM](https://clang.llvm.org/get_started.html).
     - On Ubuntu, run:

--- a/hack/rust-dependabot-patch.Dockerfile
+++ b/hack/rust-dependabot-patch.Dockerfile
@@ -1,2 +1,2 @@
 FROM dependabot/dependabot-script
-RUN rustup toolchain install 1.85 && rustup default 1.85
+RUN rustup toolchain install 1.86 && rustup default 1.86

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.85"
+channel = "1.86"
 # Target used for guest binaries. This is an additive list of targets in addition to host platform.
 # Will install the target if not already installed when building guest binaries.
 targets = ["x86_64-unknown-none", "x86_64-unknown-linux-musl"]


### PR DESCRIPTION
Updates Rust Version to 1.86

@syntactically there is a reference to 1.85 [here](https://github.com/hyperlight-dev/hyperlight/blob/main/flake.nix#L57) I did not know if this needed to be updated or how?