### PR TITLE
Introduce a separate KVM error variant of HyperlightError.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1494,7 +1494,7 @@ dependencies = [
  "tracing-subscriber",
  "tracing-tracy",
  "uuid",
- "vmm-sys-util",
+ "vmm-sys-util 0.15.0",
  "windows",
  "windows-result",
  "windows-sys 0.60.2",
@@ -1787,7 +1787,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf3432d9f609fbede9f624d1dbefcce77985a9322de1d0e6d460ec05502b7fd0"
 dependencies = [
- "vmm-sys-util",
+ "vmm-sys-util 0.14.0",
 ]
 
 [[package]]
@@ -1799,7 +1799,7 @@ dependencies = [
  "bitflags 2.9.1",
  "kvm-bindings",
  "libc",
- "vmm-sys-util",
+ "vmm-sys-util 0.14.0",
 ]
 
 [[package]]
@@ -2055,7 +2055,7 @@ checksum = "f416b4432174e5a3f956a7887f4c1a4acea9511d81def67fcb8473293630ab9e"
 dependencies = [
  "libc",
  "num_enum",
- "vmm-sys-util",
+ "vmm-sys-util 0.14.0",
  "zerocopy 0.7.35",
 ]
 
@@ -2067,7 +2067,7 @@ checksum = "1e0cb5031f3243a7459b7c13d960d25420980874eebda816db24ce6077e21d43"
 dependencies = [
  "libc",
  "num_enum",
- "vmm-sys-util",
+ "vmm-sys-util 0.14.0",
  "zerocopy 0.8.26",
 ]
 
@@ -2080,7 +2080,7 @@ dependencies = [
  "libc",
  "mshv-bindings 0.2.1",
  "thiserror 1.0.69",
- "vmm-sys-util",
+ "vmm-sys-util 0.14.0",
 ]
 
 [[package]]
@@ -2092,7 +2092,7 @@ dependencies = [
  "libc",
  "mshv-bindings 0.3.2",
  "thiserror 2.0.12",
- "vmm-sys-util",
+ "vmm-sys-util 0.14.0",
 ]
 
 [[package]]
@@ -3914,6 +3914,16 @@ name = "vmm-sys-util"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d21f366bf22bfba3e868349978766a965cbe628c323d58e026be80b8357ab789"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
+]
+
+[[package]]
+name = "vmm-sys-util"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "506c62fdf617a5176827c2f9afbcf1be155b03a9b4bf9617a60dbc07e3a1642f"
 dependencies = [
  "bitflags 1.3.2",
  "libc",

--- a/src/hyperlight_host/Cargo.toml
+++ b/src/hyperlight_host/Cargo.toml
@@ -40,7 +40,7 @@ tracing-log = "0.2.0"
 tracing-core = "0.1.34"
 hyperlight-common = { workspace = true, default-features = true, features = [ "std" ] }
 hyperlight-guest-tracing = { workspace = true, default-features = true, optional = true }
-vmm-sys-util = "0.14.0"
+vmm-sys-util = "0.15.0"
 crossbeam-channel = "0.5.15"
 thiserror = "2.0.12"
 chrono = { version = "0.4", optional = true }

--- a/src/hyperlight_host/src/error.rs
+++ b/src/hyperlight_host/src/error.rs
@@ -138,6 +138,11 @@ pub enum HyperlightError {
     #[error("Conversion of str data to json failed")]
     JsonConversionFailure(#[from] serde_json::Error),
 
+    /// KVM Error Occurred
+    #[error("KVM Error {0:?}")]
+    #[cfg(kvm)]
+    KVMError(#[from] kvm_ioctls::Error),
+
     /// An attempt to get a lock from a Mutex failed.
     #[error("Unable to lock resource")]
     LockAttemptFailed(String),


### PR DESCRIPTION
Fixes a common build error which occurs when the version of vmm-sys-util crate does not match between mshv/kvm.

VmmSysError variant is now solely used for our signal registration, and is not used by mshv nor kvm code.

Kvm functions like ` Kvm::new()?` will ue the new variant automatically.

Certain Mshv functions from mshv_bindings used to use our vmm-sys-util error, which are changed in this commit.

This error only manifests when a separate crate depends on hyperlight-host, but not when we build hyperlight-host ourselves, since we check in our cargo.lock, and dependency resolution could make crates have different versions.

The error either happened in kvm code (as seen below), or in mshv code, depending on which version of vmm-sys-util hyperlight uses

```
error[E0277]: `?` couldn't convert the error to `HyperlightError`
   --> /home/ludde/hyperlight-new/src/hyperlight_host/src/hypervisor/kvm.rs:335:29
    |
335 |         let kvm = Kvm::new()?;
    |                   ----------^ the trait `From<kvm_ioctls::Error>` is not implemented for `HyperlightError`
    |                   |
    |                   this can't be annotated with `?` because it has type `Result<_, kvm_ioctls::Error>`
    |
    = note: the question mark operation (`?`) implicitly performs a conversion on the error value using the `From` trait
    = help: the following other types implement trait `From<T>`:
              `HyperlightError` implements `From<&str>`
              `HyperlightError` implements `From<BackendError>`
              `HyperlightError` implements `From<BorrowError>`
              `HyperlightError` implements `From<BorrowMutError>`
              `HyperlightError` implements `From<FromUtf8Error>`
              `HyperlightError` implements `From<Infallible>`
              `HyperlightError` implements `From<InvalidFlatbuffer>`
              `HyperlightError` implements `From<MshvError>`
            and 11 others
    = note: required for `std::result::Result<KVMDriver, HyperlightError>` to implement `FromResidual<std::result::Result<Infallible, kvm_ioctls::Error>>`

error[E0277]: `?` couldn't convert the error to `HyperlightError`
   --> /home/ludde/hyperlight-new/src/hyperlight_host/src/hypervisor/kvm.rs:337:47
    |
337 |         let vm_fd = kvm.create_vm_with_type(0)?;
    |                         ----------------------^ the trait `From<kvm_ioctls::Error>` is not implemented for `HyperlightError`
    |                         |
    |                         this can't be annotated with `?` because it has type `Result<_, kvm_ioctls::Error>`
    |
    = note: the question mark operation (`?`) implicitly performs a conversion on the error value using the `From` trait
    = help: the following other types implement trait `From<T>`:
              `HyperlightError` implements `From<&str>`
              `HyperlightError` implements `From<BackendError>`
              `HyperlightError` implements `From<BorrowError>`
              `HyperlightError` implements `From<BorrowMutError>`
              `HyperlightError` implements `From<FromUtf8Error>`
              `HyperlightError` implements `From<Infallible>`
              `HyperlightError` implements `From<InvalidFlatbuffer>`
              `HyperlightError` implements `From<MshvError>`
            and 11 others
    = note: required for `std::result::Result<KVMDriver, HyperlightError>` to implement `FromResidual<std::result::Result<Infallible, kvm_ioctls::Error>>`

error[E0277]: `?` couldn't convert the error to `HyperlightError`
   --> /home/ludde/hyperlight-new/src/hyperlight_host/src/hypervisor/kvm.rs:343:11
    |
339 |           mem_regions.iter().enumerate().try_for_each(|(i, region)| {
    |  ________________________________________-
340 | |             let mut kvm_region: kvm_userspace_memory_region = region.clone().into();
341 | |             kvm_region.slot = i as u32;
342 | |             unsafe { vm_fd.set_user_memory_region(kvm_region) }
343 | |         })?;
    | |          -^ the trait `From<kvm_ioctls::Error>` is not implemented for `HyperlightError`
    | |__________|
    |            this can't be annotated with `?` because it has type `Result<_, kvm_ioctls::Error>`
    |
    = note: the question mark operation (`?`) implicitly performs a conversion on the error value using the `From` trait
    = help: the following other types implement trait `From<T>`:
              `HyperlightError` implements `From<&str>`
              `HyperlightError` implements `From<BackendError>`
              `HyperlightError` implements `From<BorrowError>`
              `HyperlightError` implements `From<BorrowMutError>`
              `HyperlightError` implements `From<FromUtf8Error>`
              `HyperlightError` implements `From<Infallible>`
              `HyperlightError` implements `From<InvalidFlatbuffer>`
              `HyperlightError` implements `From<MshvError>`
            and 11 others
    = note: required for `std::result::Result<KVMDriver, HyperlightError>` to implement `FromResidual<std::result::Result<Infallible, kvm_ioctls::Error>>`

error[E0277]: `?` couldn't convert the error to `HyperlightError`
   --> /home/ludde/hyperlight-new/src/hyperlight_host/src/hypervisor/kvm.rs:345:47
    |
345 |         let mut vcpu_fd = vm_fd.create_vcpu(0)?;
    |                                 --------------^ the trait `From<kvm_ioctls::Error>` is not implemented for `HyperlightError`
    |                                 |
    |                                 this can't be annotated with `?` because it has type `Result<_, kvm_ioctls::Error>`
    |
    = note: the question mark operation (`?`) implicitly performs a conversion on the error value using the `From` trait
    = help: the following other types implement trait `From<T>`:
              `HyperlightError` implements `From<&str>`
              `HyperlightError` implements `From<BackendError>`
              `HyperlightError` implements `From<BorrowError>`
              `HyperlightError` implements `From<BorrowMutError>`
              `HyperlightError` implements `From<FromUtf8Error>`
              `HyperlightError` implements `From<Infallible>`
              `HyperlightError` implements `From<InvalidFlatbuffer>`
              `HyperlightError` implements `From<MshvError>`
            and 11 others
    = note: required for `std::result::Result<KVMDriver, HyperlightError>` to implement `FromResidual<std::result::Result<Infallible, kvm_ioctls::Error>>`

error[E0277]: `?` couldn't convert the error to `HyperlightError`
   --> /home/ludde/hyperlight-new/src/hyperlight_host/src/hypervisor/kvm.rs:423:44
    |
423 |         let mut sregs = vcpu_fd.get_sregs()?;
    |                                 -----------^ the trait `From<kvm_ioctls::Error>` is not implemented for `HyperlightError`
    |                                 |
    |                                 this can't be annotated with `?` because it has type `Result<_, kvm_ioctls::Error>`
    |
    = note: the question mark operation (`?`) implicitly performs a conversion on the error value using the `From` trait
    = help: the following other types implement trait `From<T>`:
              `HyperlightError` implements `From<&str>`
              `HyperlightError` implements `From<BackendError>`
              `HyperlightError` implements `From<BorrowError>`
              `HyperlightError` implements `From<BorrowMutError>`
              `HyperlightError` implements `From<FromUtf8Error>`
              `HyperlightError` implements `From<Infallible>`
              `HyperlightError` implements `From<InvalidFlatbuffer>`
              `HyperlightError` implements `From<MshvError>`
            and 11 others
    = note: required for `std::result::Result<(), HyperlightError>` to implement `FromResidual<std::result::Result<Infallible, kvm_ioctls::Error>>`

error[E0277]: `?` couldn't convert the error to `HyperlightError`
   --> /home/ludde/hyperlight-new/src/hyperlight_host/src/hypervisor/kvm.rs:436:34
    |
436 |         vcpu_fd.set_sregs(&sregs)?;
    |                 -----------------^ the trait `From<kvm_ioctls::Error>` is not implemented for `HyperlightError`
    |                 |
    |                 this can't be annotated with `?` because it has type `Result<_, kvm_ioctls::Error>`
    |
    = note: the question mark operation (`?`) implicitly performs a conversion on the error value using the `From` trait
    = help: the following other types implement trait `From<T>`:
              `HyperlightError` implements `From<&str>`
              `HyperlightError` implements `From<BackendError>`
              `HyperlightError` implements `From<BorrowError>`
              `HyperlightError` implements `From<BorrowMutError>`
              `HyperlightError` implements `From<FromUtf8Error>`
              `HyperlightError` implements `From<Infallible>`
              `HyperlightError` implements `From<InvalidFlatbuffer>`
              `HyperlightError` implements `From<MshvError>`
            and 11 others
    = note: required for `std::result::Result<(), HyperlightError>` to implement `FromResidual<std::result::Result<Infallible, kvm_ioctls::Error>>`

error[E0277]: `?` couldn't convert the error to `HyperlightError`
   --> /home/ludde/hyperlight-new/src/hyperlight_host/src/hypervisor/kvm.rs:505:37
    |
505 |         self.vcpu_fd.set_regs(&regs)?;
    |                      ---------------^ the trait `From<kvm_ioctls::Error>` is not implemented for `HyperlightError`
    |                      |
    |                      this can't be annotated with `?` because it has type `Result<_, kvm_ioctls::Error>`
    |
    = note: the question mark operation (`?`) implicitly performs a conversion on the error value using the `From` trait
    = help: the following other types implement trait `From<T>`:
              `HyperlightError` implements `From<&str>`
              `HyperlightError` implements `From<BackendError>`
              `HyperlightError` implements `From<BorrowError>`
              `HyperlightError` implements `From<BorrowMutError>`
              `HyperlightError` implements `From<FromUtf8Error>`
              `HyperlightError` implements `From<Infallible>`
              `HyperlightError` implements `From<InvalidFlatbuffer>`
              `HyperlightError` implements `From<MshvError>`
            and 11 others
    = note: required for `std::result::Result<(), HyperlightError>` to implement `FromResidual<std::result::Result<Infallible, kvm_ioctls::Error>>`

error[E0277]: `?` couldn't convert the error to `HyperlightError`
   --> /home/ludde/hyperlight-new/src/hyperlight_host/src/hypervisor/kvm.rs:543:65
    |
543 |         unsafe { self.vm_fd.set_user_memory_region(kvm_region) }?;
    |         --------------------------------------------------------^ the trait `From<kvm_ioctls::Error>` is not implemented for `HyperlightError`
    |         |
    |         this can't be annotated with `?` because it has type `Result<_, kvm_ioctls::Error>`
    |
    = note: the question mark operation (`?`) implicitly performs a conversion on the error value using the `From` trait
    = help: the following other types implement trait `From<T>`:
              `HyperlightError` implements `From<&str>`
              `HyperlightError` implements `From<BackendError>`
              `HyperlightError` implements `From<BorrowError>`
              `HyperlightError` implements `From<BorrowMutError>`
              `HyperlightError` implements `From<FromUtf8Error>`
              `HyperlightError` implements `From<Infallible>`
              `HyperlightError` implements `From<InvalidFlatbuffer>`
              `HyperlightError` implements `From<MshvError>`
            and 11 others
    = note: required for `std::result::Result<(), HyperlightError>` to implement `FromResidual<std::result::Result<Infallible, kvm_ioctls::Error>>`

error[E0277]: `?` couldn't convert the error to `HyperlightError`
   --> /home/ludde/hyperlight-new/src/hyperlight_host/src/hypervisor/kvm.rs:558:69
    |
558 |             unsafe { self.vm_fd.set_user_memory_region(kvm_region) }?;
    |             --------------------------------------------------------^ the trait `From<kvm_ioctls::Error>` is not implemented for `HyperlightError`
    |             |
    |             this can't be annotated with `?` because it has type `Result<_, kvm_ioctls::Error>`
    |
    = note: the question mark operation (`?`) implicitly performs a conversion on the error value using the `From` trait
    = help: the following other types implement trait `From<T>`:
              `HyperlightError` implements `From<&str>`
              `HyperlightError` implements `From<BackendError>`
              `HyperlightError` implements `From<BorrowError>`
              `HyperlightError` implements `From<BorrowMutError>`
              `HyperlightError` implements `From<FromUtf8Error>`
              `HyperlightError` implements `From<Infallible>`
              `HyperlightError` implements `From<InvalidFlatbuffer>`
              `HyperlightError` implements `From<MshvError>`
            and 11 others
    = note: required for `std::result::Result<(), HyperlightError>` to implement `FromResidual<std::result::Result<Infallible, kvm_ioctls::Error>>`

error[E0277]: `?` couldn't convert the error to `HyperlightError`
   --> /home/ludde/hyperlight-new/src/hyperlight_host/src/hypervisor/kvm.rs:585:37
    |
585 |         self.vcpu_fd.set_regs(&regs)?;
    |                      ---------------^ the trait `From<kvm_ioctls::Error>` is not implemented for `HyperlightError`
    |                      |
    |                      this can't be annotated with `?` because it has type `Result<_, kvm_ioctls::Error>`
    |
    = note: the question mark operation (`?`) implicitly performs a conversion on the error value using the `From` trait
    = help: the following other types implement trait `From<T>`:
              `HyperlightError` implements `From<&str>`
              `HyperlightError` implements `From<BackendError>`
              `HyperlightError` implements `From<BorrowError>`
              `HyperlightError` implements `From<BorrowMutError>`
              `HyperlightError` implements `From<FromUtf8Error>`
              `HyperlightError` implements `From<Infallible>`
              `HyperlightError` implements `From<InvalidFlatbuffer>`
              `HyperlightError` implements `From<MshvError>`
            and 11 others
    = note: required for `std::result::Result<(), HyperlightError>` to implement `FromResidual<std::result::Result<Infallible, kvm_ioctls::Error>>`

error[E0277]: `?` couldn't convert the error to `HyperlightError`
   --> /home/ludde/hyperlight-new/src/hyperlight_host/src/hypervisor/kvm.rs:594:35
    |
594 |         self.vcpu_fd.set_fpu(&fpu)?;
    |                      -------------^ the trait `From<kvm_ioctls::Error>` is not implemented for `HyperlightError`
    |                      |
    |                      this can't be annotated with `?` because it has type `Result<_, kvm_ioctls::Error>`
    |
    = note: the question mark operation (`?`) implicitly performs a conversion on the error value using the `From` trait
    = help: the following other types implement trait `From<T>`:
              `HyperlightError` implements `From<&str>`
              `HyperlightError` implements `From<BackendError>`
              `HyperlightError` implements `From<BorrowError>`
              `HyperlightError` implements `From<BorrowMutError>`
              `HyperlightError` implements `From<FromUtf8Error>`
              `HyperlightError` implements `From<Infallible>`
              `HyperlightError` implements `From<InvalidFlatbuffer>`
              `HyperlightError` implements `From<MshvError>`
            and 11 others
    = note: required for `std::result::Result<(), HyperlightError>` to implement `FromResidual<std::result::Result<Infallible, kvm_ioctls::Error>>`

```