### PR TITLE
Updates for v0.8.0 release

### DIFF
--- a/.github/workflows/CargoPublish.yml
+++ b/.github/workflows/CargoPublish.yml
@@ -46,7 +46,7 @@ jobs:
             VERSION="${VERSION#refs/heads/release/v}"
             echo "VERSION=$VERSION" >> $GITHUB_ENV
           fi
-          ./dev/verify-version.sh "$VERSION" hyperlight-common hyperlight-guest hyperlight-guest-bin hyperlight-host hyperlight-component-util hyperlight-component-macro
+          ./dev/verify-version.sh "$VERSION" hyperlight-common hyperlight-guest hyperlight-guest-bin hyperlight-host hyperlight-component-util hyperlight-component-macro hyperlight-guest-tracing-macro hyperlight-guest-tracing
 
       - name: Determine which crates need publishing
         run: |
@@ -75,6 +75,8 @@ jobs:
           needs_publish hyperlight-component-util
           needs_publish hyperlight-component-macro
           needs_publish hyperlight-host
+          needs_publish hyperlight-guest-tracing-macro
+          needs_publish hyperlight-guest-tracing
 
       - name: Publish hyperlight-common
         continue-on-error: ${{ inputs.dry_run }}
@@ -82,6 +84,20 @@ jobs:
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_PUBLISH_TOKEN }}
         if: env.PUBLISH_HYPERLIGHT_COMMON != 'false'
+      
+      - name: Publish hyperlight-guest-tracing-macro
+        continue-on-error: ${{ inputs.dry_run }}
+        run: cargo publish --manifest-path ./src/hyperlight_guest_tracing_macro/Cargo.toml ${{ inputs.dry_run && '--dry-run' || '' }}
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_PUBLISH_TOKEN }}
+        if: env.PUBLISH_HYPERLIGHT_GUEST_TRACING_MACRO != 'false'
+
+      - name: Publish hyperlight-guest-tracing
+        continue-on-error: ${{ inputs.dry_run }}
+        run: cargo publish --manifest-path ./src/hyperlight_guest_tracing/Cargo.toml ${{ inputs.dry_run && '--dry-run' || '' }}
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_PUBLISH_TOKEN }}
+        if: env.PUBLISH_HYPERLIGHT_GUEST_TRACING != 'false'
 
       - name: Publish hyperlight-guest
         continue-on-error: ${{ inputs.dry_run }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Fix mem mgr not initialized by @dblnz in https://github.com/hyperlight-dev/hyperlight/pull/745
 
 ### Changed
-- Remove some dev-dependecies and cargo features to speed up compilation by @ludfjig in https://github.com/hyperlight-dev/hyperlight/pull/535
+- Remove some dev-dependencies and cargo features to speed up compilation by @ludfjig in https://github.com/hyperlight-dev/hyperlight/pull/535
 - Introduce a separate KVM error variant of HyperlightError. by @ludfjig in https://github.com/hyperlight-dev/hyperlight/pull/771API. by @jprendes in https://github.com/hyperlight-dev/hyperlight/pull/697
 - Evolving and Devolving apis replaced by Snapshot API
   - Remove sandbox evolving and devolving and replace it with snapshotting API. by @jprendes in https://github.com/hyperlight-dev/hyperlight/pull/697
@@ -26,7 +26,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   - Support mapping host memory into the guest by @syntactically in https://github.com/hyperlight-dev/hyperlight/pull/696
   - Make MultiUseSandbox::map_file_cow public by @ludfjig in https://github.com/hyperlight-dev/hyperlight/pull/725
   - Add memory mapping support with KVM by @jprendes in https://github.com/hyperlight-dev/hyperlight/pull/709
-  - Make sure mmaped memory is not mapped writeable into sandbox in kvm by @ludfjig in https://github.com/hyperlight-dev/hyperlight/pull/740
+  - Make sure mmapped memory is not mapped writeable into sandbox in kvm by @ludfjig in https://github.com/hyperlight-dev/hyperlight/pull/740
   - Make snapshots region aware by @ludfjig in https://github.com/hyperlight-dev/hyperlight/pull/742
   - Restrict restoring sandboxes to snapshot taken on self by @ludfjig in https://github.com/hyperlight-dev/hyperlight/pull/746
 - Enable guest tracing  by @dblnz in https://github.com/hyperlight-dev/hyperlight/pull/695

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,36 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Prerelease] - Unreleased
 
