### PR TITLE
Remove old code used for removed in-process feature

### DIFF
--- a/src/hyperlight_host/src/mem/layout.rs
+++ b/src/hyperlight_host/src/mem/layout.rs
@@ -402,9 +402,6 @@ impl SandboxMemoryLayout {
     }
 
     /// Get the offset in guest memory to the start of output data.
-    ///
-    /// This function exists to accommodate the macro that generates C API
-    /// compatible functions.
     #[instrument(skip_all, parent = Span::current(), level= "Trace")]
     #[cfg(test)]
     pub(crate) fn get_output_data_offset(&self) -> usize {

--- a/src/hyperlight_host/src/mem/layout.rs
+++ b/src/hyperlight_host/src/mem/layout.rs
@@ -385,24 +385,6 @@ impl SandboxMemoryLayout {
         self.stack_size
     }
 
-    /// Get the offset in guest memory to the OutB pointer.
-    #[instrument(skip_all, parent = Span::current(), level= "Trace")]
-    #[allow(dead_code)]
-    pub(super) fn get_outb_pointer_offset(&self) -> usize {
-        // The outb pointer is immediately after the code pointer
-        // in the `CodeAndOutBPointers` struct which is a u64
-        self.peb_code_pointer_offset + size_of::<u64>()
-    }
-
-    /// Get the offset in guest memory to the OutB context.
-    #[instrument(skip_all, parent = Span::current(), level= "Trace")]
-    #[allow(dead_code)]
-    pub(super) fn get_outb_context_offset(&self) -> usize {
-        // The outb context is immediately after the outb pointer
-        // in the `CodeAndOutBPointers` struct which is a u64
-        self.get_outb_pointer_offset() + size_of::<u64>()
-    }
-
     /// Get the offset in guest memory to the output data pointer.
     #[instrument(skip_all, parent = Span::current(), level= "Trace")]
     fn get_output_data_pointer_offset(&self) -> usize {
@@ -424,7 +406,7 @@ impl SandboxMemoryLayout {
     /// This function exists to accommodate the macro that generates C API
     /// compatible functions.
     #[instrument(skip_all, parent = Span::current(), level= "Trace")]
-    #[allow(dead_code)]
+    #[cfg(test)]
     pub(crate) fn get_output_data_offset(&self) -> usize {
         self.output_data_buffer_offset
     }
@@ -459,13 +441,6 @@ impl SandboxMemoryLayout {
         self.peb_guest_dispatch_function_ptr_offset
     }
 
-    /// Get the offset in guest memory to the PEB address
-    #[instrument(skip_all, parent = Span::current(), level= "Trace")]
-    #[allow(dead_code)]
-    pub(super) fn get_in_process_peb_offset(&self) -> usize {
-        self.peb_offset
-    }
-
     /// Get the offset in guest memory to the heap size
     #[instrument(skip_all, parent = Span::current(), level= "Trace")]
     fn get_heap_size_offset(&self) -> usize {
@@ -492,13 +467,6 @@ impl SandboxMemoryLayout {
         // The userStackAddress is immediately after the
         // minUserStackAddress (top of user stack) field in the `GuestStackData` struct which is a `u64`.
         self.get_min_guest_stack_address_offset() + size_of::<u64>()
-    }
-
-    /// Get the offset to the guest guard page
-    #[instrument(skip_all, parent = Span::current(), level= "Trace")]
-    #[allow(dead_code)]
-    pub fn get_guard_page_offset(&self) -> usize {
-        self.guard_page_offset
     }
 
     /// Get the total size of guest memory in `self`'s memory

--- a/src/hyperlight_host/src/mem/mgr.rs
+++ b/src/hyperlight_host/src/mem/mgr.rs
@@ -281,21 +281,6 @@ where
         snapshot.restore_from_snapshot(&mut self.shared_mem)?;
         Ok(())
     }
-
-    /// Sets `addr` to the correct offset in the memory referenced by
-    /// `shared_mem` to indicate the address of the outb pointer and context
-    /// for calling outb function
-    #[instrument(err(Debug), skip_all, parent = Span::current(), level= "Trace")]
-    #[allow(dead_code)]
-    pub(crate) fn set_outb_address_and_context(&mut self, addr: u64, context: u64) -> Result<()> {
-        let pointer_offset = self.layout.get_outb_pointer_offset();
-        let context_offset = self.layout.get_outb_context_offset();
-        self.shared_mem.with_exclusivity(|excl| -> Result<()> {
-            excl.write_u64(pointer_offset, addr)?;
-            excl.write_u64(context_offset, context)?;
-            Ok(())
-        })?
-    }
 }
 
 impl SandboxMemoryManager<ExclusiveSharedMemory> {

--- a/src/hyperlight_host/src/mem/shared_mem.rs
+++ b/src/hyperlight_host/src/mem/shared_mem.rs
@@ -30,7 +30,7 @@ use windows::Win32::System::Memory::PAGE_READWRITE;
 #[cfg(target_os = "windows")]
 use windows::Win32::System::Memory::{
     CreateFileMappingA, FILE_MAP_ALL_ACCESS, MEMORY_MAPPED_VIEW_ADDRESS, MapViewOfFile,
-    PAGE_EXECUTE_READWRITE, PAGE_NOACCESS, PAGE_PROTECTION_FLAGS, UnmapViewOfFile, VirtualProtect,
+    PAGE_NOACCESS, PAGE_PROTECTION_FLAGS, UnmapViewOfFile, VirtualProtect,
 };
 #[cfg(target_os = "windows")]
 use windows::core::PCSTR;

--- a/src/hyperlight_host/src/mem/shared_mem.rs
+++ b/src/hyperlight_host/src/mem/shared_mem.rs
@@ -502,46 +502,6 @@ impl ExclusiveSharedMemory {
         })
     }
 
-    #[allow(dead_code)]
-    pub(super) fn make_memory_executable(&self) -> Result<()> {
-        #[cfg(target_os = "windows")]
-        {
-            let mut _old_flags = PAGE_PROTECTION_FLAGS::default();
-            if let Err(e) = unsafe {
-                VirtualProtect(
-                    self.region.ptr as *const c_void,
-                    self.region.size,
-                    PAGE_EXECUTE_READWRITE,
-                    &mut _old_flags as *mut PAGE_PROTECTION_FLAGS,
-                )
-            } {
-                log_then_return!(WindowsAPIError(e.clone()));
-            }
-        }
-
-        // make the memory executable on Linux
-        #[cfg(target_os = "linux")]
-        {
-            use libc::{PROT_EXEC, PROT_READ, PROT_WRITE, mprotect};
-
-            let res = unsafe {
-                mprotect(
-                    self.region.ptr as *mut c_void,
-                    self.region.size,
-                    PROT_READ | PROT_WRITE | PROT_EXEC,
-                )
-            };
-
-            if res != 0 {
-                return Err(new_error!(
-                    "Failed to make memory executable: {:#?}",
-                    Error::last_os_error().raw_os_error()
-                ));
-            }
-        }
-        Ok(())
-    }
-
     /// Internal helper method to get the backing memory as a mutable slice.
     ///
     /// # Safety
@@ -612,15 +572,6 @@ impl ExclusiveSharedMemory {
         bounds_check!(offset, src.len(), data.len());
         data[offset..offset + src.len()].copy_from_slice(src);
         Ok(())
-    }
-
-    /// Return the address of memory at an offset to this `SharedMemory` checking
-    /// that the memory is within the bounds of the `SharedMemory`.
-    #[instrument(err(Debug), skip_all, parent = Span::current(), level= "Trace")]
-    #[allow(dead_code)]
-    pub(crate) fn calculate_address(&self, offset: usize) -> Result<usize> {
-        bounds_check!(offset, 0, self.mem_size());
-        Ok(self.base_addr() + offset)
     }
 
     generate_reader!(read_u8, u8);

--- a/src/hyperlight_host/src/sandbox/initialized_multi_use.rs
+++ b/src/hyperlight_host/src/sandbox/initialized_multi_use.rs
@@ -333,7 +333,6 @@ impl MultiUseSandbox {
     /// Map the contents of a file into the guest at a particular address
     ///
     /// Returns the length of the mapping in bytes.
-    #[allow(dead_code)]
     #[instrument(err(Debug), skip(self, _fp, _guest_base), parent = Span::current())]
     pub fn map_file_cow(&mut self, _fp: &Path, _guest_base: u64) -> Result<u64> {
         #[cfg(windows)]


### PR DESCRIPTION
These are all unused but seems we forgot to remove them when removing the inprocess feature