### PR TITLE
Small bugfixes in the component macros

### DIFF
--- a/src/hyperlight_component_util/src/emit.rs
+++ b/src/hyperlight_component_util/src/emit.rs
@@ -589,12 +589,13 @@ impl<'a, 'b> State<'a, 'b> {
     /// ends up with a resource type, in which case we return the
     /// resource index
     pub fn resolve_tv(&self, n: u32) -> (u32, Option<Defined<'b>>) {
-        match &self.bound_vars[self.var_offset + n as usize].bound {
+        let m = n + self.var_offset as u32;
+        match &self.bound_vars[m as usize].bound {
             TypeBound::Eq(Defined::Handleable(Handleable::Var(Tyvar::Bound(nn)))) => {
                 self.resolve_tv(n + 1 + nn)
             }
             TypeBound::Eq(t) => (n, Some(t.clone())),
-            TypeBound::SubResource => (n, None),
+            TypeBound::SubResource => (m, None),
         }
     }
     /// Construct a namespace path referring to the resource trait for

--- a/src/hyperlight_component_util/src/host.rs
+++ b/src/hyperlight_component_util/src/host.rs
@@ -56,9 +56,13 @@ fn emit_export_extern_decl<'a, 'b, 'c>(
                     let unmarshal = emit_hl_unmarshal_result(s, ret.clone(), &ft.result);
                     quote! {
                         fn #n(&mut self, #(#param_decls),*) -> #result_decl {
+                            let args = {
+                                let mut rts = self.rt.lock().unwrap();
+                                (#(#marshal,)*)
+                            };
                             let #ret = ::hyperlight_host::sandbox::Callable::call::<::std::vec::Vec::<u8>>(&mut self.sb,
                                 #hln,
-                                (#(#marshal,)*)
+                                args,
                             );
                             let ::std::result::Result::Ok(#ret) = #ret else { panic!("bad return from guest {:?}", #ret) };
                             #[allow(clippy::unused_unit)]


### PR DESCRIPTION
These are the changes required for [hyperlight-wasm-http-example](https://github.com/jprendes/hyperlight-wasm-http-example/) to build and run correctly.

I think that we need better test coverage for the macro, and I believe @syntactically is working on that.
However, I would like to get these changes in for the 0.9.0 release.

The change in `resolve_tv`, in the case of a `TypeBound::SubResource` the function was returning a relative index instead of an absolute index. In the other non-recursive branch, `TypeBound::Eq`, we need to return the relative index. I believe @syntactically is also working on a more sane refactor of this method.

The change in the generated code, when the host sends some resource to the guest, it needs to insert them in the resource table, for that the code in `#marshal` assumes that a variable `rts` is in scope, which was not the case. Also, `rts` is behind a mutex that we need to release before doing the actual guest function call, so creation of `args` is moved forward.