+## [v0.8.0] - 2025-08-08
+
+:warning: `hyperlight_component_macro::host_bindgen` and `hyperlight_component_macro::guest_bindgen` used the `Callable` trait which no longer restores state after each function call and requires an explicit Snapshot Restore using the newly exposed Snapshot API. See https://github.com/hyperlight-dev/hyperlight/pull/697 and https://github.com/hyperlight-dev/hyperlight/pull/761
+
+### Fixed
+- gdb: fix issue "Debug not enabled" when `gdb` feature was enabled by @dblnz in https://github.com/hyperlight-dev/hyperlight/pull/678
+- Fix Windows build with `--no-default-features` by @danbugs in https://github.com/hyperlight-dev/hyperlight/pull/712
+- fix(guest-bin): move logger initialization by @andreiltd in https://github.com/hyperlight-dev/hyperlight/pull/755
+- Fix mem mgr not initialized by @dblnz in https://github.com/hyperlight-dev/hyperlight/pull/745
+
+### Changed
+- Remove some dev-dependecies and cargo features to speed up compilation by @ludfjig in https://github.com/hyperlight-dev/hyperlight/pull/535
+- Introduce a separate KVM error variant of HyperlightError. by @ludfjig in https://github.com/hyperlight-dev/hyperlight/pull/771API. by @jprendes in https://github.com/hyperlight-dev/hyperlight/pull/697
+- Evolving and Devolving apis replaced by Snapshot API
+  - Remove sandbox evolving and devolving and replace it with snapshotting API. by @jprendes in https://github.com/hyperlight-dev/hyperlight/pull/697
+  - Bring back the previous behavior of `call_guest_function_by_name` by @jprendes in https://github.com/hyperlight-dev/hyperlight/pull/761
+
+### Added
+- Memory Mapping Support 
+  - Support mapping host memory into the guest by @syntactically in https://github.com/hyperlight-dev/hyperlight/pull/696
+  - Make MultiUseSandbox::map_file_cow public by @ludfjig in https://github.com/hyperlight-dev/hyperlight/pull/725
+  - Add memory mapping support with KVM by @jprendes in https://github.com/hyperlight-dev/hyperlight/pull/709
+  - Make sure mmaped memory is not mapped writeable into sandbox in kvm by @ludfjig in https://github.com/hyperlight-dev/hyperlight/pull/740
+  - Make snapshots region aware by @ludfjig in https://github.com/hyperlight-dev/hyperlight/pull/742
+  - Restrict restoring sandboxes to snapshot taken on self by @ludfjig in https://github.com/hyperlight-dev/hyperlight/pull/746
+- Enable guest tracing  by @dblnz in https://github.com/hyperlight-dev/hyperlight/pull/695
+
+### Removed
+- Removed the OutBHandler and MemAccessHandler abstractions and related implementations. by @simongdavies in https://github.com/hyperlight-dev/hyperlight/pull/732
+  
 ## [v0.7.0] - 2025-06-26
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1336,7 +1336,7 @@ dependencies = [
 
 [[package]]
 name = "hyperlight-common"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -1349,7 +1349,7 @@ dependencies = [
 
 [[package]]
 name = "hyperlight-component-macro"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "env_logger",
  "hyperlight-component-util",
@@ -1363,7 +1363,7 @@ dependencies = [
 
 [[package]]
 name = "hyperlight-component-util"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "itertools 0.14.0",
  "log",
@@ -1385,7 +1385,7 @@ dependencies = [
 
 [[package]]
 name = "hyperlight-guest"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "hyperlight-common",
@@ -1395,7 +1395,7 @@ dependencies = [
 
 [[package]]
 name = "hyperlight-guest-bin"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "buddy_system_allocator",
  "cc",
@@ -1410,7 +1410,7 @@ dependencies = [
 
 [[package]]
 name = "hyperlight-guest-tracing"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "hyperlight-common",
  "hyperlight-guest-tracing-macro",
@@ -1419,7 +1419,7 @@ dependencies = [
 
 [[package]]
 name = "hyperlight-guest-tracing-macro"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1428,7 +1428,7 @@ dependencies = [
 
 [[package]]
 name = "hyperlight-host"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "bitflags 2.9.1",
@@ -1518,7 +1518,7 @@ dependencies = [
 
 [[package]]
 name = "hyperlight_guest_capi"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "cbindgen",
  "hyperlight-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,8 +42,8 @@ hyperlight-host = { path = "src/hyperlight_host", version = "0.8.0", default-fea
 hyperlight-guest = { path = "src/hyperlight_guest", version = "0.8.0", default-features = false }
 hyperlight-guest-bin = { path = "src/hyperlight_guest_bin", version = "0.8.0", default-features = false }
 hyperlight-testing = { path = "src/hyperlight_testing", default-features = false }
-hyperlight-guest-tracing = { path = "src/hyperlight_guest_tracing", default-features = false }
-hyperlight-guest-tracing-macro = { path = "src/hyperlight_guest_tracing_macro", default-features = false }
+hyperlight-guest-tracing = { path = "src/hyperlight_guest_tracing", version = "0.8.0", default-features = false }
+hyperlight-guest-tracing-macro = { path = "src/hyperlight_guest_tracing_macro", version = "0.8.0", default-features = false }
 hyperlight-component-util = { path = "src/hyperlight_component_util", version = "0.8.0", default-features = false }
 hyperlight-component-macro = { path = "src/hyperlight_component_macro", version = "0.8.0", default-features = false }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.7.0"
+version = "0.8.0"
 edition = "2024"
 rust-version = "1.86"
 license = "Apache-2.0"
@@ -37,15 +37,15 @@ repository = "https://github.com/hyperlight-dev/hyperlight"
 readme = "README.md"
 
 [workspace.dependencies]
-hyperlight-common = { path = "src/hyperlight_common", version = "0.7.0", default-features = false }
-hyperlight-host = { path = "src/hyperlight_host", version = "0.7.0", default-features = false }
-hyperlight-guest = { path = "src/hyperlight_guest", version = "0.7.0", default-features = false }
-hyperlight-guest-bin = { path = "src/hyperlight_guest_bin", version = "0.7.0", default-features = false }
+hyperlight-common = { path = "src/hyperlight_common", version = "0.8.0", default-features = false }
+hyperlight-host = { path = "src/hyperlight_host", version = "0.8.0", default-features = false }
+hyperlight-guest = { path = "src/hyperlight_guest", version = "0.8.0", default-features = false }
+hyperlight-guest-bin = { path = "src/hyperlight_guest_bin", version = "0.8.0", default-features = false }
 hyperlight-testing = { path = "src/hyperlight_testing", default-features = false }
 hyperlight-guest-tracing = { path = "src/hyperlight_guest_tracing", default-features = false }
 hyperlight-guest-tracing-macro = { path = "src/hyperlight_guest_tracing_macro", default-features = false }
-hyperlight-component-util = { path = "src/hyperlight_component_util", version = "0.7.0", default-features = false }
-hyperlight-component-macro = { path = "src/hyperlight_component_macro", version = "0.7.0", default-features = false }
+hyperlight-component-util = { path = "src/hyperlight_component_util", version = "0.8.0", default-features = false }
+hyperlight-component-macro = { path = "src/hyperlight_component_macro", version = "0.8.0", default-features = false }
 
 [workspace.lints.rust]
 unsafe_op_in_unsafe_fn = "deny"

--- a/src/tests/rust_guests/callbackguest/Cargo.lock
+++ b/src/tests/rust_guests/callbackguest/Cargo.lock
@@ -72,7 +72,7 @@ checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
 name = "hyperlight-common"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "flatbuffers",
@@ -82,7 +82,7 @@ dependencies = [
 
 [[package]]
 name = "hyperlight-guest"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "hyperlight-common",
@@ -92,7 +92,7 @@ dependencies = [
 
 [[package]]
 name = "hyperlight-guest-bin"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "buddy_system_allocator",
  "cc",
@@ -107,7 +107,7 @@ dependencies = [
 
 [[package]]
 name = "hyperlight-guest-tracing"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "hyperlight-common",
  "hyperlight-guest-tracing-macro",
@@ -116,7 +116,7 @@ dependencies = [
 
 [[package]]
 name = "hyperlight-guest-tracing-macro"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/src/tests/rust_guests/simpleguest/Cargo.lock
+++ b/src/tests/rust_guests/simpleguest/Cargo.lock
@@ -62,7 +62,7 @@ checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
 name = "hyperlight-common"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "flatbuffers",
@@ -72,7 +72,7 @@ dependencies = [
 
 [[package]]
 name = "hyperlight-guest"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "hyperlight-common",
@@ -82,7 +82,7 @@ dependencies = [
 
 [[package]]
 name = "hyperlight-guest-bin"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "buddy_system_allocator",
  "cc",
@@ -97,7 +97,7 @@ dependencies = [
 
 [[package]]
 name = "hyperlight-guest-tracing"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "hyperlight-common",
  "hyperlight-guest-tracing-macro",
@@ -106,7 +106,7 @@ dependencies = [
 
 [[package]]
 name = "hyperlight-guest-tracing-macro"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/typos.toml
+++ b/typos.toml
@@ -7,3 +7,4 @@ extend-exclude = ["**/*.patch", "src/hyperlight_guest_bin/third_party/**/*", "NO
 [default.extend-words]
 # typ is used for field name as type is a reserved keyword
 typ="typ"
+mmaped="mmapped"


### PR DESCRIPTION
Updates for v0.8.0 release

This pull request prepares the repository for the `v0.8.0` release, updating crate versions, changelog, and CI workflow to support new features and improvements. It introduces guest tracing support, memory mapping enhancements, and updates the publishing workflow to include new crates.

**Release preparation and versioning:**
* Updated all workspace crate versions to `0.8.0` in `Cargo.toml` to reflect the new release. [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L31-R31) [[2]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L40-R48)
* Added a new section for version `v0.8.0` in `CHANGELOG.md` detailing major changes, fixes, and removals, including breaking changes to the `Callable` trait and introduction of the Snapshot API.

**Continuous Integration workflow updates:**
* Modified `.github/workflows/CargoPublish.yml` to verify and publish the new `hyperlight-guest-tracing` and `hyperlight-guest-tracing-macro` crates, ensuring they are included in the release process. [[1]](diffhunk://#diff-5a6728ca25232a93f06662722efffe8858160a1e90fd0288c5b17c4ccde7a0e8L49-R49) [[2]](diffhunk://#diff-5a6728ca25232a93f06662722efffe8858160a1e90fd0288c5b17c4ccde7a0e8R78-R79) [[3]](diffhunk://#diff-5a6728ca25232a93f06662722efffe8858160a1e90fd0288c5b17c4ccde7a0e8R88-R101)
