### PR TITLE
fix release blocker so it only blocks on release branches

### DIFF
--- a/.github/workflows/ReleaseBlockerCheck.yml
+++ b/.github/workflows/ReleaseBlockerCheck.yml
@@ -30,9 +30,15 @@ jobs:
           REPO="${{ inputs.repository || github.repository }}"
           echo "Checking repository: $REPO"
           
-          if ! ./dev/check-release-blockers.sh "$REPO"; then
-            echo "::error::Release blocked by open issues with 'release-blocker' label"
-            exit 1
+          # Only check for release blockers on release branches
+          if [[ "${{ github.ref }}" == *"refs/heads/release/"* ]]; then
+            echo "Release branch detected - checking for release blockers..."
+            if ! ./dev/check-release-blockers.sh "$REPO"; then
+              echo "::error::Release blocked by open issues with 'release-blocker' label"
+              exit 1
+            fi
+          else
+            echo "Non-release branch - skipping release blocker check"
           fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request updates the release blocker check workflow to ensure that the release blocker script only runs on release branches. 