### PR TITLE
Give release-blocker-action permission to read github issues

### DIFF
--- a/.github/workflows/CreateRelease.yml
+++ b/.github/workflows/CreateRelease.yml
@@ -10,6 +10,7 @@ on:
 permissions:
   contents: write
   id-token: write
+  issues: read
 
 jobs:
 


### PR DESCRIPTION
Fixes insufficent permission, see here https://github.com/hyperlight-dev/hyperlight/actions/runs/16727948409