### PR TITLE
Add a periodic job for building and test musl

### DIFF
--- a/.github/workflows/RustNightly.yml
+++ b/.github/workflows/RustNightly.yml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+
+name: Nightly
+
+on:
+  workflow_dispatch:
+
+jobs:
+  musl:
+    strategy:
+      fail-fast: true
+      matrix:
+        hypervisor: [kvm]
+        cpu: [amd, intel]
+        config: [debug, release]
+    uses: ./.github/workflows/dep_rust.yml
+    secrets: inherit
+    with: 
+      hypervisor: ${{ matrix.hypervisor }}
+      cpu: ${{ matrix.cpu }}
+      config: ${{ matrix.config }}
+      target_triple: x86_64-unknown-linux-musl
+
+# TODO: using notification script
+

--- a/.github/workflows/ValidatePullRequest.yml
+++ b/.github/workflows/ValidatePullRequest.yml
@@ -44,10 +44,19 @@ jobs:
   rust:
     needs:
       - docs-pr
+    strategy:
+      fail-fast: true
+      matrix:
+        hypervisor: [hyperv, 'hyperv-ws2025', mshv, mshv3, kvm]
+        cpu: [amd, intel]
+        config: [debug, release]
     uses: ./.github/workflows/dep_rust.yml
     secrets: inherit
     with: 
       docs_only: ${{needs.docs-pr.outputs.docs-only}}
+      hypervisor: ${{ matrix.hypervisor }}
+      cpu: ${{ matrix.cpu }}
+      config: ${{ matrix.config }}
 
   fuzzing:
     needs:

--- a/.github/workflows/dep_rust.yml
+++ b/.github/workflows/dep_rust.yml
@@ -11,6 +11,26 @@ on:
         required: false
         type: string
         default: "false"
+      target_triple:
+        description: Target triple for cross-compilation
+        required: false
+        type: string
+        default: ""
+      hypervisor:
+        description: Hypervisor for this run (passed from caller matrix)
+        required: false
+        type: string
+        default: "kvm"
+      config:
+        description: Build configuration for this run (passed from caller matrix)
+        required: false
+        type: string
+        default: "debug"
+      cpu:
+        description: CPU architecture for the build (passed from caller matrix)
+        required: false
+        type: string
+        default: "amd"
 
 env:
   CARGO_TERM_COLOR: always
@@ -32,13 +52,8 @@ defaults:
 
 jobs:
   code-checks:
-    if: ${{ inputs.docs_only == 'false' }}
+    if: ${{ inputs.docs_only == 'false' && (inputs.hypervisor == 'hyperv-ws2025' || inputs.hypervisor == 'kvm') }}
     timeout-minutes: 60
