### PR TITLE
Remove serial testing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -922,21 +922,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-executor",
- "futures-io",
- "futures-sink",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
 name = "futures-channel"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -998,7 +983,6 @@ version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
- "futures-channel",
  "futures-core",
  "futures-io",
  "futures-macro",
@@ -1486,7 +1470,6 @@ dependencies = [
  "seccompiler",
  "serde",
  "serde_json",
- "serial_test",
  "sha256",
  "signal-hook-registry",
  "tempfile",
@@ -3021,15 +3004,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "scc"
-version = "2.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46e6f046b7fef48e2660c57ed794263155d713de679057f2d0c169bfc6e756cc"
-dependencies = [
- "sdd",
-]
-
-[[package]]
 name = "scoped-tls"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3060,12 +3034,6 @@ dependencies = [
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "sdd"
-version = "3.0.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
 
 [[package]]
 name = "seccompiler"
@@ -3133,31 +3101,6 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
-]
-
-[[package]]
-name = "serial_test"
-version = "3.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b258109f244e1d6891bf1053a55d63a5cd4f8f4c30cf9a1280989f80e7a1fa9"
-dependencies = [
- "futures",
- "log",
- "once_cell",
- "parking_lot",
- "scc",
- "serial_test_derive",
-]
-
-[[package]]
-name = "serial_test_derive"
-version = "3.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d69265a08751de7844521fd15003ae0a888e035773ba05695c5c759a6f89eef"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]

--- a/src/hyperlight_host/Cargo.toml
+++ b/src/hyperlight_host/Cargo.toml
@@ -90,7 +90,6 @@ proptest = "1.7.0"
 tempfile = "3.22.0"
 crossbeam-queue = "0.3.12"
 tracing-serde = "0.2.0"
-serial_test = "3.1.1"
 hyperlight-testing = { workspace = true }
 env_logger = "0.11.8"
 tracing-forest = { version = "0.2.0", features = ["uuid", "chrono", "smallvec", "serde", "env-filter"] }

--- a/src/hyperlight_host/src/hypervisor/surrogate_process_manager.rs
+++ b/src/hyperlight_host/src/hypervisor/surrogate_process_manager.rs
@@ -422,7 +422,6 @@ mod tests {
 
     use hyperlight_common::mem::PAGE_SIZE_USIZE;
     use rand::{Rng, rng};
-    use serial_test::serial;
     use windows::Win32::Foundation::{CloseHandle, HANDLE, INVALID_HANDLE_VALUE};
     use windows::Win32::System::Diagnostics::ToolHelp::{
         CreateToolhelp32Snapshot, PROCESSENTRY32, Process32First, Process32Next, TH32CS_SNAPPROCESS,
@@ -437,7 +436,6 @@ mod tests {
     use super::*;
     use crate::mem::shared_mem::{ExclusiveSharedMemory, SharedMemory};
     #[test]
-    #[serial]
     fn test_surrogate_process_manager() {
         let mut threads = Vec::new();
         // create more threads than surrogate processes as we want to test that

--- a/src/hyperlight_host/tests/sandbox_host_tests.rs
+++ b/src/hyperlight_host/tests/sandbox_host_tests.rs
@@ -24,14 +24,11 @@ use hyperlight_host::{
     GuestBinary, HyperlightError, MultiUseSandbox, Result, UninitializedSandbox, new_error,
 };
 use hyperlight_testing::simple_guest_as_string;
-#[cfg(target_os = "windows")]
-use serial_test::serial; // using LoadLibrary requires serial tests
 
 pub mod common; // pub to disable dead_code warning
 use crate::common::get_simpleguest_sandboxes;
 
 #[test]
-#[cfg_attr(target_os = "windows", serial)] // using LoadLibrary requires serial tests
 fn pass_byte_array() {
     for mut sandbox in get_simpleguest_sandboxes(None).into_iter() {
         const LEN: usize = 10;
@@ -49,7 +46,6 @@ fn pass_byte_array() {
 
 #[test]
 #[ignore = "Fails with mismatched float only when c .exe guest?!"]
-#[cfg_attr(target_os = "windows", serial)] // using LoadLibrary requires serial tests
 fn float_roundtrip() {
     let doubles = [
         0.0,
@@ -107,7 +103,6 @@ fn float_roundtrip() {
 }
 
 #[test]
-#[cfg_attr(target_os = "windows", serial)] // using LoadLibrary requires serial tests
 fn invalid_guest_function_name() {
     for mut sandbox in get_simpleguest_sandboxes(None).into_iter() {
         let fn_name = "FunctionDoesntExist";
@@ -120,7 +115,6 @@ fn invalid_guest_function_name() {
 }
 
 #[test]
-#[cfg_attr(target_os = "windows", serial)] // using LoadLibrary requires serial tests
 fn set_static() {
     for mut sandbox in get_simpleguest_sandboxes(None).into_iter() {
         let fn_name = "SetStatic";
@@ -133,7 +127,6 @@ fn set_static() {
 }
 
 #[test]
-#[cfg_attr(target_os = "windows", serial)] // using LoadLibrary requires serial tests
 fn multiple_parameters() {
     let (tx, rx) = channel();
     let writer = move |msg: String| {
@@ -181,7 +174,6 @@ fn multiple_parameters() {
 }
 
 #[test]
-#[cfg_attr(target_os = "windows", serial)] // using LoadLibrary requires serial tests
 fn incorrect_parameter_type() {
     for mut sandbox in get_simpleguest_sandboxes(None) {
         let res = sandbox.call::<i32>(
@@ -199,7 +191,6 @@ fn incorrect_parameter_type() {
 }
 
 #[test]
-#[cfg_attr(target_os = "windows", serial)] // using LoadLibrary requires serial tests
 fn incorrect_parameter_num() {
     for mut sandbox in get_simpleguest_sandboxes(None).into_iter() {
         let res = sandbox.call::<i32>("Echo", ("1".to_string(), 2_i32));
@@ -229,7 +220,6 @@ fn max_memory_sandbox() {
 }
 
 #[test]
-#[cfg_attr(target_os = "windows", serial)] // using LoadLibrary requires serial tests
 fn iostack_is_working() {
     for mut sandbox in get_simpleguest_sandboxes(None).into_iter() {
         let res: i32 = sandbox
@@ -290,13 +280,11 @@ fn simple_test_helper() -> Result<()> {
 }
 
 #[test]
-#[cfg_attr(target_os = "windows", serial)] // using LoadLibrary requires serial tests
 fn simple_test() {
     simple_test_helper().unwrap();
 }
 
 #[test]
-#[cfg(target_os = "linux")]
 fn simple_test_parallel() {
     let handles: Vec<_> = (0..50)
         .map(|_| {
@@ -333,13 +321,11 @@ fn callback_test_helper() -> Result<()> {
 }
 
 #[test]
-#[cfg_attr(target_os = "windows", serial)] // using LoadLibrary requires serial tests
 fn callback_test() {
     callback_test_helper().unwrap();
 }
 
 #[test]
-#[cfg(target_os = "linux")] // windows can't run parallel with LoadLibrary
 fn callback_test_parallel() {
     let handles: Vec<_> = (0..100)
         .map(|_| {
@@ -355,7 +341,6 @@ fn callback_test_parallel() {
 }
 
 #[test]
-#[cfg_attr(target_os = "windows", serial)] // using LoadLibrary requires serial tests
 fn host_function_error() -> Result<()> {
     for mut sandbox in get_uninit_simpleguest_sandboxes(None).into_iter() {
         // create host function


### PR DESCRIPTION
we no longer need it since we don't support running in-process, which was the reason for it