### PR TITLE
Add missing clippy checks to clippy-exhaustive  just target

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -260,6 +260,10 @@ clippy-exhaustive target=default-target: (witguest-wit)
     ./hack/clippy-package-features.sh hyperlight-guest-bin {{ target }}
     ./hack/clippy-package-features.sh hyperlight-common {{ target }}
     ./hack/clippy-package-features.sh hyperlight-testing {{ target }}
+    ./hack/clippy-package-features.sh hyperlight-component-macro  {{ target }}
+    ./hack/clippy-package-features.sh hyperlight-component-util {{ target }}
+    ./hack/clippy-package-features.sh hyperlight-guest-tracing-macro {{ target }}
+    ./hack/clippy-package-features.sh hyperlight-guest-tracing {{ target }}
     just clippy-guests {{ target }}
 
 # Test a specific package with all feature combinations
@@ -268,7 +272,7 @@ clippy-package package target=default-target: (witguest-wit)
 
 # Verify Minimum Supported Rust Version
 verify-msrv:
-    ./dev/verify-msrv.sh hyperlight-host hyperlight-guest hyperlight-guest-lib hyperlight-common
+    ./dev/verify-msrv.sh hyperlight-common hyperlight-guest hyperlight-guest-bin hyperlight-host hyperlight-component-util hyperlight-component-macro hyperlight-guest-tracing-macro hyperlight-guest-tracing
 
 #####################
 ### RUST EXAMPLES ###

--- a/src/hyperlight_guest_tracing/src/lib.rs
+++ b/src/hyperlight_guest_tracing/src/lib.rs
@@ -355,7 +355,7 @@ mod trace {
         #[test]
         fn test_trace_record_creation_valid() {
             let msg = "Valid message";
-            let entry = TraceRecord::try_from(msg).expect("Failed to create TraceRecord");
+            let entry = TraceRecord::from(msg);
             assert_eq!(entry.msg_len, msg.len());
             assert_eq!(&entry.msg[..msg.len()], msg.as_bytes());
             assert!(entry.cycles > 0); // Ensure cycles is set


### PR DESCRIPTION
Adds missing `clippy` tests to  `clippy-exhaustive` Just target. 

Does not add `hyperlight_guest_capi`, this will be done in a separate PR