-    strategy:
-      fail-fast: true
-      matrix:
-        hypervisor: ['hyperv-ws2025', kvm]
-        config: [debug, release]
     runs-on: ${{ fromJson(
       format('["self-hosted", "{0}", "X64", "1ES.Pool=hld-{1}-amd"]', 
         (matrix.hypervisor == 'hyperv-ws2025') && 'Windows' || 'Linux', 
@@ -63,13 +78,13 @@ jobs:
       - name: clippy
         if: ${{ (runner.os == 'Windows' )}}
         run: |
-          just clippy ${{ matrix.config }}
-          just clippy-guests ${{ matrix.config }}
+          just clippy ${{ inputs.config }} ${{ inputs.target_triple }}
+          just clippy-guests ${{ inputs.config }}
 
       - name: clippy exhaustive check
         if: ${{ (runner.os == 'Linux' )}}
         run: |
-          just clippy-exhaustive ${{ matrix.config }}
+          just clippy-exhaustive ${{ inputs.config }} ${{ inputs.target_triple }}
 
       - name: Verify MSRV
         run: ./dev/verify-msrv.sh hyperlight-host hyperlight-guest hyperlight-guest-bin hyperlight-common
@@ -77,13 +92,6 @@ jobs:
   build:
     if: ${{ inputs.docs_only == 'false' }}
     timeout-minutes: 60
-    strategy:
-      fail-fast: true
-      matrix:
-        hypervisor: [hyperv, 'hyperv-ws2025', mshv, mshv3, kvm] # hyperv is windows, mshv and kvm are linux
-        cpu: [amd, intel]
-        config: [debug, release]
-
     runs-on: ${{ fromJson(
         format('["self-hosted", "{0}", "X64", "1ES.Pool=hld-{1}-{2}"]', 
           (matrix.hypervisor == 'hyperv' || matrix.hypervisor == 'hyperv-ws2025') && 'Windows' || 'Linux', 
@@ -112,35 +120,33 @@ jobs:
       - name: Build and move Rust guests
         run: |
           # use these commands in favor of build-and-move-rust-guests to avoid building both configs
-          just build-rust-guests ${{ matrix.config }}
-          just move-rust-guests ${{ matrix.config }}
+          just build-rust-guests ${{ inputs.config }}
+          just move-rust-guests ${{ inputs.config }}
 
       - name: Build c guests
         run: |
           # use these commands in favor of build-and-move-c-guests to avoid building both configs
-          just build-c-guests ${{ matrix.config }}
-          just move-c-guests ${{ matrix.config }}
+          just build-c-guests ${{ inputs.config }}
+          just move-c-guests ${{ inputs.config }}
+          
       - name: Build
-        run: just build ${{ matrix.config }}
+        run: just build ${{ inputs.config }} ${{ inputs.target_triple }}
 
       - name: Run Rust tests
         env:
           CARGO_TERM_COLOR: always
         run: |
           # with default features
-          just test ${{ matrix.config }} ${{ matrix.hypervisor == 'mshv' && 'mshv2' || ''}}
+          just test ${{ inputs.config }} ${{ inputs.hypervisor == 'mshv' && 'mshv2' || '""'}} ${{ inputs.target_triple }}
 
           # with only one driver enabled (driver mshv/kvm feature is ignored on windows) + seccomp 
-          just test ${{ matrix.config }} seccomp,${{ matrix.hypervisor == 'mshv' && 'mshv2' || matrix.hypervisor == 'mshv3' && 'mshv3' || 'kvm' }} 
+          just test ${{ inputs.config }} seccomp,${{ inputs.hypervisor == 'mshv' && 'mshv2' || inputs.hypervisor == 'mshv3' && 'mshv3' || 'kvm' }} ${{ inputs.target_triple }}
 
           # make sure certain cargo features compile
-          cargo check -p hyperlight-host --features crashdump
-          cargo check -p hyperlight-host --features print_debug
-          cargo check -p hyperlight-host --features gdb
-          cargo check -p hyperlight-host --features trace_guest,unwind_guest,mem_profile
+          just check ${{ inputs.target_triple }}
 
           # without any features
-          just test-compilation-no-default-features ${{ matrix.config }}
+          just test-compilation-no-default-features ${{ inputs.config }} ${{ inputs.target_triple }}
 
         # One of the examples is flaky on Windows GH runners, so this allows us to disable it for now
       - name: Run Rust examples - windows
@@ -148,43 +154,43 @@ jobs:
         env:
           CARGO_TERM_COLOR: always
           RUST_LOG: debug
-        run: just run-rust-examples ${{ matrix.config }}
+        run: just run-rust-examples ${{ inputs.config }}
 
       - name: Run Rust examples - linux
-        if: ${{ (runner.os != 'Windows') }}
+        if: false
         env:
           CARGO_TERM_COLOR: always
           RUST_LOG: debug
-        run: just run-rust-examples-linux ${{ matrix.config }} ${{ matrix.hypervisor == 'mshv' && 'mshv2' || ''}}
+        run: just run-rust-examples-linux ${{ inputs.config }} ${{ inputs.hypervisor == 'mshv' && 'mshv2' || '""'}} ${{ inputs.target_triple }}
 
       - name: Run Rust Gdb tests - linux
         if: runner.os == 'Linux'
         env:
           CARGO_TERM_COLOR: always
           RUST_LOG: debug
-        run: just test-rust-gdb-debugging ${{ matrix.config }} ${{ matrix.hypervisor == 'mshv' && 'mshv2' || ''}}
+        run: just test-rust-gdb-debugging ${{ inputs.config }} ${{ inputs.hypervisor == 'mshv' && 'mshv2' || '""'}} ${{ inputs.target_triple }}
 
       - name: Run Rust Crashdump tests
         env:
           CARGO_TERM_COLOR: always
           RUST_LOG: debug
-        run: just test-rust-crashdump ${{ matrix.config }} ${{ matrix.hypervisor == 'mshv' && 'mshv2' || ''}}
+        run: just test-rust-crashdump ${{ inputs.config }} ${{ inputs.hypervisor == 'mshv' && 'mshv2' || '""'}} ${{ inputs.target_triple }}
 
       - name: Run Rust Tracing tests - linux
         if: runner.os == 'Linux'
         env:
           CARGO_TERM_COLOR: always
           RUST_LOG: debug
-        run: just test-rust-tracing ${{ matrix.config }} ${{ matrix.hypervisor == 'mshv' && 'mshv2' || ''}}
+        run: just test-rust-tracing ${{ inputs.config }} ${{ inputs.hypervisor == 'mshv' && 'mshv2' || '""'}} ${{ inputs.target_triple }}
 
       - name: Download benchmarks from "latest"
-        run: just bench-download ${{ runner.os }} ${{ matrix.hypervisor }} ${{ matrix.cpu}} dev-latest # compare to prerelease
+        run: just bench-download ${{ runner.os }} ${{ inputs.hypervisor }} ${{ inputs.cpu}} dev-latest # compare to prerelease
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         continue-on-error: true
-        if: ${{ matrix.config == 'release' }}
+        if: ${{ inputs.config == 'release' &&  inputs.target_triple == '' }}
 
       - name: Run benchmarks
         run: |
-          just bench-ci main ${{ matrix.hypervisor == 'mshv' && 'mshv2' || ''}}
-        if: ${{ matrix.config == 'release' }}
+          just bench-ci main ${{ inputs.hypervisor == 'mshv' && 'mshv2' || ''}}
+        if: ${{ inputs.config == 'release' &&  inputs.target_triple == '' }}

--- a/Justfile
+++ b/Justfile
@@ -23,13 +23,8 @@ alias rg := build-and-move-rust-guests
 alias cg := build-and-move-c-guests
 
 # build host library
-build target=default-target:
-    cargo build --profile={{ if target == "debug" { "dev" } else { target } }} 
-
-# build host library
-build-with-musl-libc target=default-target:
-    cargo build --profile={{ if target == "debug" { "dev" } else { target } }} --target x86_64-unknown-linux-musl
-
+build target=default-target target-triple="":
+    cargo build --profile={{ if target == "debug" { "dev" } else { target } }} {{ if target-triple != "" { "--target " + target-triple } else { "" } }}
 
 # build testing guest binaries
 guests: build-and-move-rust-guests build-and-move-c-guests
@@ -143,67 +138,68 @@ like-ci config=default-target hypervisor="kvm":
     {{ if config == "release" { "just bench-ci main " + if hypervisor == "mshv" { "mshv2" } else if hypervisor == "mshv3" { "mshv3" } else { "kvm" } } else { "" } }}
 
 # runs all tests
-test target=default-target features="": (test-unit target features) (test-isolated target features) (test-integration "rust" target features) (test-integration "c" target features) (test-seccomp target features) (test-doc target features)
+test target=default-target features="" target-triple="": (test-unit target features target-triple) (test-isolated target features target-triple) (test-integration "rust" target features target-triple) (test-integration "c" target features target-triple) (test-seccomp target features target-triple) (test-doc target features target-triple)
 
 # runs unit tests
-test-unit target=default-target features="":
-    cargo test {{ if features =="" {''} else if features=="no-default-features" {"--no-default-features" } else {"--no-default-features -F init-paging," + features } }} --profile={{ if target == "debug" { "dev" } else { target } }} --lib
+test-unit target=default-target features="" target-triple="":
+    cargo test {{ if features =="" {''} else if features=="no-default-features" {"--no-default-features" } else {"--no-default-features -F init-paging," + features } }} --profile={{ if target == "debug" { "dev" } else { target } }}{{ if target-triple != "" { " --target " + target-triple } else { "" } }} --lib
 
 # runs tests that requires being run separately, for example due to global state
-test-isolated target=default-target features="":
-    cargo test {{ if features =="" {''} else if features=="no-default-features" {"--no-default-features" } else {"--no-default-features -F init-paging," + features } }} --profile={{ if target == "debug" { "dev" } else { target } }} -p hyperlight-host --lib -- sandbox::uninitialized::tests::test_trace_trace --exact --ignored
-    cargo test {{ if features =="" {''} else if features=="no-default-features" {"--no-default-features" } else {"--no-default-features -F init-paging," + features } }} --profile={{ if target == "debug" { "dev" } else { target } }} -p hyperlight-host --lib -- sandbox::uninitialized::tests::test_log_trace --exact --ignored
-    cargo test {{ if features =="" {''} else if features=="no-default-features" {"--no-default-features" } else {"--no-default-features -F init-paging," + features } }} --profile={{ if target == "debug" { "dev" } else { target } }} -p hyperlight-host --lib -- sandbox::initialized_multi_use::tests::create_1000_sandboxes --exact --ignored
-    cargo test {{ if features =="" {''} else if features=="no-default-features" {"--no-default-features" } else {"--no-default-features -F init-paging," + features } }} --profile={{ if target == "debug" { "dev" } else { target } }} -p hyperlight-host --lib -- sandbox::outb::tests::test_log_outb_log --exact --ignored
-    cargo test {{ if features =="" {''} else if features=="no-default-features" {"--no-default-features" } else {"--no-default-features -F init-paging," + features } }} --profile={{ if target == "debug" { "dev" } else { target } }} -p hyperlight-host --lib -- mem::shared_mem::tests::test_drop --exact --ignored
-    cargo test {{ if features =="" {''} else if features=="no-default-features" {"--no-default-features" } else {"--no-default-features -F init-paging," + features } }} --profile={{ if target == "debug" { "dev" } else { target } }} -p hyperlight-host --test integration_test -- log_message --exact --ignored
+test-isolated target=default-target features="" target-triple="" :
+    cargo test {{ if features =="" {''} else if features=="no-default-features" {"--no-default-features" } else {"--no-default-features -F init-paging," + features } }} --profile={{ if target == "debug" { "dev" } else { target } }}{{ if target-triple != "" { " --target " + target-triple } else { "" } }} -p hyperlight-host --lib -- sandbox::uninitialized::tests::test_trace_trace --exact --ignored
+    cargo test {{ if features =="" {''} else if features=="no-default-features" {"--no-default-features" } else {"--no-default-features -F init-paging," + features } }} --profile={{ if target == "debug" { "dev" } else { target } }}{{ if target-triple != "" { " --target " + target-triple } else { "" } }} -p hyperlight-host --lib -- sandbox::uninitialized::tests::test_log_trace --exact --ignored
+    cargo test {{ if features =="" {''} else if features=="no-default-features" {"--no-default-features" } else {"--no-default-features -F init-paging," + features } }} --profile={{ if target == "debug" { "dev" } else { target } }}{{ if target-triple != "" { " --target " + target-triple } else { "" } }} -p hyperlight-host --lib -- sandbox::initialized_multi_use::tests::create_1000_sandboxes --exact --ignored
+    cargo test {{ if features =="" {''} else if features=="no-default-features" {"--no-default-features" } else {"--no-default-features -F init-paging," + features } }} --profile={{ if target == "debug" { "dev" } else { target } }}{{ if target-triple != "" { " --target " + target-triple } else { "" } }} -p hyperlight-host --lib -- sandbox::outb::tests::test_log_outb_log --exact --ignored
+    cargo test {{ if features =="" {''} else if features=="no-default-features" {"--no-default-features" } else {"--no-default-features -F init-paging," + features } }} --profile={{ if target == "debug" { "dev" } else { target } }}{{ if target-triple != "" { " --target " + target-triple } else { "" } }} -p hyperlight-host --lib -- mem::shared_mem::tests::test_drop --exact --ignored
+    cargo test {{ if features =="" {''} else if features=="no-default-features" {"--no-default-features" } else {"--no-default-features -F init-paging," + features } }} --profile={{ if target == "debug" { "dev" } else { target } }}{{ if target-triple != "" { " --target " + target-triple } else { "" } }} -p hyperlight-host --test integration_test -- log_message --exact --ignored
     @# metrics tests
-    cargo test {{ if features =="" {''} else if features=="no-default-features" {"--no-default-features" } else {"--no-default-features -F function_call_metrics,init-paging," + features } }} --profile={{ if target == "debug" { "dev" } else { target } }} -p hyperlight-host --lib -- metrics::tests::test_metrics_are_emitted --exact 
+    cargo test {{ if features =="" {''} else if features=="no-default-features" {"--no-default-features" } else {"--no-default-features -F function_call_metrics,init-paging," + features } }} --profile={{ if target == "debug" { "dev" } else { target } }}{{ if target-triple != "" { " --target " + target-triple } else { "" } }} -p hyperlight-host --lib -- metrics::tests::test_metrics_are_emitted --exact 
 # runs integration tests. Guest can either be "rust" or "c"
-test-integration guest target=default-target features="":
+test-integration guest target=default-target features="" target-triple="":
     @# run execute_on_heap test with feature "executable_heap" on and off
-    {{if os() == "windows" { "$env:" } else { "" } }}GUEST="{{guest}}"{{if os() == "windows" { ";" } else { "" } }} cargo test --profile={{ if target == "debug" { "dev" } else { target } }} --test integration_test execute_on_heap {{ if features =="" {" --features executable_heap"} else {"--features executable_heap," + features} }} -- --ignored
-    {{if os() == "windows" { "$env:" } else { "" } }}GUEST="{{guest}}"{{if os() == "windows" { ";" } else { "" } }} cargo test --profile={{ if target == "debug" { "dev" } else { target } }} --test integration_test execute_on_heap {{ if features =="" {""} else {"--features " + features} }} -- --ignored
+    {{if os() == "windows" { "$env:" } else { "" } }}GUEST="{{guest}}"{{if os() == "windows" { ";" } else { "" } }} cargo test --profile={{ if target == "debug" { "dev" } else { target } }}{{ if target-triple != "" { " --target " + target-triple } else { "" } }} --test integration_test execute_on_heap {{ if features =="" {" --features executable_heap"} else {"--features executable_heap," + features} }} -- --ignored
+    {{if os() == "windows" { "$env:" } else { "" } }}GUEST="{{guest}}"{{if os() == "windows" { ";" } else { "" } }} cargo test --profile={{ if target == "debug" { "dev" } else { target } }}{{ if target-triple != "" { " --target " + target-triple } else { "" } }} --test integration_test execute_on_heap {{ if features =="" {""} else {"--features " + features} }} -- --ignored
     
     @# run the rest of the integration tests
-    {{if os() == "windows" { "$env:" } else { "" } }}GUEST="{{guest}}"{{if os() == "windows" { ";" } else { "" } }} cargo test -p hyperlight-host {{ if features =="" {''} else if features=="no-default-features" {"--no-default-features" } else {"--no-default-features -F init-paging," + features } }} --profile={{ if target == "debug" { "dev" } else { target } }} --test '*'
+    {{if os() == "windows" { "$env:" } else { "" } }}GUEST="{{guest}}"{{if os() == "windows" { ";" } else { "" } }} cargo test -p hyperlight-host {{ if features =="" {''} else if features=="no-default-features" {"--no-default-features" } else {"--no-default-features -F init-paging," + features } }} --profile={{ if target == "debug" { "dev" } else { target } }}{{ if target-triple != "" { " --target " + target-triple } else { "" } }} --test '*'
 
 # runs seccomp tests
-test-seccomp target=default-target features="":
+test-seccomp target=default-target features="" target-triple="":
     @# run seccomp test with feature "seccomp" on and off
-    cargo test --profile={{ if target == "debug" { "dev" } else { target } }} -p hyperlight-host test_violate_seccomp_filters --lib {{ if features =="" {''} else { "--features " + features } }} -- --ignored
-    cargo test --profile={{ if target == "debug" { "dev" } else { target } }} -p hyperlight-host test_violate_seccomp_filters --no-default-features {{ if features =~"mshv2" {"--features init-paging,mshv2"} else {"--features mshv3,init-paging,kvm" } }} --lib -- --ignored
+    cargo test --profile={{ if target == "debug" { "dev" } else { target } }} {{ if target-triple != "" { " --target " + target-triple } else { "" } }} -p hyperlight-host test_violate_seccomp_filters --lib {{ if features =="" {''} else { "--features " + features } }} -- --ignored
+    cargo test --profile={{ if target == "debug" { "dev" } else { target } }} {{ if target-triple != "" { " --target " + target-triple } else { "" } }} -p hyperlight-host test_violate_seccomp_filters --no-default-features {{ if features =~"mshv2" {"--features init-paging,mshv2"} else {"--features mshv3,init-paging,kvm" } }} --lib -- --ignored
 
 # tests compilation with no default features on different platforms
-test-compilation-no-default-features target=default-target:
+test-compilation-no-default-features target=default-target target-triple="":
     @# Linux should fail without a hypervisor feature (kvm, mshv, or mshv3)
-    {{ if os() == "linux" { "! cargo check -p hyperlight-host --no-default-features 2> /dev/null" } else { "" } }}
+    {{ if os() == "linux" { "! cargo check -p hyperlight-host --no-default-features 2> /dev/null" } else { "" } }} {{ if target-triple != "" { " --target " + target-triple } else { "" } }}
     @# Windows should succeed even without default features
     {{ if os() == "windows" { "cargo check -p hyperlight-host --no-default-features" } else { "" } }}
     @# Linux should succeed with a hypervisor driver but without init-paging
-    {{ if os() == "linux" { "cargo check -p hyperlight-host --no-default-features --features kvm" } else { "" } }}
-    {{ if os() == "linux" { "cargo check -p hyperlight-host --no-default-features --features mshv2" } else { "" } }}
-    {{ if os() == "linux" { "cargo check -p hyperlight-host --no-default-features --features mshv3" } else { "" } }}    
+    {{ if os() == "linux" { "cargo check -p hyperlight-host --no-default-features --features kvm" } else { "" } }} {{ if target-triple != "" { " --target " + target-triple } else { "" } }}
+    {{ if os() == "linux" { "cargo check -p hyperlight-host --no-default-features --features mshv2" } else { "" } }} {{ if target-triple != "" { " --target " + target-triple } else { "" } }}
+    {{ if os() == "linux" { "cargo check -p hyperlight-host --no-default-features --features mshv3" } else { "" } }} {{ if target-triple != "" { " --target " + target-triple } else { "" } }}
 
 # runs tests that exercise gdb debugging
-test-rust-gdb-debugging target=default-target features="":
-    cargo test --profile={{ if target == "debug" { "dev" } else { target } }} --example guest-debugging {{ if features =="" {'--features gdb'} else { "--features gdb," + features } }}
-    cargo test --profile={{ if target == "debug" { "dev" } else { target } }} {{ if features =="" {'--features gdb'} else { "--features gdb," + features } }} -- test_gdb
+test-rust-gdb-debugging target=default-target features="" target-triple="":
+    cargo test --profile={{ if target == "debug" { "dev" } else { target } }} {{ if target-triple != "" { " --target " + target-triple } else { "" } }} --example guest-debugging {{ if features =="" {'--features gdb'} else { "--features gdb," + features } }}
+    cargo test --profile={{ if target == "debug" { "dev" } else { target } }} {{ if target-triple != "" { " --target " + target-triple } else { "" } }} {{ if features =="" {'--features gdb'} else { "--features gdb," + features } }} -- test_gdb
 
 # rust test for crashdump
-test-rust-crashdump target=default-target features="":
-    cargo test --profile={{ if target == "debug" { "dev" } else { target } }} {{ if features =="" {'--features crashdump'} else { "--features crashdump," + features } }} -- test_crashdump
+test-rust-crashdump target=default-target features="" target-triple="":
+    cargo test --profile={{ if target == "debug" { "dev" } else { target } }} {{ if target-triple != "" { " --target " + target-triple } else { "" } }} {{ if features =="" {'--features crashdump'} else { "--features crashdump," + features } }} -- test_crashdump
 
 # rust test for tracing
-test-rust-tracing target=default-target features="":
+test-rust-tracing target=default-target features="" target-triple="":
     # Run tests for the tracing guest and macro
-    cargo test -p hyperlight-guest-tracing --profile={{ if target == "debug" { "dev" } else { target } }}
-    cargo test -p hyperlight-guest-tracing-macro --profile={{ if target == "debug" { "dev" } else { target } }}
+    cargo test -p hyperlight-guest-tracing --profile={{ if target == "debug" { "dev" } else { target } }} {{ if target-triple != "" { " --target " + target-triple } else { "" } }}
+    cargo test -p hyperlight-guest-tracing-macro --profile={{ if target == "debug" { "dev" } else { target } }} {{ if target-triple != "" { " --target " + target-triple } else { "" } }}
 
     # Prepare the tracing guest for testing
     just build-rust-guests {{ target }} trace_guest
     just move-rust-guests {{ target }}
     # Run hello-world example with tracing enabled to get the trace output
+    # note that trace-dump doesn't run on MUSL target as of now
     TRACE_OUTPUT="$(cargo run --profile={{ if target == "debug" { "dev" } else { target } }} --example hello-world --features {{ if features =="" {"trace_guest"} else { "trace_guest," + features } }})" && \
         TRACE_FILE="$(echo "$TRACE_OUTPUT" | grep -oE 'Creating trace file at: [^ ]+' | awk -F': ' '{print $2}')" && \
         echo "$TRACE_OUTPUT" && \
@@ -218,14 +214,18 @@ test-rust-tracing target=default-target features="":
     just build-rust-guests {{ target }}
     just move-rust-guests {{ target }}
 
-test-doc target=default-target features="":
-    cargo test --profile={{ if target == "debug" { "dev" } else { target } }} {{ if features =="" {''} else { "--features " + features } }} --doc
+test-doc target=default-target features="" target-triple="":
+    cargo test --profile={{ if target == "debug" { "dev" } else { target } }}{{ if target-triple != "" { " --target " + target-triple } else { "" } }} {{ if features =="" {''} else { "--features " + features } }} --doc
 ################
 ### LINTING ####
 ################
 
-check:
-    cargo check
+check target-triple="":
+    cargo check {{ if target-triple != "" { " --target " + target-triple } else { "" } }}
+    cargo check -p hyperlight-host --features crashdump {{ if target-triple != "" { " --target " + target-triple } else { "" } }}
+    cargo check -p hyperlight-host --features print_debug {{ if target-triple != "" { " --target " + target-triple } else { "" } }}
+    cargo check -p hyperlight-host --features gdb {{ if target-triple != "" { " --target " + target-triple } else { "" } }}
+    cargo check -p hyperlight-host --features trace_guest,unwind_guest,mem_profile {{ if target-triple != "" { " --target " + target-triple } else { "" } }}
 
 fmt-check:
     cargo +nightly fmt --all -- --check
@@ -246,11 +246,11 @@ fmt-apply:
     cargo +nightly fmt --manifest-path src/tests/rust_guests/witguest/Cargo.toml
     cargo +nightly fmt --manifest-path src/hyperlight_guest_capi/Cargo.toml
 
-clippy target=default-target: (witguest-wit)
-    cargo clippy --all-targets --all-features --profile={{ if target == "debug" { "dev" } else { target } }} -- -D warnings
+clippy target=default-target target-triple="": (witguest-wit)
+    cargo clippy --all-targets --all-features --profile={{ if target == "debug" { "dev" } else { target } }} {{ if target-triple != "" { " --target " + target-triple } else { "" } }} -- -D warnings
 
 clippy-guests target=default-target: (witguest-wit)
-    cd src/tests/rust_guests/simpleguest && cargo clippy --profile={{ if target == "debug" { "dev" } else { target } }} -- -D warnings
+    cd src/tests/rust_guests/simpleguest && cargo clippy --profile={{ if target == "debug" { "dev" } else { target } }}  -- -D warnings
     cd src/tests/rust_guests/callbackguest && cargo clippy --profile={{ if target == "debug" { "dev" } else { target } }} -- -D warnings
     cd src/tests/rust_guests/witguest && cargo clippy --profile={{ if target == "debug" { "dev" } else { target } }} -- -D warnings
 
@@ -261,12 +261,12 @@ clippy-apply-fix-windows:
     cargo clippy --target x86_64-pc-windows-msvc --fix --all 
 
 # Run clippy with feature combinations for all packages
-clippy-exhaustive target=default-target: (witguest-wit)
-    ./hack/clippy-package-features.sh hyperlight-host {{ target }}
-    ./hack/clippy-package-features.sh hyperlight-guest {{ target }}
+clippy-exhaustive target=default-target target-triple="": (witguest-wit)
+    ./hack/clippy-package-features.sh hyperlight-host {{ target }} {{ if target-triple != "" { target-triple } else { "" } }}
+    ./hack/clippy-package-features.sh hyperlight-guest {{ target }} 
     ./hack/clippy-package-features.sh hyperlight-guest-bin {{ target }}
-    ./hack/clippy-package-features.sh hyperlight-common {{ target }}
-    ./hack/clippy-package-features.sh hyperlight-testing {{ target }}
+    ./hack/clippy-package-features.sh hyperlight-common {{ target }} {{ if target-triple != "" { target-triple } else { "" } }}
+    ./hack/clippy-package-features.sh hyperlight-testing {{ target }} {{ if target-triple != "" { target-triple } else { "" } }}
     just clippy-guests {{ target }}
 
 # Test a specific package with all feature combinations
@@ -281,15 +281,15 @@ verify-msrv:
 ### RUST EXAMPLES ###
 #####################
 
-run-rust-examples target=default-target features="":
-    cargo run --profile={{ if target == "debug" { "dev" } else { target } }} --example metrics {{ if features =="" {''} else { "--features " + features } }}
-    cargo run --profile={{ if target == "debug" { "dev" } else { target } }} --example metrics {{ if features =="" {"--features function_call_metrics"} else {"--features function_call_metrics," + features} }}
-    cargo run --profile={{ if target == "debug" { "dev" } else { target } }} --example logging {{ if features =="" {''} else { "--features " + features } }}
+run-rust-examples target=default-target features="" target-triple="":
+    cargo run --profile={{ if target == "debug" { "dev" } else { target } }} {{ if target-triple != "" { " --target " + target-triple } else { "" } }} --example metrics {{ if features =="" {''} else { "--features " + features } }}
+    cargo run --profile={{ if target == "debug" { "dev" } else { target } }} {{ if target-triple != "" { " --target " + target-triple } else { "" } }} --example metrics {{ if features =="" {"--features function_call_metrics"} else {"--features function_call_metrics," + features} }}
+    cargo run --profile={{ if target == "debug" { "dev" } else { target } }} {{ if target-triple != "" { " --target " + target-triple } else { "" } }} --example logging {{ if features =="" {''} else { "--features " + features } }}
 
 # The two tracing examples are flaky on windows so we run them on linux only for now, need to figure out why as they run fine locally on windows
-run-rust-examples-linux target=default-target features="": (run-rust-examples target features)
-    cargo run --profile={{ if target == "debug" { "dev" } else { target } }} --example tracing {{ if features =="" {''} else { "--features " + features } }}
-    cargo run --profile={{ if target == "debug" { "dev" } else { target } }} --example tracing {{ if features =="" {"--features function_call_metrics" } else {"--features function_call_metrics," + features} }}
+run-rust-examples-linux target=default-target features="" target-triple="": (run-rust-examples target features target-triple)
+    cargo run --profile={{ if target == "debug" { "dev" } else { target } }}  {{ if target-triple != "" { " --target " + target-triple } else { "" } }} --example tracing {{ if features =="" {''} else { "--features " + features } }}
+    cargo run --profile={{ if target == "debug" { "dev" } else { target } }}  {{ if target-triple != "" { " --target " + target-triple } else { "" } }}  --example tracing {{ if features =="" {"--features function_call_metrics" } else {"--features function_call_metrics," + features} }}
 
 
 #########################

--- a/hack/clippy-package-features.sh
+++ b/hack/clippy-package-features.sh
@@ -4,13 +4,20 @@ set -euo pipefail
 
 # Check for required arguments
 if [[ $# -lt 2 ]]; then
-    echo "Usage: $0 <package> <target>" >&2
-    echo "Example: $0 hyperlight-host debug" >&2
+    echo "Usage: $0 <package> <target> [target_triple]" >&2
+    echo "Example: $0 hyperlight-host debug x86_64-unknown-linux-musl" >&2
     exit 1
 fi
 
 PACKAGE="$1"
 TARGET="$2"
+TARGET_TRIPLE="${3:-}"
+
+# Cargo target argument to append to cargo calls (empty if not provided)
+TRIPLE_ARG=""
+if [[ -n "${TARGET_TRIPLE}" ]]; then
+    TRIPLE_ARG="--target ${TARGET_TRIPLE}"
+fi
 
 # Convert target for cargo profile
 PROFILE=$([ "$TARGET" = "debug" ] && echo "dev" || echo "$TARGET")
@@ -38,23 +45,23 @@ fi
 # Test with minimal features
 if [[ ${#REQUIRED_FEATURES[@]} -gt 0 ]]; then
     echo "Testing $PACKAGE with required features only ($required_features_str)..."
-    (set -x; cargo clippy -p "$PACKAGE" --all-targets --no-default-features --features "$required_features_str" --profile="$PROFILE" -- -D warnings)
+    (set -x; cargo clippy -p "$PACKAGE" --all-targets --no-default-features --features "$required_features_str" --profile="$PROFILE" ${TRIPLE_ARG} -- -D warnings)
 else
     echo "Testing $PACKAGE with no features..."
-    (set -x; cargo clippy -p "$PACKAGE" --all-targets --no-default-features --profile="$PROFILE" -- -D warnings)
+    (set -x; cargo clippy -p "$PACKAGE" --all-targets --no-default-features --profile="$PROFILE" ${TRIPLE_ARG} -- -D warnings)
 fi
 
 echo "Testing $PACKAGE with default features..."
-(set -x; cargo clippy -p "$PACKAGE" --all-targets --profile="$PROFILE" -- -D warnings)
+(set -x; cargo clippy -p "$PACKAGE" --all-targets --profile="$PROFILE" ${TRIPLE_ARG} -- -D warnings)
 
 # Test each additional feature individually
 for feature in $features; do
     if [[ ${#REQUIRED_FEATURES[@]} -gt 0 ]]; then
         echo "Testing $PACKAGE with feature: $required_features_str,$feature"
-        (set -x; cargo clippy -p "$PACKAGE" --all-targets --no-default-features --features "$required_features_str,$feature" --profile="$PROFILE" -- -D warnings)
+        (set -x; cargo clippy -p "$PACKAGE" --all-targets --no-default-features --features "$required_features_str,$feature" --profile="$PROFILE" ${TRIPLE_ARG} -- -D warnings)
     else
         echo "Testing $PACKAGE with feature: $feature"
-        (set -x; cargo clippy -p "$PACKAGE" --all-targets --no-default-features --features "$feature" --profile="$PROFILE" -- -D warnings)
+        (set -x; cargo clippy -p "$PACKAGE" --all-targets --no-default-features --features "$feature" --profile="$PROFILE" ${TRIPLE_ARG} -- -D warnings)
     fi
 done
 
@@ -63,9 +70,9 @@ if [[ -n "$features" ]]; then
     all_features=$(echo $features | tr '\n' ',' | sed 's/,$//')
     if [[ ${#REQUIRED_FEATURES[@]} -gt 0 ]]; then
         echo "Testing $PACKAGE with all features: $required_features_str,$all_features"
-        (set -x; cargo clippy -p "$PACKAGE" --all-targets --no-default-features --features "$required_features_str,$all_features" --profile="$PROFILE" -- -D warnings)
+        (set -x; cargo clippy -p "$PACKAGE" --all-targets --no-default-features --features "$required_features_str,$all_features" --profile="$PROFILE" ${TRIPLE_ARG} -- -D warnings)
     else
         echo "Testing $PACKAGE with all features: $all_features"
-        (set -x; cargo clippy -p "$PACKAGE" --all-targets --no-default-features --features "$all_features" --profile="$PROFILE" -- -D warnings)
+        (set -x; cargo clippy -p "$PACKAGE" --all-targets --no-default-features --features "$all_features" --profile="$PROFILE" ${TRIPLE_ARG} -- -D warnings)
     fi
 fi

--- a/src/hyperlight_host/Cargo.toml
+++ b/src/hyperlight_host/Cargo.toml
@@ -106,7 +106,6 @@ criterion = "0.7.0"
 tracing-chrome = "0.7.2"
 metrics-util = "0.20.0"
 metrics-exporter-prometheus = { version = "0.17.2", default-features = false }
-tracing-tracy = "0.11.4"
 serde_json = "1.0"
 hyperlight-component-macro = { workspace = true }
 
@@ -117,6 +116,11 @@ windows = { version = "0.61", features = [
 
 [target.'cfg(unix)'.dev-dependencies]
 proc-maps = "0.4.0"
+
+# tracy doesn't play well with musl (it does work in cross)
+[target.'cfg(not(target_env = "musl"))'.dev-dependencies]
+tracing-tracy = "0.11.4"
+
 
 [build-dependencies]
 anyhow = { version = "1.0.99" }

--- a/src/hyperlight_host/build.rs
+++ b/src/hyperlight_host/build.rs
@@ -101,6 +101,7 @@ fn main() -> Result<()> {
         // the other features they want.
         mshv2: { all(feature = "mshv2", target_os = "linux") },
         mshv3: { all(feature = "mshv3", not(feature="mshv2"), target_os = "linux") },
+        seccomp: { all(feature = "seccomp", target_os = "linux", not(target_env = "musl")) },
     }
 
     #[cfg(feature = "build-metadata")]

--- a/src/hyperlight_host/examples/guest-debugging/main.rs
+++ b/src/hyperlight_host/examples/guest-debugging/main.rs
@@ -151,6 +151,18 @@ mod tests {
         #[cfg(not(mshv2))]
         let features = "gdb";
 
+        // build it before running to avoid a race condition below
+        let mut guest_child = Command::new("cargo")
+            .arg("build")
+            .arg("--example")
+            .arg("guest-debugging")
+            .arg("--features")
+            .arg(features)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .status()
+            .map_err(|e| new_error!("Failed to build guest process: {}", e))?;
+
         let mut guest_child = Command::new("cargo")
             .arg("run")
             .arg("--example")

--- a/src/hyperlight_host/examples/tracing-tracy/main.rs
+++ b/src/hyperlight_host/examples/tracing-tracy/main.rs
@@ -13,17 +13,28 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 #![allow(clippy::disallowed_macros)]
+#[cfg(not(target_env = "musl"))]
 use hyperlight_host::sandbox::uninitialized::UninitializedSandbox;
+#[cfg(not(target_env = "musl"))]
 use hyperlight_host::{GuestBinary, Result};
+#[cfg(not(target_env = "musl"))]
 use hyperlight_testing::simple_guest_as_string;
+#[cfg(not(target_env = "musl"))]
 use tracing_subscriber::EnvFilter;
+#[cfg(not(target_env = "musl"))]
 use tracing_subscriber::layer::SubscriberExt;
 
+#[cfg(target_env = "musl")]
+fn main() {
+    println!("Tracy example isn't tested run on musl");
+}
 // An example of how to get tracy tracing working with hyperlight.
 // Run with:
 // TRACY_NO_EXIT=1 RUST_LOG=trace cargo run --package hyperlight-host --example tracing-tracy --profile release-with-debug,
 // and then open the `tracy-profiler` GUI, and there should be an option to load the client created by this example.
+#[cfg(not(target_env = "musl"))]
 fn main() -> Result<()> {
     tracing::subscriber::set_global_default(
         tracing_subscriber::registry()

--- a/src/hyperlight_host/src/error.rs
+++ b/src/hyperlight_host/src/error.rs
@@ -71,7 +71,7 @@ pub enum HyperlightError {
 
     /// A disallowed syscall was caught
     #[error("Seccomp filter trapped on disallowed syscall (check STDERR for offending syscall)")]
-    #[cfg(all(feature = "seccomp", target_os = "linux"))]
+    #[cfg(seccomp)]
     DisallowedSyscall,
 
     /// A generic error with a message
@@ -218,12 +218,12 @@ pub enum HyperlightError {
 
     /// a backend error occurred with seccomp filters
     #[error("Backend Error with Seccomp Filter {0:?}")]
-    #[cfg(all(feature = "seccomp", target_os = "linux"))]
+    #[cfg(seccomp)]
     SeccompFilterBackendError(#[from] seccompiler::BackendError),
 
     /// an error occurred with seccomp filters
     #[error("Error with Seccomp Filter {0:?}")]
-    #[cfg(all(feature = "seccomp", target_os = "linux"))]
+    #[cfg(seccomp)]
     SeccompFilterError(#[from] seccompiler::Error),
 
     /// Tried to restore snapshot to a sandbox that is not the same as the one the snapshot was taken from

--- a/src/hyperlight_host/src/func/host_functions.rs
+++ b/src/hyperlight_host/src/func/host_functions.rs
@@ -35,7 +35,7 @@ pub trait Registerable {
     ) -> Result<()>;
     /// Register a primitive host function whose worker thread has
     /// extra permissive seccomp filters installed
-    #[cfg(all(feature = "seccomp", target_os = "linux"))]
+    #[cfg(seccomp)]
     fn register_host_function_with_syscalls<Args: ParameterTuple, Output: SupportedReturnType>(
         &mut self,
         name: &str,
@@ -63,7 +63,7 @@ impl Registerable for UninitializedSandbox {
 
         (*hfs).register_host_function(name.to_string(), entry, self.mgr.unwrap_mgr_mut())
     }
-    #[cfg(all(feature = "seccomp", target_os = "linux"))]
+    #[cfg(seccomp)]
     fn register_host_function_with_syscalls<Args: ParameterTuple, Output: SupportedReturnType>(
         &mut self,
         name: &str,

--- a/src/hyperlight_host/src/lib.rs
+++ b/src/hyperlight_host/src/lib.rs
@@ -76,7 +76,7 @@ pub mod metrics;
 /// outside this file. Types from this module needed for public consumption are
 /// re-exported below.
 pub mod sandbox;
-#[cfg(all(feature = "seccomp", target_os = "linux"))]
+#[cfg(seccomp)]
 pub(crate) mod seccomp;
 /// Signal handling for Linux
 #[cfg(target_os = "linux")]

--- a/src/hyperlight_host/src/metrics/mod.rs
+++ b/src/hyperlight_host/src/metrics/mod.rs
@@ -133,7 +133,7 @@ mod tests {
             if #[cfg(feature = "function_call_metrics")] {
                 use metrics::Label;
 
-                let expected_num_metrics = if cfg!(all(feature = "seccomp", target_os = "linux")) {
+                let expected_num_metrics = if cfg!(all(seccomp)) {
                     3 // if seccomp enabled, the host call duration metric is emitted on a separate thread which this local recorder doesn't capture
                 } else {
                     4
@@ -186,7 +186,7 @@ mod tests {
                     "Histogram metric does not match expected value"
                 );
 
-                if !cfg!(all(feature = "seccomp", target_os = "linux")) {
+                if !cfg!(all(seccomp)) {
                     // 4. Host call duration
                     let histogram_key = CompositeKey::new(
                         metrics_util::MetricKind::Histogram,

--- a/src/hyperlight_host/src/sandbox/host_funcs.rs
+++ b/src/hyperlight_host/src/sandbox/host_funcs.rs
@@ -154,7 +154,7 @@ pub(super) fn default_writer_func(s: String) -> Result<i32> {
     }
 }
 
-#[cfg(all(feature = "seccomp", target_os = "linux"))]
+#[cfg(seccomp)]
 fn maybe_with_seccomp<T: Send>(
     name: &str,
     syscalls: Option<&[ExtraAllowedSyscall]>,
@@ -199,7 +199,7 @@ fn maybe_with_seccomp<T: Send>(
     })
 }
 
-#[cfg(not(all(feature = "seccomp", target_os = "linux")))]
+#[cfg(not(all(seccomp)))]
 fn maybe_with_seccomp<T: Send>(
     _name: &str,
     _syscalls: Option<&[ExtraAllowedSyscall]>,

--- a/src/hyperlight_host/src/sandbox/initialized_multi_use.rs
+++ b/src/hyperlight_host/src/sandbox/initialized_multi_use.rs
@@ -615,7 +615,7 @@ mod tests {
 
             let res: Result<u64> = sbox.call("ViolateSeccompFilters", ());
 
-            #[cfg(feature = "seccomp")]
+            #[cfg(seccomp)]
             match res {
                 Ok(_) => panic!("Expected to fail due to seccomp violation"),
                 Err(e) => match e {
@@ -624,7 +624,7 @@ mod tests {
                 },
             }
 
-            #[cfg(not(feature = "seccomp"))]
+            #[cfg(not(seccomp))]
             match res {
                 Ok(_) => (),
                 Err(e) => panic!("Expected to succeed without seccomp: {}", e),
@@ -632,7 +632,7 @@ mod tests {
         }
 
         // Second, run with allowing `SYS_getpid`
-        #[cfg(feature = "seccomp")]
+        #[cfg(seccomp)]
         {
             let mut usbox = UninitializedSandbox::new(
                 GuestBinary::FilePath(simple_guest_as_string().expect("Guest Binary Missing")),
@@ -709,7 +709,7 @@ mod tests {
                 )
                 .expect("Expected to call host function that returns i64");
 
-            if cfg!(feature = "seccomp") {
+            if cfg!(seccomp) {
                 // If seccomp is enabled, we expect the syscall to return EACCES, as setup by our seccomp filter
                 assert_eq!(host_func_result, -libc::EACCES as i64);
             } else {
@@ -718,7 +718,7 @@ mod tests {
             }
         }
 
-        #[cfg(feature = "seccomp")]
+        #[cfg(seccomp)]
         {
             // Now let's make sure if we register the `openat` syscall as an extra allowed syscall, it will succeed
             let mut ubox = UninitializedSandbox::new(

--- a/src/hyperlight_host/src/sandbox/uninitialized.rs
+++ b/src/hyperlight_host/src/sandbox/uninitialized.rs
@@ -36,7 +36,7 @@ use crate::mem::shared_mem::ExclusiveSharedMemory;
 use crate::sandbox::SandboxConfiguration;
 use crate::{MultiUseSandbox, Result, new_error};
 
-#[cfg(all(target_os = "linux", feature = "seccomp"))]
+#[cfg(seccomp)]
 const EXTRA_ALLOWED_SYSCALLS_FOR_WRITER_FUNC: &[super::ExtraAllowedSyscall] = &[
     // Fuzzing fails without `mmap` being an allowed syscall on our seccomp filter.
     // All fuzzing does is call `PrintOutput` (which calls `HostPrint` ). Thing is, `println!`
@@ -325,7 +325,7 @@ impl UninitializedSandbox {
     ///
     /// Unlike [`register`](Self::register), this variant allows specifying extra syscalls
     /// that will be permitted when the function handler runs.
-    #[cfg(all(feature = "seccomp", target_os = "linux"))]
+    #[cfg(seccomp)]
     pub fn register_with_extra_allowed_syscalls<
         Args: ParameterTuple,
         Output: SupportedReturnType,
@@ -348,10 +348,10 @@ impl UninitializedSandbox {
         &mut self,
         print_func: impl Into<HostFunction<i32, (String,)>>,
     ) -> Result<()> {
-        #[cfg(not(all(target_os = "linux", feature = "seccomp")))]
+        #[cfg(not(seccomp))]
         self.register("HostPrint", print_func)?;
 
-        #[cfg(all(target_os = "linux", feature = "seccomp"))]
+        #[cfg(seccomp)]
         self.register_with_extra_allowed_syscalls(
             "HostPrint",
             print_func,
@@ -365,13 +365,13 @@ impl UninitializedSandbox {
     ///
     /// Like [`register_print`](Self::register_print), but allows specifying extra syscalls
     /// that will be permitted during function execution.
-    #[cfg(all(feature = "seccomp", target_os = "linux"))]
+    #[cfg(seccomp)]
     pub fn register_print_with_extra_allowed_syscalls(
         &mut self,
         print_func: impl Into<HostFunction<i32, (String,)>>,
         extra_allowed_syscalls: impl IntoIterator<Item = crate::sandbox::ExtraAllowedSyscall>,
     ) -> Result<()> {
-        #[cfg(all(target_os = "linux", feature = "seccomp"))]
+        #[cfg(seccomp)]
         self.register_with_extra_allowed_syscalls(
             "HostPrint",
             print_func,

--- a/src/hyperlight_host/src/signal_handlers/mod.rs
+++ b/src/hyperlight_host/src/signal_handlers/mod.rs
@@ -18,7 +18,7 @@ use libc::c_int;
 
 use crate::sandbox::SandboxConfiguration;
 
-#[cfg(feature = "seccomp")]
+#[cfg(seccomp)]
 pub mod sigsys_signal_handler;
 
 pub(crate) fn setup_signal_handlers(config: &SandboxConfiguration) -> crate::Result<()> {
@@ -27,7 +27,7 @@ pub(crate) fn setup_signal_handlers(config: &SandboxConfiguration) -> crate::Res
     // Anything that performs memory allocations, locks, and others are non-async-signal-safe.
     // Hyperlight signal handlers are all designed to be async-signal-safe, so this function
     // should be safe to call.
-    #[cfg(feature = "seccomp")]
+    #[cfg(seccomp)]
     {
         use std::sync::Once;
 

--- a/src/hyperlight_host/src/signal_handlers/sigsys_signal_handler.rs
+++ b/src/hyperlight_host/src/signal_handlers/sigsys_signal_handler.rs
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#[cfg(feature = "seccomp")]
+#[cfg(seccomp)]
 pub(super) extern "C" fn handle_sigsys(
     signal: i32,
     info: *mut libc::siginfo_t,

--- a/src/hyperlight_host/tests/integration_test.rs
+++ b/src/hyperlight_host/tests/integration_test.rs
@@ -51,10 +51,10 @@ fn interrupt_host_call() {
         Ok(())
     };
 
-    #[cfg(any(target_os = "windows", not(feature = "seccomp")))]
+    #[cfg(any(target_os = "windows", not(seccomp)))]
     usbox.register("Spin", spin).unwrap();
 
-    #[cfg(all(target_os = "linux", feature = "seccomp"))]
+    #[cfg(seccomp)]
     usbox
         .register_with_extra_allowed_syscalls("Spin", spin, vec![libc::SYS_clock_nanosleep])
         .unwrap();


### PR DESCRIPTION
fixes: #606

This pull request refactors the CI workflows and `Justfile` to improve support for musl target.  It refactors the rust build job so it can be re-used across multiple targets and other github workflows. This doesn't currently reduce the number of jobs we run on PR's but sets the foundation for being able to reduce the number of items run.

When enabling musl I found a few items which will need follow up (will create issues):

- Building tracy-client (used in one of the tests) [didn't build on musl cleanly](https://github.com/houseabsolute/actions-rust-cross/issues/22).  I was able to get it build using cross but there was more extensive changes require to get cross working so disabled it for now, the rest of the other examples work.
- The seccomp tests fail with `signal: 11, SIGSEGV: invalid memory reference` when executing host functions that violate a seccomp rule.  We've seen a few other issues around this code so to get basic coverage up I've disabled this for now and plan to revisit enabling this feature.
- Includes a fix for https://github.com/hyperlight-dev/hyperlight/issues/626. Not sure why this was easier to reproduce with musl builds but I ran into this race condition a couple times while testing.

This does require installing some tools on the host VM's so I've marked this in draft until those tools are enabled.



