### PR TITLE
Rename `MultiUseSandbox` -> `Sandbox`, `UninitializedSandbox::evolve` -> `UninitializedSandbox::init`

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ fn main() -> hyperlight_host::Result<()> {
     // Note: This function is unused by the guest code below, it's just here for demonstration purposes
 
     // Initialize sandbox to be able to call host functions
-    let mut multi_use_sandbox = uninitialized_sandbox.evolve()?;
+    let mut multi_use_sandbox = uninitialized_sandbox.init()?;
 
     // Call a function in the guest
     let message = "Hello, World! I am executing inside of a VM :)\n".to_string();

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ It is followed by an example of a simple guest application using the Hyperlight 
 ```rust
 use std::thread;
 
-use hyperlight_host::{MultiUseSandbox, UninitializedSandbox};
+use hyperlight_host::{Sandbox, UninitializedSandbox};
 
 fn main() -> hyperlight_host::Result<()> {
     // Create an uninitialized sandbox with a guest binary
@@ -52,7 +52,7 @@ fn main() -> hyperlight_host::Result<()> {
     // Note: This function is unused by the guest code below, it's just here for demonstration purposes
 
     // Initialize sandbox to be able to call host functions
-    let mut multi_use_sandbox: MultiUseSandbox = uninitialized_sandbox.evolve()?;
+    let mut multi_use_sandbox = uninitialized_sandbox.evolve()?;
 
     // Call a function in the guest
     let message = "Hello, World! I am executing inside of a VM :)\n".to_string();

--- a/fuzz/fuzz_targets/guest_call.rs
+++ b/fuzz/fuzz_targets/guest_call.rs
@@ -20,10 +20,10 @@ use std::sync::{Mutex, OnceLock};
 
 use hyperlight_host::func::{ParameterValue, ReturnType};
 use hyperlight_host::sandbox::uninitialized::GuestBinary;
-use hyperlight_host::{MultiUseSandbox, UninitializedSandbox};
+use hyperlight_host::{Sandbox, UninitializedSandbox};
 use hyperlight_testing::simple_guest_for_fuzzing_as_string;
 use libfuzzer_sys::fuzz_target;
-static SANDBOX: OnceLock<Mutex<MultiUseSandbox>> = OnceLock::new();
+static SANDBOX: OnceLock<Mutex<Sandbox>> = OnceLock::new();
 
 // This fuzz target tests all combinations of ReturnType and Parameters for `call_guest_function_by_name`.
 // For fuzzing efficiency, we create one Sandbox and reuse it for all fuzzing iterations.
@@ -36,7 +36,7 @@ fuzz_target!(
         )
         .unwrap();
 
-        let mu_sbox: MultiUseSandbox = u_sbox.evolve().unwrap();
+        let mu_sbox: Sandbox = u_sbox.evolve().unwrap();
         SANDBOX.set(Mutex::new(mu_sbox)).unwrap();
     },
 

--- a/fuzz/fuzz_targets/guest_call.rs
+++ b/fuzz/fuzz_targets/guest_call.rs
@@ -36,7 +36,7 @@ fuzz_target!(
         )
         .unwrap();
 
-        let mu_sbox: Sandbox = u_sbox.evolve().unwrap();
+        let mu_sbox: Sandbox = u_sbox.init().unwrap();
         SANDBOX.set(Mutex::new(mu_sbox)).unwrap();
     },
 

--- a/fuzz/fuzz_targets/host_call.rs
+++ b/fuzz/fuzz_targets/host_call.rs
@@ -35,7 +35,7 @@ fuzz_target!(
         )
         .unwrap();
 
-        let mu_sbox: Sandbox = u_sbox.evolve().unwrap();
+        let mu_sbox: Sandbox = u_sbox.init().unwrap();
         SANDBOX.set(Mutex::new(mu_sbox)).unwrap();
     },
 

--- a/fuzz/fuzz_targets/host_call.rs
+++ b/fuzz/fuzz_targets/host_call.rs
@@ -20,10 +20,10 @@ use std::sync::{Mutex, OnceLock};
 
 use hyperlight_host::func::{ParameterValue, ReturnType};
 use hyperlight_host::sandbox::uninitialized::GuestBinary;
-use hyperlight_host::{HyperlightError, MultiUseSandbox, UninitializedSandbox};
+use hyperlight_host::{HyperlightError, Sandbox, UninitializedSandbox};
 use hyperlight_testing::simple_guest_for_fuzzing_as_string;
 use libfuzzer_sys::fuzz_target;
-static SANDBOX: OnceLock<Mutex<MultiUseSandbox>> = OnceLock::new();
+static SANDBOX: OnceLock<Mutex<Sandbox>> = OnceLock::new();
 
 // This fuzz target tests all combinations of ReturnType and Parameters for `call_guest_function_by_name`.
 // For fuzzing efficiency, we create one Sandbox and reuse it for all fuzzing iterations.
@@ -35,7 +35,7 @@ fuzz_target!(
         )
         .unwrap();
 
-        let mu_sbox: MultiUseSandbox = u_sbox.evolve().unwrap();
+        let mu_sbox: Sandbox = u_sbox.evolve().unwrap();
         SANDBOX.set(Mutex::new(mu_sbox)).unwrap();
     },
 

--- a/fuzz/fuzz_targets/host_print.rs
+++ b/fuzz/fuzz_targets/host_print.rs
@@ -21,7 +21,7 @@ fuzz_target!(
         )
         .unwrap();
 
-        let mu_sbox: Sandbox = u_sbox.evolve().unwrap();
+        let mu_sbox: Sandbox = u_sbox.init().unwrap();
         SANDBOX.set(Mutex::new(mu_sbox)).unwrap();
     },
 

--- a/fuzz/fuzz_targets/host_print.rs
+++ b/fuzz/fuzz_targets/host_print.rs
@@ -3,11 +3,11 @@
 use std::sync::{Mutex, OnceLock};
 
 use hyperlight_host::sandbox::uninitialized::GuestBinary;
-use hyperlight_host::{MultiUseSandbox, UninitializedSandbox};
+use hyperlight_host::{Sandbox, UninitializedSandbox};
 use hyperlight_testing::simple_guest_for_fuzzing_as_string;
 use libfuzzer_sys::{Corpus, fuzz_target};
 
-static SANDBOX: OnceLock<Mutex<MultiUseSandbox>> = OnceLock::new();
+static SANDBOX: OnceLock<Mutex<Sandbox>> = OnceLock::new();
 
 // This fuzz target is used to test the HostPrint host function. We generate
 // an arbitrary ParameterValue::String, which is passed to the guest, which passes
@@ -21,7 +21,7 @@ fuzz_target!(
         )
         .unwrap();
 
-        let mu_sbox: MultiUseSandbox = u_sbox.evolve().unwrap();
+        let mu_sbox: Sandbox = u_sbox.evolve().unwrap();
         SANDBOX.set(Mutex::new(mu_sbox)).unwrap();
     },
 

--- a/src/hyperlight_component_util/src/host.rs
+++ b/src/hyperlight_component_util/src/host.rs
@@ -359,7 +359,7 @@ fn emit_component<'a, 'b, 'c>(s: &'c mut State<'a, 'b>, wn: WitName, ct: &'c Com
             type Exports<I: #ns::#import_trait + ::std::marker::Send> = #wrapper_name<I, ::hyperlight_host::sandbox::sandbox::Sandbox>;
             fn instantiate<I: #ns::#import_trait + ::std::marker::Send + 'static>(mut self, i: I) -> Self::Exports<I> {
                 let rts = register_host_functions(&mut self, i);
-                let sb = self.evolve().unwrap();
+                let sb = self.init().unwrap();
                 #wrapper_name {
                     sb,
                     rt: rts,

--- a/src/hyperlight_component_util/src/host.rs
+++ b/src/hyperlight_component_util/src/host.rs
@@ -356,7 +356,7 @@ fn emit_component<'a, 'b, 'c>(s: &'c mut State<'a, 'b>, wn: WitName, ct: &'c Com
             #(#exports)*
         }
         impl #ns::#r#trait for ::hyperlight_host::sandbox::UninitializedSandbox {
-            type Exports<I: #ns::#import_trait + ::std::marker::Send> = #wrapper_name<I, ::hyperlight_host::sandbox::initialized_multi_use::MultiUseSandbox>;
+            type Exports<I: #ns::#import_trait + ::std::marker::Send> = #wrapper_name<I, ::hyperlight_host::sandbox::sandbox::Sandbox>;
             fn instantiate<I: #ns::#import_trait + ::std::marker::Send + 'static>(mut self, i: I) -> Self::Exports<I> {
                 let rts = register_host_functions(&mut self, i);
                 let sb = self.evolve().unwrap();

--- a/src/hyperlight_host/benches/benchmarks.rs
+++ b/src/hyperlight_host/benches/benchmarks.rs
@@ -16,9 +16,7 @@ limitations under the License.
 
 use criterion::{Criterion, criterion_group, criterion_main};
 use hyperlight_host::GuestBinary;
-use hyperlight_host::sandbox::{
-    Callable, Sandbox, SandboxConfiguration, UninitializedSandbox,
-};
+use hyperlight_host::sandbox::{Callable, Sandbox, SandboxConfiguration, UninitializedSandbox};
 use hyperlight_testing::simple_guest_as_string;
 
 fn create_uninit_sandbox() -> UninitializedSandbox {

--- a/src/hyperlight_host/benches/benchmarks.rs
+++ b/src/hyperlight_host/benches/benchmarks.rs
@@ -17,7 +17,7 @@ limitations under the License.
 use criterion::{Criterion, criterion_group, criterion_main};
 use hyperlight_host::GuestBinary;
 use hyperlight_host::sandbox::{
-    Callable, MultiUseSandbox, SandboxConfiguration, UninitializedSandbox,
+    Callable, Sandbox, SandboxConfiguration, UninitializedSandbox,
 };
 use hyperlight_testing::simple_guest_as_string;
 
@@ -26,7 +26,7 @@ fn create_uninit_sandbox() -> UninitializedSandbox {
     UninitializedSandbox::new(GuestBinary::FilePath(path), None).unwrap()
 }
 
-fn create_multiuse_sandbox() -> MultiUseSandbox {
+fn create_multiuse_sandbox() -> Sandbox {
     create_uninit_sandbox().evolve().unwrap()
 }
 
@@ -63,7 +63,7 @@ fn guest_call_benchmark(c: &mut Criterion) {
             .register("HostAdd", |a: i32, b: i32| Ok(a + b))
             .unwrap();
 
-        let mut multiuse_sandbox: MultiUseSandbox = uninitialized_sandbox.evolve().unwrap();
+        let mut multiuse_sandbox: Sandbox = uninitialized_sandbox.evolve().unwrap();
 
         b.iter(|| {
             multiuse_sandbox

--- a/src/hyperlight_host/benches/benchmarks.rs
+++ b/src/hyperlight_host/benches/benchmarks.rs
@@ -27,7 +27,7 @@ fn create_uninit_sandbox() -> UninitializedSandbox {
 }
 
 fn create_multiuse_sandbox() -> Sandbox {
-    create_uninit_sandbox().evolve().unwrap()
+    create_uninit_sandbox().init().unwrap()
 }
 
 fn guest_call_benchmark(c: &mut Criterion) {
@@ -63,7 +63,7 @@ fn guest_call_benchmark(c: &mut Criterion) {
             .register("HostAdd", |a: i32, b: i32| Ok(a + b))
             .unwrap();
 
-        let mut multiuse_sandbox: Sandbox = uninitialized_sandbox.evolve().unwrap();
+        let mut multiuse_sandbox: Sandbox = uninitialized_sandbox.init().unwrap();
 
         b.iter(|| {
             multiuse_sandbox
@@ -95,7 +95,7 @@ fn guest_call_benchmark_large_param(c: &mut Criterion) {
             Some(config),
         )
         .unwrap();
-        let mut sandbox = sandbox.evolve().unwrap();
+        let mut sandbox = sandbox.init().unwrap();
 
         b.iter(|| {
             sandbox

--- a/src/hyperlight_host/examples/func_ctx/main.rs
+++ b/src/hyperlight_host/examples/func_ctx/main.rs
@@ -24,7 +24,7 @@ fn main() {
     let path = simple_guest_as_string().unwrap();
     let mut sbox = UninitializedSandbox::new(GuestBinary::FilePath(path), None)
         .unwrap()
-        .evolve()
+        .init()
         .unwrap();
 
     // Do several calls against a sandbox running the `simpleguest.exe` binary,

--- a/src/hyperlight_host/examples/func_ctx/main.rs
+++ b/src/hyperlight_host/examples/func_ctx/main.rs
@@ -19,7 +19,7 @@ use hyperlight_host::sandbox::UninitializedSandbox;
 use hyperlight_testing::simple_guest_as_string;
 
 fn main() {
-    // create a new `MultiUseSandbox` configured to run the `simpleguest.exe`
+    // create a new `Sandbox` configured to run the `simpleguest.exe`
     // test guest binary
     let path = simple_guest_as_string().unwrap();
     let mut sbox = UninitializedSandbox::new(GuestBinary::FilePath(path), None)

--- a/src/hyperlight_host/examples/guest-debugging/main.rs
+++ b/src/hyperlight_host/examples/guest-debugging/main.rs
@@ -68,8 +68,8 @@ fn main() -> hyperlight_host::Result<()> {
     // Note: This function is unused, it's just here for demonstration purposes
 
     // Initialize sandboxes to be able to call host functions
-    let mut multi_use_sandbox_dbg: Sandbox = uninitialized_sandbox_dbg.evolve()?;
-    let mut multi_use_sandbox: Sandbox = uninitialized_sandbox.evolve()?;
+    let mut multi_use_sandbox_dbg: Sandbox = uninitialized_sandbox_dbg.init()?;
+    let mut multi_use_sandbox: Sandbox = uninitialized_sandbox.init()?;
 
     // Call guest function
     let message =

--- a/src/hyperlight_host/examples/guest-debugging/main.rs
+++ b/src/hyperlight_host/examples/guest-debugging/main.rs
@@ -19,7 +19,7 @@ use std::thread;
 use hyperlight_host::sandbox::SandboxConfiguration;
 #[cfg(gdb)]
 use hyperlight_host::sandbox::config::DebugInfo;
-use hyperlight_host::{MultiUseSandbox, UninitializedSandbox};
+use hyperlight_host::{Sandbox, UninitializedSandbox};
 
 /// Build a sandbox configuration that enables GDB debugging when the `gdb` feature is enabled.
 fn get_sandbox_cfg() -> Option<SandboxConfiguration> {
@@ -68,8 +68,8 @@ fn main() -> hyperlight_host::Result<()> {
     // Note: This function is unused, it's just here for demonstration purposes
 
     // Initialize sandboxes to be able to call host functions
-    let mut multi_use_sandbox_dbg: MultiUseSandbox = uninitialized_sandbox_dbg.evolve()?;
-    let mut multi_use_sandbox: MultiUseSandbox = uninitialized_sandbox.evolve()?;
+    let mut multi_use_sandbox_dbg: Sandbox = uninitialized_sandbox_dbg.evolve()?;
+    let mut multi_use_sandbox: Sandbox = uninitialized_sandbox.evolve()?;
 
     // Call guest function
     let message =

--- a/src/hyperlight_host/examples/hello-world/main.rs
+++ b/src/hyperlight_host/examples/hello-world/main.rs
@@ -16,7 +16,7 @@ limitations under the License.
 #![allow(clippy::disallowed_macros)]
 use std::thread;
 
-use hyperlight_host::{MultiUseSandbox, UninitializedSandbox};
+use hyperlight_host::{Sandbox, UninitializedSandbox};
 
 fn main() -> hyperlight_host::Result<()> {
     // Create an uninitialized sandbox with a guest binary
@@ -35,7 +35,7 @@ fn main() -> hyperlight_host::Result<()> {
     // Note: This function is unused, it's just here for demonstration purposes
 
     // Initialize sandbox to be able to call host functions
-    let mut multi_use_sandbox: MultiUseSandbox = uninitialized_sandbox.evolve()?;
+    let mut multi_use_sandbox: Sandbox = uninitialized_sandbox.evolve()?;
 
     // Call guest function
     let message = "Hello, World! I am executing inside of a VM :)\n".to_string();

--- a/src/hyperlight_host/examples/hello-world/main.rs
+++ b/src/hyperlight_host/examples/hello-world/main.rs
@@ -35,7 +35,7 @@ fn main() -> hyperlight_host::Result<()> {
     // Note: This function is unused, it's just here for demonstration purposes
 
     // Initialize sandbox to be able to call host functions
-    let mut multi_use_sandbox: Sandbox = uninitialized_sandbox.evolve()?;
+    let mut multi_use_sandbox: Sandbox = uninitialized_sandbox.init()?;
 
     // Call guest function
     let message = "Hello, World! I am executing inside of a VM :)\n".to_string();

--- a/src/hyperlight_host/examples/logging/main.rs
+++ b/src/hyperlight_host/examples/logging/main.rs
@@ -45,7 +45,7 @@ fn main() -> Result<()> {
             usandbox.register_print(fn_writer)?;
 
             // Initialize the sandbox.
-            let mut multiuse_sandbox = usandbox.evolve()?;
+            let mut multiuse_sandbox = usandbox.init()?;
 
             // Call a guest function 5 times to generate some log entries.
             for _ in 0..5 {
@@ -75,7 +75,7 @@ fn main() -> Result<()> {
         UninitializedSandbox::new(GuestBinary::FilePath(hyperlight_guest_path.clone()), None)?;
 
     // Initialize the sandbox.
-    let mut multiuse_sandbox = usandbox.evolve()?;
+    let mut multiuse_sandbox = usandbox.init()?;
     let interrupt_handle = multiuse_sandbox.interrupt_handle();
     let barrier = Arc::new(Barrier::new(2));
     let barrier2 = barrier.clone();

--- a/src/hyperlight_host/examples/metrics/main.rs
+++ b/src/hyperlight_host/examples/metrics/main.rs
@@ -56,7 +56,7 @@ fn do_hyperlight_stuff() {
             usandbox.register_print(fn_writer)?;
 
             // Initialize the sandbox.
-            let mut multiuse_sandbox = usandbox.evolve().expect("Failed to evolve sandbox");
+            let mut multiuse_sandbox = usandbox.init().expect("Failed to init sandbox");
 
             // Call a guest function 5 times to generate some metrics.
             for _ in 0..5 {
@@ -87,7 +87,7 @@ fn do_hyperlight_stuff() {
             .expect("Failed to create UninitializedSandbox");
 
     // Initialize the sandbox.
-    let mut multiuse_sandbox = usandbox.evolve().expect("Failed to evolve sandbox");
+    let mut multiuse_sandbox = usandbox.init().expect("Failed to init sandbox");
     let interrupt_handle = multiuse_sandbox.interrupt_handle();
 
     const NUM_CALLS: i32 = 5;

--- a/src/hyperlight_host/examples/tracing-chrome/main.rs
+++ b/src/hyperlight_host/examples/tracing-chrome/main.rs
@@ -32,7 +32,7 @@ fn main() -> Result<()> {
     // Create a new sandbox.
     let usandbox = UninitializedSandbox::new(GuestBinary::FilePath(simple_guest_path), None)?;
 
-    let mut sbox = usandbox.evolve().unwrap();
+    let mut sbox = usandbox.init().unwrap();
 
     // do the function call
     let current_time = std::time::Instant::now();

--- a/src/hyperlight_host/examples/tracing-otlp/main.rs
+++ b/src/hyperlight_host/examples/tracing-otlp/main.rs
@@ -131,7 +131,7 @@ fn run_example(wait_input: bool) -> HyperlightResult<()> {
                 usandbox.register_print(fn_writer)?;
 
                 // Initialize the sandbox.
-                let mut multiuse_sandbox = usandbox.evolve()?;
+                let mut multiuse_sandbox = usandbox.init()?;
 
                 // Call a guest function 5 times to generate some log entries.
                 for _ in 0..5 {

--- a/src/hyperlight_host/examples/tracing-tracy/main.rs
+++ b/src/hyperlight_host/examples/tracing-tracy/main.rs
@@ -38,7 +38,7 @@ fn main() -> Result<()> {
     // Create a new sandbox.
     let usandbox = UninitializedSandbox::new(GuestBinary::FilePath(simple_guest_path), None)?;
 
-    let mut sbox = usandbox.evolve().unwrap();
+    let mut sbox = usandbox.init().unwrap();
 
     // do the function call
     let current_time = std::time::Instant::now();

--- a/src/hyperlight_host/examples/tracing/main.rs
+++ b/src/hyperlight_host/examples/tracing/main.rs
@@ -73,7 +73,7 @@ fn run_example() -> Result<()> {
             usandbox.register_print(fn_writer)?;
 
             // Initialize the sandbox.
-            let mut multiuse_sandbox = usandbox.evolve()?;
+            let mut multiuse_sandbox = usandbox.init()?;
 
             // Call a guest function 5 times to generate some log entries.
             for _ in 0..5 {
@@ -102,7 +102,7 @@ fn run_example() -> Result<()> {
         UninitializedSandbox::new(GuestBinary::FilePath(hyperlight_guest_path.clone()), None)?;
 
     // Initialize the sandbox.
-    let mut multiuse_sandbox = usandbox.evolve()?;
+    let mut multiuse_sandbox = usandbox.init()?;
     let interrupt_handle = multiuse_sandbox.interrupt_handle();
 
     // Call a function that gets cancelled by the host function 5 times to generate some log entries.

--- a/src/hyperlight_host/src/hypervisor/mod.rs
+++ b/src/hyperlight_host/src/hypervisor/mod.rs
@@ -532,7 +532,7 @@ pub(crate) mod tests {
     use crate::sandbox::uninitialized::GuestBinary;
     #[cfg(any(crashdump, gdb))]
     use crate::sandbox::uninitialized::SandboxRuntimeConfig;
-    use crate::sandbox::uninitialized_evolve::set_up_hypervisor_partition;
+    use crate::sandbox::uninitialized_init::set_up_hypervisor_partition;
     use crate::sandbox::{SandboxConfiguration, UninitializedSandbox};
     use crate::{Result, is_hypervisor_present, new_error};
 

--- a/src/hyperlight_host/src/lib.rs
+++ b/src/hyperlight_host/src/lib.rs
@@ -22,7 +22,7 @@ limitations under the License.
 //! and host-guest communication.
 //!
 //! The primary entry points are [`UninitializedSandbox`] for initial setup and
-//! [`MultiUseSandbox`] for executing guest functions.
+//! [`Sandbox`] for executing guest functions.
 //!
 //! ## Guest Requirements
 //!

--- a/src/hyperlight_host/src/lib.rs
+++ b/src/hyperlight_host/src/lib.rs
@@ -92,7 +92,7 @@ pub use error::HyperlightError;
 /// Re-export for `MemMgrWrapper` type
 /// A sandbox that can call be used to make multiple calls to guest functions,
 /// and otherwise reused multiple times
-pub use sandbox::MultiUseSandbox;
+pub use sandbox::Sandbox;
 /// The re-export for the `UninitializedSandbox` type
 pub use sandbox::UninitializedSandbox;
 /// The re-export for the `is_hypervisor_present` type

--- a/src/hyperlight_host/src/metrics/mod.rs
+++ b/src/hyperlight_host/src/metrics/mod.rs
@@ -106,7 +106,7 @@ mod tests {
             )
             .unwrap();
 
-            let mut multi = uninit.evolve().unwrap();
+            let mut multi = uninit.init().unwrap();
             let interrupt_handle = multi.interrupt_handle();
 
             // interrupt the guest function call to "Spin" after 1 second

--- a/src/hyperlight_host/src/sandbox/mod.rs
+++ b/src/hyperlight_host/src/sandbox/mod.rs
@@ -36,7 +36,7 @@ pub mod sandbox;
 pub mod uninitialized;
 /// Functionality for properly converting `UninitializedSandbox`es to
 /// initialized `Sandbox`es.
-pub(crate) mod uninitialized_evolve;
+pub(crate) mod uninitialized_init;
 
 /// Representation of a snapshot of a `Sandbox`.
 pub mod snapshot;

--- a/src/hyperlight_host/src/sandbox/mod.rs
+++ b/src/hyperlight_host/src/sandbox/mod.rs
@@ -20,9 +20,6 @@ pub mod config;
 pub(crate) mod host_funcs;
 /// Functionality for dealing with `Sandbox`es that contain Hypervisors
 pub(crate) mod hypervisor;
-/// Functionality for dealing with initialized sandboxes that can
-/// call 0 or more guest functions
-pub mod sandbox;
 /// Functionality for dealing with memory access from the VM guest
 /// executable
 pub(crate) mod mem_access;
@@ -30,6 +27,9 @@ pub(crate) mod mem_access;
 /// `SandboxMemoryManager`
 pub(crate) mod mem_mgr;
 pub(crate) mod outb;
+/// Functionality for dealing with initialized sandboxes that can
+/// call 0 or more guest functions
+pub mod sandbox;
 /// Functionality for creating uninitialized sandboxes, manipulating them,
 /// and converting them to initialized sandboxes.
 pub mod uninitialized;

--- a/src/hyperlight_host/src/sandbox/mod.rs
+++ b/src/hyperlight_host/src/sandbox/mod.rs
@@ -29,6 +29,7 @@ pub(crate) mod mem_mgr;
 pub(crate) mod outb;
 /// Functionality for dealing with initialized sandboxes that can
 /// call 0 or more guest functions
+#[allow(clippy::module_inception)]
 pub mod sandbox;
 /// Functionality for creating uninitialized sandboxes, manipulating them,
 /// and converting them to initialized sandboxes.

--- a/src/hyperlight_host/src/sandbox/mod.rs
+++ b/src/hyperlight_host/src/sandbox/mod.rs
@@ -22,7 +22,7 @@ pub(crate) mod host_funcs;
 pub(crate) mod hypervisor;
 /// Functionality for dealing with initialized sandboxes that can
 /// call 0 or more guest functions
-pub mod initialized_multi_use;
+pub mod sandbox;
 /// Functionality for dealing with memory access from the VM guest
 /// executable
 pub(crate) mod mem_access;
@@ -54,8 +54,8 @@ pub use callable::Callable;
 pub use config::SandboxConfiguration;
 #[cfg(feature = "unwind_guest")]
 use framehop::Unwinder;
-/// Re-export for the `MultiUseSandbox` type
-pub use initialized_multi_use::MultiUseSandbox;
+/// Re-export for the `Sandbox` type
+pub use sandbox::Sandbox;
 use tracing::{Span, instrument};
 /// Re-export for `GuestBinary` type
 pub use uninitialized::GuestBinary;
@@ -245,7 +245,7 @@ mod tests {
     use hyperlight_testing::simple_guest_as_string;
 
     use crate::sandbox::uninitialized::GuestBinary;
-    use crate::{MultiUseSandbox, UninitializedSandbox, new_error};
+    use crate::{Sandbox, UninitializedSandbox, new_error};
 
     #[test]
     // TODO: add support for testing on WHP
@@ -269,7 +269,7 @@ mod tests {
     #[test]
     fn check_create_and_use_sandbox_on_different_threads() {
         let unintializedsandbox_queue = Arc::new(ArrayQueue::<UninitializedSandbox>::new(10));
-        let sandbox_queue = Arc::new(ArrayQueue::<MultiUseSandbox>::new(10));
+        let sandbox_queue = Arc::new(ArrayQueue::<Sandbox>::new(10));
 
         for i in 0..10 {
             let simple_guest_path = simple_guest_as_string().expect("Guest Binary Missing");

--- a/src/hyperlight_host/src/sandbox/mod.rs
+++ b/src/hyperlight_host/src/sandbox/mod.rs
@@ -305,7 +305,7 @@ mod tests {
                         ))
                         .unwrap();
 
-                    let sandbox = uninitialized_sandbox.evolve().unwrap_or_else(|_| {
+                    let sandbox = uninitialized_sandbox.init().unwrap_or_else(|_| {
                         panic!("Failed to initialize UninitializedSandbox thread {}", i)
                     });
 

--- a/src/hyperlight_host/src/sandbox/sandbox.rs
+++ b/src/hyperlight_host/src/sandbox/sandbox.rs
@@ -468,10 +468,10 @@ mod tests {
         }
     }
 
-    /// Tests that evolving from Sandbox to Sandbox creates a new state
-    /// and restoring a snapshot from before evolving restores the previous state
+    /// Tests that calling a guest function from a Sandbox mutates its state
+    /// and restoring a snapshot restores the previous state
     #[test]
-    fn snapshot_evolve_restore_handles_state_correctly() {
+    fn snapshot_restore_resets_state_correctly() {
         let mut sbox: Sandbox = {
             let path = simple_guest_as_string().unwrap();
             let u_sbox = UninitializedSandbox::new(GuestBinary::FilePath(path), None).unwrap();

--- a/src/hyperlight_host/src/sandbox/sandbox.rs
+++ b/src/hyperlight_host/src/sandbox/sandbox.rs
@@ -430,7 +430,7 @@ mod tests {
     #[cfg(target_os = "linux")]
     use crate::mem::shared_mem::{ExclusiveSharedMemory, GuestSharedMemory, SharedMemory as _};
     use crate::sandbox::{Callable, SandboxConfiguration};
-    use crate::{GuestBinary, HyperlightError, Sandbox, Result, UninitializedSandbox};
+    use crate::{GuestBinary, HyperlightError, Result, Sandbox, UninitializedSandbox};
 
     // Tests to ensure that many (1000) function calls can be made in a call context with a small stack (1K) and heap(14K).
     // This test effectively ensures that the stack is being properly reset after each call and we are not leaking memory in the Guest.

--- a/src/hyperlight_host/src/sandbox/snapshot.rs
+++ b/src/hyperlight_host/src/sandbox/snapshot.rs
@@ -16,7 +16,7 @@ limitations under the License.
 
 use crate::mem::shared_mem_snapshot::SharedMemorySnapshot;
 
-/// A snapshot capturing the state of the memory in a `MultiUseSandbox`.
+/// A snapshot capturing the state of the memory in a `Sandbox`.
 #[derive(Clone)]
 pub struct Snapshot {
     // TODO: Use Arc<SharedMemorySnapshot>

--- a/src/hyperlight_host/src/sandbox/uninitialized.rs
+++ b/src/hyperlight_host/src/sandbox/uninitialized.rs
@@ -34,7 +34,7 @@ use crate::mem::memory_region::{DEFAULT_GUEST_BLOB_MEM_FLAGS, MemoryRegionFlags}
 use crate::mem::mgr::{STACK_COOKIE_LEN, SandboxMemoryManager};
 use crate::mem::shared_mem::ExclusiveSharedMemory;
 use crate::sandbox::SandboxConfiguration;
-use crate::{Sandbox, Result, new_error};
+use crate::{Result, Sandbox, new_error};
 
 #[cfg(all(target_os = "linux", feature = "seccomp"))]
 const EXTRA_ALLOWED_SYSCALLS_FOR_WRITER_FUNC: &[super::ExtraAllowedSyscall] = &[
@@ -421,7 +421,7 @@ mod tests {
 
     use crate::sandbox::SandboxConfiguration;
     use crate::sandbox::uninitialized::{GuestBinary, GuestEnvironment};
-    use crate::{Sandbox, Result, UninitializedSandbox, new_error};
+    use crate::{Result, Sandbox, UninitializedSandbox, new_error};
 
     #[test]
     fn test_load_extra_blob() {

--- a/src/hyperlight_host/src/sandbox/uninitialized.rs
+++ b/src/hyperlight_host/src/sandbox/uninitialized.rs
@@ -24,7 +24,7 @@ use tracing::{Span, instrument};
 
 use super::host_funcs::{FunctionRegistry, default_writer_func};
 use super::mem_mgr::MemMgrWrapper;
-use super::uninitialized_evolve::evolve_impl_multi_use;
+use super::uninitialized_init::init_impl_multi_use;
 use crate::func::host_functions::{HostFunction, register_host_function};
 use crate::func::{ParameterTuple, SupportedReturnType};
 #[cfg(feature = "build-metadata")]
@@ -97,11 +97,11 @@ impl UninitializedSandbox {
     /// Creates and initializes the virtual machine, transforming this into a ready-to-use sandbox.
     ///
     /// This method consumes the `UninitializedSandbox` and performs the final initialization
-    /// steps to create the underlying virtual machine. Once evolved, the resulting
+    /// steps to create the underlying virtual machine. Once initialized, the resulting
     /// [`Sandbox`] can execute guest code and handle function calls.
     #[instrument(err(Debug), skip_all, parent = Span::current(), level = "Trace")]
     pub fn init(self) -> Result<Sandbox> {
-        evolve_impl_multi_use(self)
+        init_impl_multi_use(self)
     }
 }
 

--- a/src/hyperlight_host/src/sandbox/uninitialized_evolve.rs
+++ b/src/hyperlight_host/src/sandbox/uninitialized_evolve.rs
@@ -43,7 +43,7 @@ use crate::sandbox::host_funcs::FunctionRegistry;
 use crate::sandbox::{HostSharedMemory, MemMgrWrapper};
 #[cfg(target_os = "linux")]
 use crate::signal_handlers::setup_signal_handlers;
-use crate::{MultiUseSandbox, Result, UninitializedSandbox, log_then_return, new_error};
+use crate::{Sandbox, Result, UninitializedSandbox, log_then_return, new_error};
 
 /// The implementation for evolving `UninitializedSandbox`es to
 /// `Sandbox`es.
@@ -120,11 +120,11 @@ where
 }
 
 #[instrument(err(Debug), skip_all, parent = Span::current(), level = "Trace")]
-pub(super) fn evolve_impl_multi_use(u_sbox: UninitializedSandbox) -> Result<MultiUseSandbox> {
+pub(super) fn evolve_impl_multi_use(u_sbox: UninitializedSandbox) -> Result<Sandbox> {
     evolve_impl(u_sbox, |hf, hshm, vm, dispatch_ptr| {
         #[cfg(gdb)]
         let dbg_mem_wrapper = dbg_mem_access_handler_wrapper(hshm.clone());
-        Ok(MultiUseSandbox::from_uninit(
+        Ok(Sandbox::from_uninit(
             hf,
             hshm,
             vm,

--- a/src/hyperlight_host/src/sandbox/uninitialized_evolve.rs
+++ b/src/hyperlight_host/src/sandbox/uninitialized_evolve.rs
@@ -43,7 +43,7 @@ use crate::sandbox::host_funcs::FunctionRegistry;
 use crate::sandbox::{HostSharedMemory, MemMgrWrapper};
 #[cfg(target_os = "linux")]
 use crate::signal_handlers::setup_signal_handlers;
-use crate::{Sandbox, Result, UninitializedSandbox, log_then_return, new_error};
+use crate::{Result, Sandbox, UninitializedSandbox, log_then_return, new_error};
 
 /// The implementation for evolving `UninitializedSandbox`es to
 /// `Sandbox`es.

--- a/src/hyperlight_host/tests/common/mod.rs
+++ b/src/hyperlight_host/tests/common/mod.rs
@@ -54,7 +54,7 @@ pub fn get_simpleguest_sandboxes(
             if let Some(writer) = writer.clone() {
                 sandbox.register_print(writer).unwrap();
             }
-            sandbox.evolve().unwrap()
+            sandbox.init().unwrap()
         })
         .collect()
 }

--- a/src/hyperlight_host/tests/common/mod.rs
+++ b/src/hyperlight_host/tests/common/mod.rs
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 use hyperlight_host::func::HostFunction;
-use hyperlight_host::{GuestBinary, Sandbox, Result, UninitializedSandbox};
+use hyperlight_host::{GuestBinary, Result, Sandbox, UninitializedSandbox};
 use hyperlight_testing::{
     c_callback_guest_as_string, c_simple_guest_as_string, callback_guest_as_string,
     simple_guest_as_string,

--- a/src/hyperlight_host/tests/common/mod.rs
+++ b/src/hyperlight_host/tests/common/mod.rs
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 use hyperlight_host::func::HostFunction;
-use hyperlight_host::{GuestBinary, MultiUseSandbox, Result, UninitializedSandbox};
+use hyperlight_host::{GuestBinary, Sandbox, Result, UninitializedSandbox};
 use hyperlight_testing::{
     c_callback_guest_as_string, c_simple_guest_as_string, callback_guest_as_string,
     simple_guest_as_string,
@@ -40,7 +40,7 @@ pub fn new_uninit_rust() -> Result<UninitializedSandbox> {
 
 pub fn get_simpleguest_sandboxes(
     writer: Option<HostFunction<i32, (String,)>>, // An optional writer to make sure correct info is passed to the host printer
-) -> Vec<MultiUseSandbox> {
+) -> Vec<Sandbox> {
     let elf_path = get_c_or_rust_simpleguest_path();
 
     let sandboxes = [

--- a/src/hyperlight_host/tests/integration_test.rs
+++ b/src/hyperlight_host/tests/integration_test.rs
@@ -59,7 +59,7 @@ fn interrupt_host_call() {
         .register_with_extra_allowed_syscalls("Spin", spin, vec![libc::SYS_clock_nanosleep])
         .unwrap();
 
-    let mut sandbox: Sandbox = usbox.evolve().unwrap();
+    let mut sandbox: Sandbox = usbox.init().unwrap();
     let interrupt_handle = sandbox.interrupt_handle();
     assert!(!interrupt_handle.dropped()); // not yet dropped
 
@@ -81,7 +81,7 @@ fn interrupt_host_call() {
 /// Makes sure a running guest call can be interrupted by the host
 #[test]
 fn interrupt_in_progress_guest_call() {
-    let mut sbox1: Sandbox = new_uninit_rust().unwrap().evolve().unwrap();
+    let mut sbox1: Sandbox = new_uninit_rust().unwrap().init().unwrap();
     let barrier = Arc::new(Barrier::new(2));
     let barrier2 = barrier.clone();
     let interrupt_handle = sbox1.interrupt_handle();
@@ -116,7 +116,7 @@ fn interrupt_in_progress_guest_call() {
 /// Makes sure interrupting a vm before the guest call has started also prevents the guest call from being executed
 #[test]
 fn interrupt_guest_call_in_advance() {
-    let mut sbox1: Sandbox = new_uninit_rust().unwrap().evolve().unwrap();
+    let mut sbox1: Sandbox = new_uninit_rust().unwrap().init().unwrap();
     let barrier = Arc::new(Barrier::new(2));
     let barrier2 = barrier.clone();
     let interrupt_handle = sbox1.interrupt_handle();
@@ -158,9 +158,9 @@ fn interrupt_guest_call_in_advance() {
 /// all possible interleavings, but can hopefully increases confidence somewhat.
 #[test]
 fn interrupt_same_thread() {
-    let mut sbox1: Sandbox = new_uninit_rust().unwrap().evolve().unwrap();
-    let mut sbox2: Sandbox = new_uninit_rust().unwrap().evolve().unwrap();
-    let mut sbox3: Sandbox = new_uninit_rust().unwrap().evolve().unwrap();
+    let mut sbox1: Sandbox = new_uninit_rust().unwrap().init().unwrap();
+    let mut sbox2: Sandbox = new_uninit_rust().unwrap().init().unwrap();
+    let mut sbox3: Sandbox = new_uninit_rust().unwrap().init().unwrap();
 
     let barrier = Arc::new(Barrier::new(2));
     let barrier2 = barrier.clone();
@@ -200,9 +200,9 @@ fn interrupt_same_thread() {
 /// Same test as above but with no per-iteration barrier, to get more possible interleavings.
 #[test]
 fn interrupt_same_thread_no_barrier() {
-    let mut sbox1: Sandbox = new_uninit_rust().unwrap().evolve().unwrap();
-    let mut sbox2: Sandbox = new_uninit_rust().unwrap().evolve().unwrap();
-    let mut sbox3: Sandbox = new_uninit_rust().unwrap().evolve().unwrap();
+    let mut sbox1: Sandbox = new_uninit_rust().unwrap().init().unwrap();
+    let mut sbox2: Sandbox = new_uninit_rust().unwrap().init().unwrap();
+    let mut sbox3: Sandbox = new_uninit_rust().unwrap().init().unwrap();
 
     let barrier = Arc::new(Barrier::new(2));
     let barrier2 = barrier.clone();
@@ -246,8 +246,8 @@ fn interrupt_same_thread_no_barrier() {
 // and that anther sandbox on the original thread does not get incorrectly killed
 #[test]
 fn interrupt_moved_sandbox() {
-    let mut sbox1: Sandbox = new_uninit_rust().unwrap().evolve().unwrap();
-    let mut sbox2: Sandbox = new_uninit_rust().unwrap().evolve().unwrap();
+    let mut sbox1: Sandbox = new_uninit_rust().unwrap().init().unwrap();
+    let mut sbox2: Sandbox = new_uninit_rust().unwrap().init().unwrap();
 
     let interrupt_handle = sbox1.interrupt_handle();
     let interrupt_handle2 = sbox2.interrupt_handle();
@@ -298,7 +298,7 @@ fn interrupt_custom_signal_no_and_retry_delay() {
         Some(config),
     )
     .unwrap()
-    .evolve()
+    .init()
     .unwrap();
 
     let interrupt_handle = sbox1.interrupt_handle();
@@ -338,7 +338,7 @@ fn interrupt_spamming_host_call() {
             // do nothing
         })
         .unwrap();
-    let mut sbox1: Sandbox = uninit.evolve().unwrap();
+    let mut sbox1: Sandbox = uninit.init().unwrap();
 
     let interrupt_handle = sbox1.interrupt_handle();
 
@@ -367,7 +367,7 @@ fn print_four_args_c_guest() {
     let path = c_simple_guest_as_string().unwrap();
     let guest_path = GuestBinary::FilePath(path);
     let uninit = UninitializedSandbox::new(guest_path, None);
-    let mut sbox1 = uninit.unwrap().evolve().unwrap();
+    let mut sbox1 = uninit.unwrap().init().unwrap();
 
     let res = sbox1.call_guest_function_by_name::<i32>(
         "PrintFourArgs",
@@ -380,7 +380,7 @@ fn print_four_args_c_guest() {
 // Checks that guest can abort with a specific code.
 #[test]
 fn guest_abort() {
-    let mut sbox1 = new_uninit().unwrap().evolve().unwrap();
+    let mut sbox1 = new_uninit().unwrap().init().unwrap();
     let error_code: u8 = 13; // this is arbitrary
     let res = sbox1
         .call_guest_function_by_name::<()>("GuestAbortWithCode", error_code as i32)
@@ -393,7 +393,7 @@ fn guest_abort() {
 
 #[test]
 fn guest_abort_with_context1() {
-    let mut sbox1 = new_uninit().unwrap().evolve().unwrap();
+    let mut sbox1 = new_uninit().unwrap().init().unwrap();
 
     let res = sbox1
         .call_guest_function_by_name::<()>("GuestAbortWithMessage", (25_i32, "Oh no".to_string()))
@@ -406,7 +406,7 @@ fn guest_abort_with_context1() {
 
 #[test]
 fn guest_abort_with_context2() {
-    let mut sbox1 = new_uninit().unwrap().evolve().unwrap();
+    let mut sbox1 = new_uninit().unwrap().init().unwrap();
 
     // The buffer size for the panic context is 1024 bytes.
     // This test will see what happens if the panic message is longer than that
@@ -460,7 +460,7 @@ fn guest_abort_c_guest() {
     let path = c_simple_guest_as_string().unwrap();
     let guest_path = GuestBinary::FilePath(path);
     let uninit = UninitializedSandbox::new(guest_path, None);
-    let mut sbox1 = uninit.unwrap().evolve().unwrap();
+    let mut sbox1 = uninit.unwrap().init().unwrap();
 
     let res = sbox1
         .call_guest_function_by_name::<()>(
@@ -477,7 +477,7 @@ fn guest_abort_c_guest() {
 #[test]
 fn guest_panic() {
     // this test is rust-specific
-    let mut sbox1 = new_uninit_rust().unwrap().evolve().unwrap();
+    let mut sbox1 = new_uninit_rust().unwrap().init().unwrap();
 
     let res = sbox1
         .call_guest_function_by_name::<()>("guest_panic", "Error... error...".to_string())
@@ -491,7 +491,7 @@ fn guest_panic() {
 #[test]
 fn guest_malloc() {
     // this test is rust-only
-    let mut sbox1 = new_uninit_rust().unwrap().evolve().unwrap();
+    let mut sbox1 = new_uninit_rust().unwrap().init().unwrap();
 
     let size_to_allocate = 2000_i32;
     sbox1
@@ -501,7 +501,7 @@ fn guest_malloc() {
 
 #[test]
 fn guest_allocate_vec() {
-    let mut sbox1 = new_uninit().unwrap().evolve().unwrap();
+    let mut sbox1 = new_uninit().unwrap().init().unwrap();
 
     let size_to_allocate = 2000_i32;
 
@@ -518,7 +518,7 @@ fn guest_allocate_vec() {
 // checks that malloc failures are captured correctly
 #[test]
 fn guest_malloc_abort() {
-    let mut sbox1 = new_uninit_rust().unwrap().evolve().unwrap();
+    let mut sbox1 = new_uninit_rust().unwrap().init().unwrap();
 
     let size = 20000000_i32; // some big number that should fail when allocated
 
@@ -542,7 +542,7 @@ fn guest_malloc_abort() {
         Some(cfg),
     )
     .unwrap();
-    let mut sbox2 = uninit.evolve().unwrap();
+    let mut sbox2 = uninit.init().unwrap();
 
     let res = sbox2.call_guest_function_by_name::<i32>(
         "CallMalloc", // uses the rust allocator to allocate a vector on heap
@@ -562,7 +562,7 @@ fn dynamic_stack_allocate_c_guest() {
     let path = c_simple_guest_as_string().unwrap();
     let guest_path = GuestBinary::FilePath(path);
     let uninit = UninitializedSandbox::new(guest_path, None);
-    let mut sbox1: Sandbox = uninit.unwrap().evolve().unwrap();
+    let mut sbox1: Sandbox = uninit.unwrap().init().unwrap();
 
     let res: i32 = sbox1
         .call_guest_function_by_name("StackAllocate", 100_i32)
@@ -578,7 +578,7 @@ fn dynamic_stack_allocate_c_guest() {
 // checks that a small buffer on stack works
 #[test]
 fn static_stack_allocate() {
-    let mut sbox1 = new_uninit().unwrap().evolve().unwrap();
+    let mut sbox1 = new_uninit().unwrap().init().unwrap();
 
     let res: i32 = sbox1.call_guest_function_by_name("SmallVar", ()).unwrap();
     assert_eq!(res, 1024);
@@ -587,7 +587,7 @@ fn static_stack_allocate() {
 // checks that a huge buffer on stack fails with stackoverflow
 #[test]
 fn static_stack_allocate_overflow() {
-    let mut sbox1 = new_uninit().unwrap().evolve().unwrap();
+    let mut sbox1 = new_uninit().unwrap().init().unwrap();
     let res = sbox1
         .call_guest_function_by_name::<i32>("LargeVar", ())
         .unwrap_err();
@@ -597,7 +597,7 @@ fn static_stack_allocate_overflow() {
 // checks that a recursive function with stack allocation works, (that chkstk can be called without overflowing)
 #[test]
 fn recursive_stack_allocate() {
-    let mut sbox1 = new_uninit().unwrap().evolve().unwrap();
+    let mut sbox1 = new_uninit().unwrap().init().unwrap();
 
     let iterations = 1_i32;
 
@@ -627,7 +627,7 @@ fn guard_page_check() {
     for offset in offsets_from_page_guard_start {
         // we have to create a sandbox each iteration because can't reuse after MMIO error in release mode
 
-        let mut sbox1 = new_uninit_rust().unwrap().evolve().unwrap();
+        let mut sbox1 = new_uninit_rust().unwrap().init().unwrap();
         let result = sbox1.call_guest_function_by_name::<String>("test_write_raw_ptr", offset);
         if guard_range.contains(&offset) {
             // should have failed
@@ -644,7 +644,7 @@ fn guard_page_check() {
 #[test]
 fn guard_page_check_2() {
     // this test is rust-guest only
-    let mut sbox1 = new_uninit_rust().unwrap().evolve().unwrap();
+    let mut sbox1 = new_uninit_rust().unwrap().init().unwrap();
 
     let result = sbox1
         .call_guest_function_by_name::<()>("InfiniteRecursion", ())
@@ -654,7 +654,7 @@ fn guard_page_check_2() {
 
 #[test]
 fn execute_on_stack() {
-    let mut sbox1 = new_uninit().unwrap().evolve().unwrap();
+    let mut sbox1 = new_uninit().unwrap().init().unwrap();
 
     let result = sbox1
         .call_guest_function_by_name::<String>("ExecuteOnStack", ())
@@ -670,7 +670,7 @@ fn execute_on_stack() {
 #[test]
 #[ignore] // ran from Justfile because requires feature "executable_heap"
 fn execute_on_heap() {
-    let mut sbox1 = new_uninit_rust().unwrap().evolve().unwrap();
+    let mut sbox1 = new_uninit_rust().unwrap().init().unwrap();
     let result = sbox1.call_guest_function_by_name::<String>("ExecuteOnHeap", ());
 
     println!("{:#?}", result);
@@ -689,7 +689,7 @@ fn execute_on_heap() {
 // checks that a recursive function with stack allocation eventually fails with stackoverflow
 #[test]
 fn recursive_stack_allocate_overflow() {
-    let mut sbox1 = new_uninit().unwrap().evolve().unwrap();
+    let mut sbox1 = new_uninit().unwrap().init().unwrap();
 
     let iterations = 10_i32;
 
@@ -764,7 +764,7 @@ fn log_test_messages(levelfilter: Option<log::LevelFilter>) {
             sbox.set_max_guest_log_level(levelfilter);
         }
 
-        let mut sbox1 = sbox.evolve().unwrap();
+        let mut sbox1 = sbox.init().unwrap();
 
         let message = format!("Hello from log_message level {}", level as i32);
         sbox1

--- a/src/hyperlight_host/tests/sandbox_host_tests.rs
+++ b/src/hyperlight_host/tests/sandbox_host_tests.rs
@@ -83,7 +83,7 @@ fn float_roundtrip() {
         f32::NAN,
         -f32::NAN,
     ];
-    let mut sandbox: Sandbox = new_uninit().unwrap().evolve().unwrap();
+    let mut sandbox: Sandbox = new_uninit().unwrap().init().unwrap();
     for f in doubles.iter() {
         let res: f64 = sandbox
             .call_guest_function_by_name("EchoDouble", *f)
@@ -330,7 +330,7 @@ fn callback_test_helper() -> Result<()> {
         })?;
 
         // call guest function that calls host function
-        let mut init_sandbox: Sandbox = sandbox.evolve()?;
+        let mut init_sandbox: Sandbox = sandbox.init()?;
         let msg = "Hello world";
         init_sandbox.call_guest_function_by_name::<i32>("GuestMethod1", msg.to_string())?;
 
@@ -372,7 +372,7 @@ fn host_function_error() -> Result<()> {
         })?;
 
         // call guest function that calls host function
-        let mut init_sandbox: Sandbox = sandbox.evolve()?;
+        let mut init_sandbox: Sandbox = sandbox.init()?;
         let msg = "Hello world";
         let res = init_sandbox
             .call_guest_function_by_name::<i32>("GuestMethod1", msg.to_string())

--- a/src/hyperlight_host/tests/sandbox_host_tests.rs
+++ b/src/hyperlight_host/tests/sandbox_host_tests.rs
@@ -21,7 +21,7 @@ use std::sync::{Arc, Mutex};
 use common::new_uninit;
 use hyperlight_host::sandbox::{Callable, SandboxConfiguration};
 use hyperlight_host::{
-    GuestBinary, HyperlightError, MultiUseSandbox, Result, UninitializedSandbox, new_error,
+    GuestBinary, HyperlightError, Sandbox, Result, UninitializedSandbox, new_error,
 };
 use hyperlight_testing::simple_guest_as_string;
 #[cfg(target_os = "windows")]
@@ -83,7 +83,7 @@ fn float_roundtrip() {
         f32::NAN,
         -f32::NAN,
     ];
-    let mut sandbox: MultiUseSandbox = new_uninit().unwrap().evolve().unwrap();
+    let mut sandbox: Sandbox = new_uninit().unwrap().evolve().unwrap();
     for f in doubles.iter() {
         let res: f64 = sandbox
             .call_guest_function_by_name("EchoDouble", *f)
@@ -330,7 +330,7 @@ fn callback_test_helper() -> Result<()> {
         })?;
 
         // call guest function that calls host function
-        let mut init_sandbox: MultiUseSandbox = sandbox.evolve()?;
+        let mut init_sandbox: Sandbox = sandbox.evolve()?;
         let msg = "Hello world";
         init_sandbox.call_guest_function_by_name::<i32>("GuestMethod1", msg.to_string())?;
 
@@ -372,7 +372,7 @@ fn host_function_error() -> Result<()> {
         })?;
 
         // call guest function that calls host function
-        let mut init_sandbox: MultiUseSandbox = sandbox.evolve()?;
+        let mut init_sandbox: Sandbox = sandbox.evolve()?;
         let msg = "Hello world";
         let res = init_sandbox
             .call_guest_function_by_name::<i32>("GuestMethod1", msg.to_string())

--- a/src/hyperlight_host/tests/sandbox_host_tests.rs
+++ b/src/hyperlight_host/tests/sandbox_host_tests.rs
@@ -21,7 +21,7 @@ use std::sync::{Arc, Mutex};
 use common::new_uninit;
 use hyperlight_host::sandbox::{Callable, SandboxConfiguration};
 use hyperlight_host::{
-    GuestBinary, HyperlightError, Sandbox, Result, UninitializedSandbox, new_error,
+    GuestBinary, HyperlightError, Result, Sandbox, UninitializedSandbox, new_error,
 };
 use hyperlight_testing::simple_guest_as_string;
 #[cfg(target_os = "windows")]

--- a/src/hyperlight_host/tests/wit_test.rs
+++ b/src/hyperlight_host/tests/wit_test.rs
@@ -18,7 +18,7 @@ limitations under the License.
 use std::sync::{Arc, Mutex};
 
 use hyperlight_common::resource::BorrowedResourceGuard;
-use hyperlight_host::{GuestBinary, MultiUseSandbox, UninitializedSandbox};
+use hyperlight_host::{GuestBinary, Sandbox, UninitializedSandbox};
 use hyperlight_testing::wit_guest_as_string;
 
 extern crate alloc;
@@ -280,7 +280,7 @@ impl test::wit::TestImports for Host {
     }
 }
 
-fn sb() -> TestSandbox<Host, MultiUseSandbox> {
+fn sb() -> TestSandbox<Host, Sandbox> {
     let path = wit_guest_as_string().unwrap();
     let guest_path = GuestBinary::FilePath(path);
     let uninit = UninitializedSandbox::new(guest_path, None).unwrap();


### PR DESCRIPTION
Rename `MultiUseSandbox` as `Sandbox`.
Rename `UninitializedSandbox::evolve` as `UninitializedSandbox::init`