### PR TITLE
Unify register representation across hypervisors

### DIFF
--- a/src/hyperlight_host/src/hypervisor/regs.rs
+++ b/src/hyperlight_host/src/hypervisor/regs.rs
@@ -14,6 +14,23 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-pub(crate) const FP_CONTROL_WORD_DEFAULT: u16 = 0x37f; // mask all fp-exception, set rounding to nearest, set precision to 64-bit
-pub(crate) const FP_TAG_WORD_DEFAULT: u8 = 0xff; // each 8 of x87 fpu registers is empty
-pub(crate) const MXCSR_DEFAULT: u32 = 0x1f80; // mask simd fp-exceptions, clear exception flags, set rounding to nearest, disable flush-to-zero mode, disable denormals-are-zero mode
+mod fpu;
+mod special_regs;
+mod standard_regs;
+
+#[cfg(target_os = "windows")]
+use std::collections::HashSet;
+
+pub(crate) use fpu::*;
+pub(crate) use special_regs::*;
+pub(crate) use standard_regs::*;
+
+#[cfg(target_os = "windows")]
+#[derive(Debug, PartialEq)]
+pub(crate) enum FromWhpRegisterError {
+    MissingRegister(HashSet<i32>),
+    InvalidLength(usize),
+    InvalidEncoding,
+    DuplicateRegister(i32),
+    InvalidRegister(i32),
+}

--- a/src/hyperlight_host/src/hypervisor/regs/fpu.rs
+++ b/src/hyperlight_host/src/hypervisor/regs/fpu.rs
@@ -1,0 +1,438 @@
+/*
+Copyright 2024 The Hyperlight Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+#[cfg(mshv2)]
+extern crate mshv_bindings2 as mshv_bindings;
+#[cfg(mshv2)]
+extern crate mshv_ioctls2 as mshv_ioctls;
+
+#[cfg(mshv3)]
+extern crate mshv_bindings3 as mshv_bindings;
+#[cfg(mshv3)]
+extern crate mshv_ioctls3 as mshv_ioctls;
+
+#[cfg(target_os = "windows")]
+use std::collections::HashSet;
+
+#[cfg(kvm)]
+use kvm_bindings::kvm_fpu;
+#[cfg(mshv)]
+use mshv_bindings::FloatingPointUnit;
+
+#[cfg(target_os = "windows")]
+use super::Align16;
+#[cfg(target_os = "windows")]
+use crate::hypervisor::regs::FromWhpRegisterError;
+
+pub(crate) const FP_CONTROL_WORD_DEFAULT: u16 = 0x37f; // mask all fp-exception, set rounding to nearest, set precision to 64-bit
+pub(crate) const MXCSR_DEFAULT: u32 = 0x1f80; // mask simd fp-exceptions, clear exception flags, set rounding to nearest, disable flush-to-zero mode, disable denormals-are-zero mode
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(crate) struct CommonFpu {
+    pub fpr: [[u8; 16]; 8],
+    pub fcw: u16,
+    pub fsw: u16,
+    pub ftwx: u8,
+    pub pad1: u8,
+    pub last_opcode: u16,
+    pub last_ip: u64,
+    pub last_dp: u64,
+    pub xmm: [[u8; 16]; 16],
+    pub mxcsr: u32,
+    pub pad2: u32,
+}
+
+impl Default for CommonFpu {
+    fn default() -> Self {
+        Self {
+            fpr: [[0u8; 16]; 8],
+            fcw: FP_CONTROL_WORD_DEFAULT,
+            fsw: 0,
+            ftwx: 0,
+            pad1: 0,
+            last_opcode: 0,
+            last_ip: 0,
+            last_dp: 0,
+            xmm: [[0u8; 16]; 16],
+            mxcsr: MXCSR_DEFAULT,
+            pad2: 0,
+        }
+    }
+}
+
+#[cfg(kvm)]
+impl From<&CommonFpu> for kvm_fpu {
+    fn from(common_fpu: &CommonFpu) -> Self {
+        kvm_fpu {
+            fpr: common_fpu.fpr,
+            fcw: common_fpu.fcw,
+            fsw: common_fpu.fsw,
+            ftwx: common_fpu.ftwx,
+            pad1: common_fpu.pad1,
+            last_opcode: common_fpu.last_opcode,
+            last_ip: common_fpu.last_ip,
+            last_dp: common_fpu.last_dp,
+            xmm: common_fpu.xmm,
+            mxcsr: common_fpu.mxcsr,
+            pad2: common_fpu.pad2,
+        }
+    }
+}
+
+#[cfg(mshv)]
+impl From<&CommonFpu> for FloatingPointUnit {
+    fn from(common_fpu: &CommonFpu) -> FloatingPointUnit {
+        FloatingPointUnit {
+            fpr: common_fpu.fpr,
+            fcw: common_fpu.fcw,
+            fsw: common_fpu.fsw,
+            ftwx: common_fpu.ftwx,
+            pad1: common_fpu.pad1,
+            last_opcode: common_fpu.last_opcode,
+            last_ip: common_fpu.last_ip,
+            last_dp: common_fpu.last_dp,
+            xmm: common_fpu.xmm,
+            mxcsr: common_fpu.mxcsr,
+            pad2: common_fpu.pad2,
+        }
+    }
+}
+
+#[cfg(kvm)]
+impl From<&kvm_fpu> for CommonFpu {
+    fn from(kvm_fpu: &kvm_fpu) -> Self {
+        Self {
+            fpr: kvm_fpu.fpr,
+            fcw: kvm_fpu.fcw,
+            fsw: kvm_fpu.fsw,
+            ftwx: kvm_fpu.ftwx,
+            pad1: kvm_fpu.pad1,
+            last_opcode: kvm_fpu.last_opcode,
+            last_ip: kvm_fpu.last_ip,
+            last_dp: kvm_fpu.last_dp,
+            xmm: kvm_fpu.xmm,
+            mxcsr: kvm_fpu.mxcsr,
+            pad2: kvm_fpu.pad2,
+        }
+    }
+}
+
+#[cfg(mshv)]
+impl From<&FloatingPointUnit> for CommonFpu {
+    fn from(mshv_fpu: &FloatingPointUnit) -> Self {
+        Self {
+            fpr: mshv_fpu.fpr,
+            fcw: mshv_fpu.fcw,
+            fsw: mshv_fpu.fsw,
+            ftwx: mshv_fpu.ftwx,
+            pad1: mshv_fpu.pad1,
+            last_opcode: mshv_fpu.last_opcode,
+            last_ip: mshv_fpu.last_ip,
+            last_dp: mshv_fpu.last_dp,
+            xmm: mshv_fpu.xmm,
+            mxcsr: mshv_fpu.mxcsr,
+            pad2: mshv_fpu.pad2,
+        }
+    }
+}
+
+#[cfg(target_os = "windows")]
+use windows::Win32::System::Hypervisor::*;
+
+#[cfg(target_os = "windows")]
+impl From<&CommonFpu> for [(WHV_REGISTER_NAME, Align16<WHV_REGISTER_VALUE>); WHP_FPU_NAMES_LEN] {
+    fn from(fpu: &CommonFpu) -> Self {
+        let mut regs: [(WHV_REGISTER_NAME, Align16<WHV_REGISTER_VALUE>); WHP_FPU_NAMES_LEN] =
+            [Default::default(); WHP_FPU_NAMES_LEN];
+        let mut idx = 0;
+
+        // FPU/MMX registers (8 x 128-bit)
+        for (i, reg) in fpu.fpr.iter().enumerate() {
+            let mut value = WHV_REGISTER_VALUE::default();
+            value.Reg128 = WHV_UINT128 {
+                Dword: [
+                    u32::from_le_bytes([reg[0], reg[1], reg[2], reg[3]]),
+                    u32::from_le_bytes([reg[4], reg[5], reg[6], reg[7]]),
+                    u32::from_le_bytes([reg[8], reg[9], reg[10], reg[11]]),
+                    u32::from_le_bytes([reg[12], reg[13], reg[14], reg[15]]),
+                ],
+            };
+            regs[idx] = (
+                WHV_REGISTER_NAME(WHvX64RegisterFpMmx0.0 + i as i32),
+                Align16(value),
+            );
+            idx += 1;
+        }
+
+        // FpControlStatus
+        let mut fp_control_status = WHV_REGISTER_VALUE::default();
+        fp_control_status.FpControlStatus = WHV_X64_FP_CONTROL_STATUS_REGISTER {
+            Anonymous: WHV_X64_FP_CONTROL_STATUS_REGISTER_0 {
+                FpControl: fpu.fcw,
+                FpStatus: fpu.fsw,
+                FpTag: fpu.ftwx,
+                Reserved: fpu.pad1,
+                LastFpOp: fpu.last_opcode,
+                Anonymous: WHV_X64_FP_CONTROL_STATUS_REGISTER_0_0 {
+                    LastFpRip: fpu.last_ip,
+                },
+            },
+        };
+        regs[idx] = (WHvX64RegisterFpControlStatus, Align16(fp_control_status));
+        idx += 1;
+
+        // XMM registers (16 x 128-bit)
+        for (i, reg) in fpu.xmm.iter().enumerate() {
+            let mut value = WHV_REGISTER_VALUE::default();
+            value.Reg128 = WHV_UINT128 {
+                Dword: [
+                    u32::from_le_bytes([reg[0], reg[1], reg[2], reg[3]]),
+                    u32::from_le_bytes([reg[4], reg[5], reg[6], reg[7]]),
+                    u32::from_le_bytes([reg[8], reg[9], reg[10], reg[11]]),
+                    u32::from_le_bytes([reg[12], reg[13], reg[14], reg[15]]),
+                ],
+            };
+            regs[idx] = (
+                WHV_REGISTER_NAME(WHvX64RegisterXmm0.0 + i as i32),
+                Align16(value),
+            );
+            idx += 1;
+        }
+
+        // XmmControlStatus
+        let mut xmm_control_status = WHV_REGISTER_VALUE::default();
+        xmm_control_status.XmmControlStatus = WHV_X64_XMM_CONTROL_STATUS_REGISTER {
+            Anonymous: WHV_X64_XMM_CONTROL_STATUS_REGISTER_0 {
+                XmmStatusControl: fpu.mxcsr,
+                XmmStatusControlMask: !0,
+                Anonymous: WHV_X64_XMM_CONTROL_STATUS_REGISTER_0_0 {
+                    LastFpRdp: fpu.last_dp,
+                },
+            },
+        };
+        regs[idx] = (WHvX64RegisterXmmControlStatus, Align16(xmm_control_status));
+
+        regs
+    }
+}
+
+#[cfg(target_os = "windows")]
+pub(crate) const WHP_FPU_NAMES_LEN: usize = 26;
+#[cfg(target_os = "windows")]
+pub(crate) const WHP_FPU_NAMES: [WHV_REGISTER_NAME; WHP_FPU_NAMES_LEN] = [
+    WHvX64RegisterFpMmx0,
+    WHvX64RegisterFpMmx1,
+    WHvX64RegisterFpMmx2,
+    WHvX64RegisterFpMmx3,
+    WHvX64RegisterFpMmx4,
+    WHvX64RegisterFpMmx5,
+    WHvX64RegisterFpMmx6,
+    WHvX64RegisterFpMmx7,
+    WHvX64RegisterFpControlStatus,
+    WHvX64RegisterXmm0,
+    WHvX64RegisterXmm1,
+    WHvX64RegisterXmm2,
+    WHvX64RegisterXmm3,
+    WHvX64RegisterXmm4,
+    WHvX64RegisterXmm5,
+    WHvX64RegisterXmm6,
+    WHvX64RegisterXmm7,
+    WHvX64RegisterXmm8,
+    WHvX64RegisterXmm9,
+    WHvX64RegisterXmm10,
+    WHvX64RegisterXmm11,
+    WHvX64RegisterXmm12,
+    WHvX64RegisterXmm13,
+    WHvX64RegisterXmm14,
+    WHvX64RegisterXmm15,
+    WHvX64RegisterXmmControlStatus,
+];
+
+#[cfg(target_os = "windows")]
+impl TryFrom<&[(WHV_REGISTER_NAME, Align16<WHV_REGISTER_VALUE>)]> for CommonFpu {
+    type Error = FromWhpRegisterError;
+
+    fn try_from(
+        regs: &[(WHV_REGISTER_NAME, Align16<WHV_REGISTER_VALUE>)],
+    ) -> Result<Self, Self::Error> {
+        if regs.len() != WHP_FPU_NAMES_LEN {
+            return Err(FromWhpRegisterError::InvalidLength(regs.len()));
+        }
+
+        let mut fpu = CommonFpu::default();
+        let mut seen_registers = HashSet::new();
+
+        for (name, value) in regs {
+            let name_id = name.0;
+
+            // Check for duplicates
+            if !seen_registers.insert(name_id) {
+                return Err(FromWhpRegisterError::DuplicateRegister(name_id));
+            }
+
+            match name_id {
+                id if (WHvX64RegisterFpMmx0.0..WHvX64RegisterFpMmx0.0 + 8).contains(&id) => {
+                    let idx = (id - WHvX64RegisterFpMmx0.0) as usize;
+                    let dwords = unsafe { value.0.Reg128.Dword };
+                    fpu.fpr[idx] = [
+                        dwords[0].to_le_bytes(),
+                        dwords[1].to_le_bytes(),
+                        dwords[2].to_le_bytes(),
+                        dwords[3].to_le_bytes(),
+                    ]
+                    .concat()
+                    .try_into()
+                    .map_err(|_| FromWhpRegisterError::InvalidEncoding)?;
+                }
+
+                id if id == WHvX64RegisterFpControlStatus.0 => {
+                    let control = unsafe { value.0.FpControlStatus.Anonymous };
+                    fpu.fcw = control.FpControl;
+                    fpu.fsw = control.FpStatus;
+                    fpu.ftwx = control.FpTag;
+                    fpu.pad1 = control.Reserved;
+                    fpu.last_opcode = control.LastFpOp;
+                    fpu.last_ip = unsafe { control.Anonymous.LastFpRip };
+                }
+
+                id if (WHvX64RegisterXmm0.0..WHvX64RegisterXmm0.0 + 16).contains(&id) => {
+                    let idx = (id - WHvX64RegisterXmm0.0) as usize;
+                    let dwords = unsafe { value.0.Reg128.Dword };
+                    fpu.xmm[idx] = [
+                        dwords[0].to_le_bytes(),
+                        dwords[1].to_le_bytes(),
+                        dwords[2].to_le_bytes(),
+                        dwords[3].to_le_bytes(),
+                    ]
+                    .concat()
+                    .try_into()
+                    .map_err(|_| FromWhpRegisterError::InvalidEncoding)?;
+                }
+
+                id if id == WHvX64RegisterXmmControlStatus.0 => {
+                    let control = unsafe { value.0.XmmControlStatus.Anonymous };
+                    fpu.mxcsr = control.XmmStatusControl;
+                    fpu.last_dp = unsafe { control.Anonymous.LastFpRdp };
+                }
+
+                _ => {
+                    return Err(FromWhpRegisterError::InvalidRegister(name_id));
+                }
+            }
+        }
+
+        // Set of all expected register names
+        let expected_registers: HashSet<i32> = WHP_FPU_NAMES.iter().map(|reg| reg.0).collect();
+
+        // Technically it should not be possible to have any missing registers at this point
+        // since we are guaranteed to have WHP_FPU_NAMES_LEN non-duplicate registers that have passed the match-arm above, but leaving this here for safety anyway
+        let missing: HashSet<i32> = expected_registers
+            .difference(&seen_registers)
+            .cloned()
+            .collect();
+
+        if !missing.is_empty() {
+            return Err(FromWhpRegisterError::MissingRegister(missing));
+        }
+
+        Ok(fpu)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_common_fpu() -> CommonFpu {
+        CommonFpu {
+            fpr: [
+                [1u8; 16], [2u8; 16], [3u8; 16], [4u8; 16], [5u8; 16], [6u8; 16], [7u8; 16],
+                [8u8; 16],
+            ],
+            fcw: 0x1234,
+            fsw: 0x5678,
+            ftwx: 0x9a,
+            pad1: 0xbc,
+            last_opcode: 0xdef0,
+            last_ip: 0xdeadbeefcafebabe,
+            last_dp: 0xabad1deaf00dbabe,
+            xmm: [
+                [8u8; 16], [9u8; 16], [10u8; 16], [11u8; 16], [12u8; 16], [13u8; 16], [14u8; 16],
+                [15u8; 16], [16u8; 16], [17u8; 16], [18u8; 16], [19u8; 16], [20u8; 16], [21u8; 16],
+                [22u8; 16], [23u8; 16],
+            ],
+            mxcsr: 0x1f80,
+            pad2: 0,
+        }
+    }
+
+    #[cfg(kvm)]
+    #[test]
+    fn round_trip_kvm_fpu() {
+        use kvm_bindings::kvm_fpu;
+
+        let original = sample_common_fpu();
+        let kvm: kvm_fpu = (&original).into();
+        let round_tripped = CommonFpu::from(&kvm);
+
+        assert_eq!(original, round_tripped);
+    }
+
+    #[cfg(mshv)]
+    #[test]
+    fn round_trip_mshv_fpu() {
+        use mshv_bindings::FloatingPointUnit;
+
+        let original = sample_common_fpu();
+        let mshv: FloatingPointUnit = (&original).into();
+        let round_tripped = CommonFpu::from(&mshv);
+
+        assert_eq!(original, round_tripped);
+    }
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn round_trip_windows_fpu() {
+        use windows::Win32::System::Hypervisor::*;
+
+        let original = sample_common_fpu();
+        let windows: [(WHV_REGISTER_NAME, Align16<WHV_REGISTER_VALUE>); WHP_FPU_NAMES_LEN] =
+            (&original).into();
+        let round_tripped = CommonFpu::try_from(windows.as_ref()).unwrap();
+        assert_eq!(original, round_tripped);
+
+        // test for duplicate register error handling
+        let original = sample_common_fpu();
+        let mut windows: [(WHV_REGISTER_NAME, Align16<WHV_REGISTER_VALUE>); WHP_FPU_NAMES_LEN] =
+            (&original).into();
+        windows[0].0 = WHvX64RegisterFpMmx1;
+        let err = CommonFpu::try_from(windows.as_ref()).unwrap_err();
+        assert_eq!(
+            err,
+            FromWhpRegisterError::DuplicateRegister(WHvX64RegisterFpMmx1.0)
+        );
+
+        // test for passing non-fpu register (e.g. RAX)
+        let original = sample_common_fpu();
+        let mut windows: [(WHV_REGISTER_NAME, Align16<WHV_REGISTER_VALUE>); WHP_FPU_NAMES_LEN] =
+            (&original).into();
+        windows[0] = (WHvX64RegisterRax, windows[0].1);
+        let err = CommonFpu::try_from(windows.as_ref()).unwrap_err();
+        assert_eq!(
+            err,
+            FromWhpRegisterError::InvalidRegister(WHvX64RegisterRax.0)
+        );
+    }
+}

--- a/src/hyperlight_host/src/hypervisor/regs/special_regs.rs
+++ b/src/hyperlight_host/src/hypervisor/regs/special_regs.rs
@@ -1,0 +1,667 @@
+/*
+Copyright 2025  The Hyperlight Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#[cfg(mshv2)]
+extern crate mshv_bindings2 as mshv_bindings;
+#[cfg(mshv2)]
+extern crate mshv_ioctls2 as mshv_ioctls;
+
+#[cfg(mshv3)]
+extern crate mshv_bindings3 as mshv_bindings;
+#[cfg(mshv3)]
+extern crate mshv_ioctls3 as mshv_ioctls;
+
+#[cfg(target_os = "windows")]
+use std::collections::HashSet;
+
+#[cfg(kvm)]
+use kvm_bindings::{kvm_dtable, kvm_segment, kvm_sregs};
+#[cfg(mshv)]
+use mshv_bindings::{SegmentRegister, SpecialRegisters, TableRegister};
+#[cfg(target_os = "windows")]
+use windows::Win32::System::Hypervisor::*;
+
+#[cfg(target_os = "windows")]
+use super::FromWhpRegisterError;
+
+#[derive(Debug, Default, Copy, Clone, PartialEq)]
+pub(crate) struct CommonSpecialRegisters {
+    pub cs: CommonSegmentRegister,
+    pub ds: CommonSegmentRegister,
+    pub es: CommonSegmentRegister,
+    pub fs: CommonSegmentRegister,
+    pub gs: CommonSegmentRegister,
+    pub ss: CommonSegmentRegister,
+    pub tr: CommonSegmentRegister,
+    pub ldt: CommonSegmentRegister,
+    pub gdt: CommonTableRegister,
+    pub idt: CommonTableRegister,
+    pub cr0: u64,
+    pub cr2: u64,
+    pub cr3: u64,
+    pub cr4: u64,
+    pub cr8: u64,
+    pub efer: u64,
+    pub apic_base: u64,
+    pub interrupt_bitmap: [u64; 4],
+}
+
+#[cfg(mshv)]
+impl From<&SpecialRegisters> for CommonSpecialRegisters {
+    fn from(value: &SpecialRegisters) -> Self {
+        CommonSpecialRegisters {
+            cs: value.cs.into(),
+            ds: value.ds.into(),
+            es: value.es.into(),
+            fs: value.fs.into(),
+            gs: value.gs.into(),
+            ss: value.ss.into(),
+            tr: value.tr.into(),
+            ldt: value.ldt.into(),
+            gdt: value.gdt.into(),
+            idt: value.idt.into(),
+            cr0: value.cr0,
+            cr2: value.cr2,
+            cr3: value.cr3,
+            cr4: value.cr4,
+            cr8: value.cr8,
+            efer: value.efer,
+            apic_base: value.apic_base,
+            interrupt_bitmap: value.interrupt_bitmap,
+        }
+    }
+}
+
+#[cfg(mshv)]
+impl From<&CommonSpecialRegisters> for SpecialRegisters {
+    fn from(other: &CommonSpecialRegisters) -> Self {
+        SpecialRegisters {
+            cs: other.cs.into(),
+            ds: other.ds.into(),
+            es: other.es.into(),
+            fs: other.fs.into(),
+            gs: other.gs.into(),
+            ss: other.ss.into(),
+            tr: other.tr.into(),
+            ldt: other.ldt.into(),
+            gdt: other.gdt.into(),
+            idt: other.idt.into(),
+            cr0: other.cr0,
+            cr2: other.cr2,
+            cr3: other.cr3,
+            cr4: other.cr4,
+            cr8: other.cr8,
+            efer: other.efer,
+            apic_base: other.apic_base,
+            interrupt_bitmap: other.interrupt_bitmap,
+        }
+    }
+}
+
+#[cfg(kvm)]
+impl From<&kvm_sregs> for CommonSpecialRegisters {
+    fn from(kvm_sregs: &kvm_sregs) -> Self {
+        CommonSpecialRegisters {
+            cs: kvm_sregs.cs.into(),
+            ds: kvm_sregs.ds.into(),
+            es: kvm_sregs.es.into(),
+            fs: kvm_sregs.fs.into(),
+            gs: kvm_sregs.gs.into(),
+            ss: kvm_sregs.ss.into(),
+            tr: kvm_sregs.tr.into(),
+            ldt: kvm_sregs.ldt.into(),
+            gdt: kvm_sregs.gdt.into(),
+            idt: kvm_sregs.idt.into(),
+            cr0: kvm_sregs.cr0,
+            cr2: kvm_sregs.cr2,
+            cr3: kvm_sregs.cr3,
+            cr4: kvm_sregs.cr4,
+            cr8: kvm_sregs.cr8,
+            efer: kvm_sregs.efer,
+            apic_base: kvm_sregs.apic_base,
+            interrupt_bitmap: kvm_sregs.interrupt_bitmap,
+        }
+    }
+}
+
+#[cfg(kvm)]
+impl From<&CommonSpecialRegisters> for kvm_sregs {
+    fn from(common_sregs: &CommonSpecialRegisters) -> Self {
+        kvm_sregs {
+            cs: common_sregs.cs.into(),
+            ds: common_sregs.ds.into(),
+            es: common_sregs.es.into(),
+            fs: common_sregs.fs.into(),
+            gs: common_sregs.gs.into(),
+            ss: common_sregs.ss.into(),
+            tr: common_sregs.tr.into(),
+            ldt: common_sregs.ldt.into(),
+            gdt: common_sregs.gdt.into(),
+            idt: common_sregs.idt.into(),
+            cr0: common_sregs.cr0,
+            cr2: common_sregs.cr2,
+            cr3: common_sregs.cr3,
+            cr4: common_sregs.cr4,
+            cr8: common_sregs.cr8,
+            efer: common_sregs.efer,
+            apic_base: common_sregs.apic_base,
+            interrupt_bitmap: common_sregs.interrupt_bitmap,
+        }
+    }
+}
+
+/// WHV_REGISTER_VALUE must be 16-byte aligned, but the rust struct is incorrectly generated
+/// as 8-byte aligned. This is a workaround to ensure that the struct is 16-byte aligned.
+#[cfg(target_os = "windows")]
+#[repr(C, align(16))]
+#[derive(Debug, Default, Copy, Clone, PartialEq)]
+pub(crate) struct Align16<T>(pub(crate) T);
+
+#[cfg(target_os = "windows")]
+#[allow(clippy::disallowed_macros)] // compile time
+const _: () = {
+    assert!(
+        std::mem::size_of::<Align16<WHV_REGISTER_VALUE>>()
+            == std::mem::size_of::<WHV_REGISTER_VALUE>()
+    );
+};
+
+#[cfg(target_os = "windows")]
+pub(crate) const WHP_SREGS_NAMES_LEN: usize = 17;
+#[cfg(target_os = "windows")]
+pub(crate) static WHP_SREGS_NAMES: [WHV_REGISTER_NAME; WHP_SREGS_NAMES_LEN] = [
+    WHvX64RegisterCs,
+    WHvX64RegisterDs,
+    WHvX64RegisterEs,
+    WHvX64RegisterFs,
+    WHvX64RegisterGs,
+    WHvX64RegisterSs,
+    WHvX64RegisterTr,
+    WHvX64RegisterLdtr,
+    WHvX64RegisterGdtr,
+    WHvX64RegisterIdtr,
+    WHvX64RegisterCr0,
+    WHvX64RegisterCr2,
+    WHvX64RegisterCr3,
+    WHvX64RegisterCr4,
+    WHvX64RegisterCr8,
+    WHvX64RegisterEfer,
+    WHvX64RegisterApicBase,
+];
+
+#[cfg(target_os = "windows")]
+impl From<&CommonSpecialRegisters>
+    for [(WHV_REGISTER_NAME, Align16<WHV_REGISTER_VALUE>); WHP_SREGS_NAMES_LEN]
+{
+    fn from(other: &CommonSpecialRegisters) -> Self {
+        [
+            (WHvX64RegisterCs, Align16(other.cs.into())),
+            (WHvX64RegisterDs, Align16(other.ds.into())),
+            (WHvX64RegisterEs, Align16(other.es.into())),
+            (WHvX64RegisterFs, Align16(other.fs.into())),
+            (WHvX64RegisterGs, Align16(other.gs.into())),
+            (WHvX64RegisterSs, Align16(other.ss.into())),
+            (WHvX64RegisterTr, Align16(other.tr.into())),
+            (WHvX64RegisterLdtr, Align16(other.ldt.into())),
+            (WHvX64RegisterGdtr, Align16(other.gdt.into())),
+            (WHvX64RegisterIdtr, Align16(other.idt.into())),
+            (
+                WHvX64RegisterCr0,
+                Align16(WHV_REGISTER_VALUE { Reg64: other.cr0 }),
+            ),
+            (
+                WHvX64RegisterCr2,
+                Align16(WHV_REGISTER_VALUE { Reg64: other.cr2 }),
+            ),
+            (
+                WHvX64RegisterCr3,
+                Align16(WHV_REGISTER_VALUE { Reg64: other.cr3 }),
+            ),
+            (
+                WHvX64RegisterCr4,
+                Align16(WHV_REGISTER_VALUE { Reg64: other.cr4 }),
+            ),
+            (
+                WHvX64RegisterCr8,
+                Align16(WHV_REGISTER_VALUE { Reg64: other.cr8 }),
+            ),
+            (
+                WHvX64RegisterEfer,
+                Align16(WHV_REGISTER_VALUE { Reg64: other.efer }),
+            ),
+            (
+                WHvX64RegisterApicBase,
+                Align16(WHV_REGISTER_VALUE {
+                    Reg64: other.apic_base,
+                }),
+            ),
+        ]
+    }
+}
+
+#[cfg(target_os = "windows")]
+impl TryFrom<&[(WHV_REGISTER_NAME, Align16<WHV_REGISTER_VALUE>)]> for CommonSpecialRegisters {
+    type Error = FromWhpRegisterError;
+
+    #[expect(
+        non_upper_case_globals,
+        reason = "Windows API has lowercase register names"
+    )]
+    fn try_from(
+        regs: &[(WHV_REGISTER_NAME, Align16<WHV_REGISTER_VALUE>)],
+    ) -> Result<Self, Self::Error> {
+        if regs.len() != WHP_SREGS_NAMES_LEN {
+            return Err(FromWhpRegisterError::InvalidLength(regs.len()));
+        }
+        let mut registers = CommonSpecialRegisters::default();
+        let mut seen_registers = HashSet::new();
+
+        for &(name, ref value) in regs {
+            let name_id = name.0;
+
+            // Check for duplicates
+            if !seen_registers.insert(name_id) {
+                return Err(FromWhpRegisterError::DuplicateRegister(name_id));
+            }
+
+            unsafe {
+                match name {
+                    WHvX64RegisterCs => registers.cs = value.0.into(),
+                    WHvX64RegisterDs => registers.ds = value.0.into(),
+                    WHvX64RegisterEs => registers.es = value.0.into(),
+                    WHvX64RegisterFs => registers.fs = value.0.into(),
+                    WHvX64RegisterGs => registers.gs = value.0.into(),
+                    WHvX64RegisterSs => registers.ss = value.0.into(),
+                    WHvX64RegisterTr => registers.tr = value.0.into(),
+                    WHvX64RegisterLdtr => registers.ldt = value.0.into(),
+                    WHvX64RegisterGdtr => registers.gdt = value.0.into(),
+                    WHvX64RegisterIdtr => registers.idt = value.0.into(),
+                    WHvX64RegisterCr0 => registers.cr0 = value.0.Reg64,
+                    WHvX64RegisterCr2 => registers.cr2 = value.0.Reg64,
+                    WHvX64RegisterCr3 => registers.cr3 = value.0.Reg64,
+                    WHvX64RegisterCr4 => registers.cr4 = value.0.Reg64,
+                    WHvX64RegisterCr8 => registers.cr8 = value.0.Reg64,
+                    WHvX64RegisterEfer => registers.efer = value.0.Reg64,
+                    WHvX64RegisterApicBase => registers.apic_base = value.0.Reg64,
+                    _ => {
+                        // Given unexpected register
+                        return Err(FromWhpRegisterError::InvalidRegister(name_id));
+                    }
+                }
+            }
+        }
+
+        // TODO: I'm not sure how to get this from WHP at the moment
+        registers.interrupt_bitmap = Default::default();
+
+        // Set of all expected register names
+        let expected_registers: HashSet<i32> =
+            WHP_SREGS_NAMES.map(|name| name.0).into_iter().collect();
+
+        // Technically it should not be possible to have any missing registers at this point
+        // since we are guaranteed to have WHP_SREGS_NAMES_LEN (17) non-duplicate registers that have passed the match-arm above, but leaving this here for safety anyway
+        let missing: HashSet<_> = expected_registers
+            .difference(&seen_registers)
+            .cloned()
+            .collect();
+
+        if !missing.is_empty() {
+            return Err(FromWhpRegisterError::MissingRegister(missing));
+        }
+
+        Ok(registers)
+    }
+}
+
+// --- Segment Register ---
+
+#[derive(Debug, Default, Copy, Clone, PartialEq)]
+pub(crate) struct CommonSegmentRegister {
+    pub base: u64,
+    pub limit: u32,
+    pub selector: u16,
+    pub type_: u8,
+    pub present: u8,
+    pub dpl: u8,
+    pub db: u8,
+    pub s: u8,
+    pub l: u8,
+    pub g: u8,
+    pub avl: u8,
+    pub unusable: u8,
+    pub padding: u8,
+}
+
+#[cfg(mshv)]
+impl From<SegmentRegister> for CommonSegmentRegister {
+    fn from(other: SegmentRegister) -> Self {
+        CommonSegmentRegister {
+            base: other.base,
+            limit: other.limit,
+            selector: other.selector,
+            type_: other.type_,
+            present: other.present,
+            dpl: other.dpl,
+            db: other.db,
+            s: other.s,
+            l: other.l,
+            g: other.g,
+            avl: other.avl,
+            unusable: other.unusable,
+            padding: other.padding,
+        }
+    }
+}
+
+#[cfg(mshv)]
+impl From<CommonSegmentRegister> for SegmentRegister {
+    fn from(other: CommonSegmentRegister) -> Self {
+        SegmentRegister {
+            base: other.base,
+            limit: other.limit,
+            selector: other.selector,
+            type_: other.type_,
+            present: other.present,
+            dpl: other.dpl,
+            db: other.db,
+            s: other.s,
+            l: other.l,
+            g: other.g,
+            avl: other.avl,
+            unusable: other.unusable,
+            padding: other.padding,
+        }
+    }
+}
+
+#[cfg(kvm)]
+impl From<kvm_segment> for CommonSegmentRegister {
+    fn from(kvm_segment: kvm_segment) -> Self {
+        CommonSegmentRegister {
+            base: kvm_segment.base,
+            limit: kvm_segment.limit,
+            selector: kvm_segment.selector,
+            type_: kvm_segment.type_,
+            present: kvm_segment.present,
+            dpl: kvm_segment.dpl,
+            db: kvm_segment.db,
+            s: kvm_segment.s,
+            l: kvm_segment.l,
+            g: kvm_segment.g,
+            avl: kvm_segment.avl,
+            unusable: kvm_segment.unusable,
+            padding: kvm_segment.padding,
+        }
+    }
+}
+
+#[cfg(kvm)]
+impl From<CommonSegmentRegister> for kvm_segment {
+    fn from(common_segment: CommonSegmentRegister) -> Self {
+        kvm_segment {
+            base: common_segment.base,
+            limit: common_segment.limit,
+            selector: common_segment.selector,
+            type_: common_segment.type_,
+            present: common_segment.present,
+            dpl: common_segment.dpl,
+            db: common_segment.db,
+            s: common_segment.s,
+            l: common_segment.l,
+            g: common_segment.g,
+            avl: common_segment.avl,
+            unusable: common_segment.unusable,
+            padding: common_segment.padding,
+        }
+    }
+}
+
+#[cfg(target_os = "windows")]
+impl From<WHV_REGISTER_VALUE> for CommonSegmentRegister {
+    fn from(other: WHV_REGISTER_VALUE) -> Self {
+        unsafe {
+            let segment = other.Segment;
+            let bits = segment.Anonymous.Attributes;
+
+            // Source of bit layout: https://learn.microsoft.com/en-us/virtualization/api/hypervisor-platform/funcs/whvvirtualprocessordatatypes
+            CommonSegmentRegister {
+                base: segment.Base,
+                limit: segment.Limit,
+                selector: segment.Selector,
+                type_: (bits & 0b1111) as u8,    // bits 0–3: SegmentType
+                s: ((bits >> 4) & 0b1) as u8,    // bit 4: NonSystemSegment
+                dpl: ((bits >> 5) & 0b11) as u8, // bits 5–6: DPL
+                present: ((bits >> 7) & 0b1) as u8, // bit 7: Present
+                // bits 8–11: Reserved
+                avl: ((bits >> 12) & 0b1) as u8, // bit 12: Available
+                l: ((bits >> 13) & 0b1) as u8,   // bit 13: Long mode
+                db: ((bits >> 14) & 0b1) as u8,  // bit 14: Default
+                g: ((bits >> 15) & 0b1) as u8,   // bit 15: Granularity
+                unusable: 0,
+                padding: 0,
+            }
+        }
+    }
+}
+
+#[cfg(target_os = "windows")]
+impl From<CommonSegmentRegister> for WHV_REGISTER_VALUE {
+    fn from(other: CommonSegmentRegister) -> Self {
+        // Truncate each field to its valid bit width before composing `Attributes`.
+        let type_ = other.type_ & 0xF; // 4 bits
+        let s = other.s & 0x1; // 1 bit
+        let dpl = other.dpl & 0x3; // 2 bits
+        let present = other.present & 0x1; // 1 bit
+        let avl = other.avl & 0x1; // 1 bit
+        let l = other.l & 0x1; // 1 bit
+        let db = other.db & 0x1; // 1 bit
+        let g = other.g & 0x1; // 1 bit
+
+        WHV_REGISTER_VALUE {
+            Segment: WHV_X64_SEGMENT_REGISTER {
+                Base: other.base,
+                Limit: other.limit,
+                Selector: other.selector,
+                Anonymous: WHV_X64_SEGMENT_REGISTER_0 {
+                    Attributes: (type_ as u16) // bit 0-3
+                        | ((s as u16) << 4) // bit 4
+                        | ((dpl as u16) << 5) // bit 5-6
+                        | ((present as u16) << 7) // bit 7
+                        | ((avl as u16) << 12) // bit 12
+                        | ((l as u16) << 13) // bit 13
+                        | ((db as u16) << 14) // bit 14
+                        | ((g as u16) << 15), // bit 15
+                },
+            },
+        }
+    }
+}
+
+// --- Table Register ---
+
+#[derive(Debug, Default, Copy, Clone, PartialEq)]
+pub(crate) struct CommonTableRegister {
+    pub base: u64,
+    pub limit: u16,
+}
+
+#[cfg(mshv)]
+impl From<TableRegister> for CommonTableRegister {
+    fn from(other: TableRegister) -> Self {
+        CommonTableRegister {
+            base: other.base,
+            limit: other.limit,
+        }
+    }
+}
+
+#[cfg(mshv)]
+impl From<CommonTableRegister> for TableRegister {
+    fn from(other: CommonTableRegister) -> Self {
+        TableRegister {
+            base: other.base,
+            limit: other.limit,
+        }
+    }
+}
+
+#[cfg(kvm)]
+impl From<kvm_dtable> for CommonTableRegister {
+    fn from(kvm_dtable: kvm_dtable) -> Self {
+        CommonTableRegister {
+            base: kvm_dtable.base,
+            limit: kvm_dtable.limit,
+        }
+    }
+}
+
+#[cfg(kvm)]
+impl From<CommonTableRegister> for kvm_dtable {
+    fn from(common_dtable: CommonTableRegister) -> Self {
+        kvm_dtable {
+            base: common_dtable.base,
+            limit: common_dtable.limit,
+            padding: Default::default(),
+        }
+    }
+}
+
+#[cfg(target_os = "windows")]
+impl From<WHV_REGISTER_VALUE> for CommonTableRegister {
+    fn from(other: WHV_REGISTER_VALUE) -> Self {
+        unsafe {
+            let table = other.Table;
+            CommonTableRegister {
+                base: table.Base,
+                limit: table.Limit,
+            }
+        }
+    }
+}
+
+#[cfg(target_os = "windows")]
+impl From<CommonTableRegister> for WHV_REGISTER_VALUE {
+    fn from(other: CommonTableRegister) -> Self {
+        WHV_REGISTER_VALUE {
+            Table: WHV_X64_TABLE_REGISTER {
+                Base: other.base,
+                Limit: other.limit,
+                Pad: Default::default(),
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_common_special_registers() -> CommonSpecialRegisters {
+        let sample_segment = CommonSegmentRegister {
+            base: 0x1000,
+            limit: 0xFFFF,
+            selector: 0x10,
+            type_: 0xB,
+            present: 1,
+            dpl: 0,
+            db: 1,
+            s: 1,
+            l: 0,
+            g: 1,
+            avl: 0,
+            unusable: 0,
+            padding: 0,
+        };
+
+        let sample_table = CommonTableRegister {
+            base: 0x2000,
+            limit: 0x1000,
+        };
+
+        CommonSpecialRegisters {
+            cs: sample_segment,
+            ds: sample_segment,
+            es: sample_segment,
+            fs: sample_segment,
+            gs: sample_segment,
+            ss: sample_segment,
+            tr: sample_segment,
+            ldt: sample_segment,
+            gdt: sample_table,
+            idt: sample_table,
+            cr0: 0xDEAD_BEEF,
+            cr2: 0xBAD_C0DE,
+            cr3: 0xC0FFEE,
+            cr4: 0xFACE_CAFE,
+            cr8: 0x1234,
+            efer: 0x5678,
+            apic_base: 0x9ABC,
+            interrupt_bitmap: [0; 4],
+        }
+    }
+
+    #[cfg(kvm)]
+    #[test]
+    fn round_trip_kvm_sregs() {
+        let original = sample_common_special_registers();
+        let kvm_sregs: kvm_sregs = (&original).into();
+        let roundtrip = CommonSpecialRegisters::from(&kvm_sregs);
+
+        assert_eq!(original, roundtrip);
+    }
+
+    #[cfg(mshv)]
+    #[test]
+    fn round_trip_mshv_sregs() {
+        let original = sample_common_special_registers();
+        let mshv_sregs: SpecialRegisters = (&original).into();
+        let roundtrip = CommonSpecialRegisters::from(&mshv_sregs);
+
+        assert_eq!(original, roundtrip);
+    }
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn round_trip_whp_sregs() {
+        let original = sample_common_special_registers();
+        let whp_sregs: [(WHV_REGISTER_NAME, Align16<WHV_REGISTER_VALUE>); WHP_SREGS_NAMES_LEN] =
+            (&original).into();
+        let roundtrip = CommonSpecialRegisters::try_from(whp_sregs.as_ref()).unwrap();
+        assert_eq!(original, roundtrip);
+
+        // Test duplicate register error
+        let original = sample_common_special_registers();
+        let mut whp_sregs: [(WHV_REGISTER_NAME, Align16<WHV_REGISTER_VALUE>); WHP_SREGS_NAMES_LEN] =
+            (&original).into();
+        whp_sregs[0].0 = WHvX64RegisterDs;
+        let err = CommonSpecialRegisters::try_from(whp_sregs.as_ref()).unwrap_err();
+        assert_eq!(
+            err,
+            FromWhpRegisterError::DuplicateRegister(WHvX64RegisterDs.0)
+        );
+
+        // Test passing non-sregs register (e.g. RIP)
+        let original = sample_common_special_registers();
+        let mut whp_sregs: [(WHV_REGISTER_NAME, Align16<WHV_REGISTER_VALUE>); WHP_SREGS_NAMES_LEN] =
+            (&original).into();
+        whp_sregs[0].0 = WHvX64RegisterRip;
+        let err = CommonSpecialRegisters::try_from(whp_sregs.as_ref()).unwrap_err();
+        assert_eq!(
+            err,
+            FromWhpRegisterError::InvalidRegister(WHvX64RegisterRip.0)
+        );
+    }
+}

--- a/src/hyperlight_host/src/hypervisor/regs/standard_regs.rs
+++ b/src/hyperlight_host/src/hypervisor/regs/standard_regs.rs
@@ -1,0 +1,423 @@
+/*
+Copyright 2025  The Hyperlight Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#[cfg(mshv2)]
+extern crate mshv_bindings2 as mshv_bindings;
+#[cfg(mshv2)]
+extern crate mshv_ioctls2 as mshv_ioctls;
+
+#[cfg(mshv3)]
+extern crate mshv_bindings3 as mshv_bindings;
+#[cfg(mshv3)]
+extern crate mshv_ioctls3 as mshv_ioctls;
+
+#[cfg(kvm)]
+use kvm_bindings::kvm_regs;
+#[cfg(mshv)]
+use mshv_bindings::StandardRegisters;
+
+#[derive(Debug, Default, Copy, Clone, PartialEq)]
+pub(crate) struct CommonRegisters {
+    pub rax: u64,
+    pub rbx: u64,
+    pub rcx: u64,
+    pub rdx: u64,
+    pub rsi: u64,
+    pub rdi: u64,
+    pub rsp: u64,
+    pub rbp: u64,
+    pub r8: u64,
+    pub r9: u64,
+    pub r10: u64,
+    pub r11: u64,
+    pub r12: u64,
+    pub r13: u64,
+    pub r14: u64,
+    pub r15: u64,
+    pub rip: u64,
+    pub rflags: u64,
+}
+
+// --- KVM ---
+#[cfg(kvm)]
+impl From<&kvm_regs> for CommonRegisters {
+    fn from(kvm_regs: &kvm_regs) -> Self {
+        CommonRegisters {
+            rax: kvm_regs.rax,
+            rbx: kvm_regs.rbx,
+            rcx: kvm_regs.rcx,
+            rdx: kvm_regs.rdx,
+            rsi: kvm_regs.rsi,
+            rdi: kvm_regs.rdi,
+            rsp: kvm_regs.rsp,
+            rbp: kvm_regs.rbp,
+            r8: kvm_regs.r8,
+            r9: kvm_regs.r9,
+            r10: kvm_regs.r10,
+            r11: kvm_regs.r11,
+            r12: kvm_regs.r12,
+            r13: kvm_regs.r13,
+            r14: kvm_regs.r14,
+            r15: kvm_regs.r15,
+            rip: kvm_regs.rip,
+            rflags: kvm_regs.rflags,
+        }
+    }
+}
+
+#[cfg(kvm)]
+impl From<&CommonRegisters> for kvm_regs {
+    fn from(regs: &CommonRegisters) -> Self {
+        kvm_regs {
+            rax: regs.rax,
+            rbx: regs.rbx,
+            rcx: regs.rcx,
+            rdx: regs.rdx,
+            rsi: regs.rsi,
+            rdi: regs.rdi,
+            rsp: regs.rsp,
+            rbp: regs.rbp,
+            r8: regs.r8,
+            r9: regs.r9,
+            r10: regs.r10,
+            r11: regs.r11,
+            r12: regs.r12,
+            r13: regs.r13,
+            r14: regs.r14,
+            r15: regs.r15,
+            rip: regs.rip,
+            rflags: regs.rflags,
+        }
+    }
+}
+
+// --- MSHV ---
+
+#[cfg(mshv)]
+impl From<&StandardRegisters> for CommonRegisters {
+    fn from(mshv_regs: &StandardRegisters) -> Self {
+        CommonRegisters {
+            rax: mshv_regs.rax,
+            rbx: mshv_regs.rbx,
+            rcx: mshv_regs.rcx,
+            rdx: mshv_regs.rdx,
+            rsi: mshv_regs.rsi,
+            rdi: mshv_regs.rdi,
+            rsp: mshv_regs.rsp,
+            rbp: mshv_regs.rbp,
+            r8: mshv_regs.r8,
+            r9: mshv_regs.r9,
+            r10: mshv_regs.r10,
+            r11: mshv_regs.r11,
+            r12: mshv_regs.r12,
+            r13: mshv_regs.r13,
+            r14: mshv_regs.r14,
+            r15: mshv_regs.r15,
+            rip: mshv_regs.rip,
+            rflags: mshv_regs.rflags,
+        }
+    }
+}
+
+#[cfg(mshv)]
+impl From<&CommonRegisters> for StandardRegisters {
+    fn from(regs: &CommonRegisters) -> Self {
+        StandardRegisters {
+            rax: regs.rax,
+            rbx: regs.rbx,
+            rcx: regs.rcx,
+            rdx: regs.rdx,
+            rsi: regs.rsi,
+            rdi: regs.rdi,
+            rsp: regs.rsp,
+            rbp: regs.rbp,
+            r8: regs.r8,
+            r9: regs.r9,
+            r10: regs.r10,
+            r11: regs.r11,
+            r12: regs.r12,
+            r13: regs.r13,
+            r14: regs.r14,
+            r15: regs.r15,
+            rip: regs.rip,
+            rflags: regs.rflags,
+        }
+    }
+}
+
+#[cfg(target_os = "windows")]
+use windows::Win32::System::Hypervisor::*;
+
+#[cfg(target_os = "windows")]
+impl From<&CommonRegisters>
+    for [(WHV_REGISTER_NAME, Align16<WHV_REGISTER_VALUE>); WHP_REGS_NAMES_LEN]
+{
+    fn from(regs: &CommonRegisters) -> Self {
+        [
+            (
+                WHvX64RegisterRax,
+                Align16(WHV_REGISTER_VALUE { Reg64: regs.rax }),
+            ),
+            (
+                WHvX64RegisterRbx,
+                Align16(WHV_REGISTER_VALUE { Reg64: regs.rbx }),
+            ),
+            (
+                WHvX64RegisterRcx,
+                Align16(WHV_REGISTER_VALUE { Reg64: regs.rcx }),
+            ),
+            (
+                WHvX64RegisterRdx,
+                Align16(WHV_REGISTER_VALUE { Reg64: regs.rdx }),
+            ),
+            (
+                WHvX64RegisterRsi,
+                Align16(WHV_REGISTER_VALUE { Reg64: regs.rsi }),
+            ),
+            (
+                WHvX64RegisterRdi,
+                Align16(WHV_REGISTER_VALUE { Reg64: regs.rdi }),
+            ),
+            (
+                WHvX64RegisterRsp,
+                Align16(WHV_REGISTER_VALUE { Reg64: regs.rsp }),
+            ),
+            (
+                WHvX64RegisterRbp,
+                Align16(WHV_REGISTER_VALUE { Reg64: regs.rbp }),
+            ),
+            (
+                WHvX64RegisterR8,
+                Align16(WHV_REGISTER_VALUE { Reg64: regs.r8 }),
+            ),
+            (
+                WHvX64RegisterR9,
+                Align16(WHV_REGISTER_VALUE { Reg64: regs.r9 }),
+            ),
+            (
+                WHvX64RegisterR10,
+                Align16(WHV_REGISTER_VALUE { Reg64: regs.r10 }),
+            ),
+            (
+                WHvX64RegisterR11,
+                Align16(WHV_REGISTER_VALUE { Reg64: regs.r11 }),
+            ),
+            (
+                WHvX64RegisterR12,
+                Align16(WHV_REGISTER_VALUE { Reg64: regs.r12 }),
+            ),
+            (
+                WHvX64RegisterR13,
+                Align16(WHV_REGISTER_VALUE { Reg64: regs.r13 }),
+            ),
+            (
+                WHvX64RegisterR14,
+                Align16(WHV_REGISTER_VALUE { Reg64: regs.r14 }),
+            ),
+            (
+                WHvX64RegisterR15,
+                Align16(WHV_REGISTER_VALUE { Reg64: regs.r15 }),
+            ),
+            (
+                WHvX64RegisterRip,
+                Align16(WHV_REGISTER_VALUE { Reg64: regs.rip }),
+            ),
+            (
+                WHvX64RegisterRflags,
+                Align16(WHV_REGISTER_VALUE { Reg64: regs.rflags }),
+            ),
+        ]
+    }
+}
+
+#[cfg(target_os = "windows")]
+use std::collections::HashSet;
+
+#[cfg(target_os = "windows")]
+use super::{Align16, FromWhpRegisterError};
+
+#[cfg(target_os = "windows")]
+pub(crate) const WHP_REGS_NAMES_LEN: usize = 18;
+#[cfg(target_os = "windows")]
+pub(crate) const WHP_REGS_NAMES: [WHV_REGISTER_NAME; WHP_REGS_NAMES_LEN] = [
+    WHvX64RegisterRax,
+    WHvX64RegisterRbx,
+    WHvX64RegisterRcx,
+    WHvX64RegisterRdx,
+    WHvX64RegisterRsi,
+    WHvX64RegisterRdi,
+    WHvX64RegisterRsp,
+    WHvX64RegisterRbp,
+    WHvX64RegisterR8,
+    WHvX64RegisterR9,
+    WHvX64RegisterR10,
+    WHvX64RegisterR11,
+    WHvX64RegisterR12,
+    WHvX64RegisterR13,
+    WHvX64RegisterR14,
+    WHvX64RegisterR15,
+    WHvX64RegisterRip,
+    WHvX64RegisterRflags,
+];
+
+#[cfg(target_os = "windows")]
+impl TryFrom<&[(WHV_REGISTER_NAME, Align16<WHV_REGISTER_VALUE>)]> for CommonRegisters {
+    type Error = FromWhpRegisterError;
+
+    #[expect(
+        non_upper_case_globals,
+        reason = "Windows API has lowercase register names"
+    )]
+    fn try_from(
+        regs: &[(WHV_REGISTER_NAME, Align16<WHV_REGISTER_VALUE>)],
+    ) -> Result<Self, Self::Error> {
+        if regs.len() != WHP_REGS_NAMES_LEN {
+            return Err(FromWhpRegisterError::InvalidLength(regs.len()));
+        }
+        let mut registers = CommonRegisters::default();
+        let mut seen_registers = HashSet::new();
+
+        for &(name, value) in regs {
+            let name_id = name.0;
+
+            // Check for duplicates
+            if !seen_registers.insert(name_id) {
+                return Err(FromWhpRegisterError::DuplicateRegister(name_id));
+            }
+
+            unsafe {
+                match name {
+                    WHvX64RegisterRax => registers.rax = value.0.Reg64,
+                    WHvX64RegisterRbx => registers.rbx = value.0.Reg64,
+                    WHvX64RegisterRcx => registers.rcx = value.0.Reg64,
+                    WHvX64RegisterRdx => registers.rdx = value.0.Reg64,
+                    WHvX64RegisterRsi => registers.rsi = value.0.Reg64,
+                    WHvX64RegisterRdi => registers.rdi = value.0.Reg64,
+                    WHvX64RegisterRsp => registers.rsp = value.0.Reg64,
+                    WHvX64RegisterRbp => registers.rbp = value.0.Reg64,
+                    WHvX64RegisterR8 => registers.r8 = value.0.Reg64,
+                    WHvX64RegisterR9 => registers.r9 = value.0.Reg64,
+                    WHvX64RegisterR10 => registers.r10 = value.0.Reg64,
+                    WHvX64RegisterR11 => registers.r11 = value.0.Reg64,
+                    WHvX64RegisterR12 => registers.r12 = value.0.Reg64,
+                    WHvX64RegisterR13 => registers.r13 = value.0.Reg64,
+                    WHvX64RegisterR14 => registers.r14 = value.0.Reg64,
+                    WHvX64RegisterR15 => registers.r15 = value.0.Reg64,
+                    WHvX64RegisterRip => registers.rip = value.0.Reg64,
+                    WHvX64RegisterRflags => registers.rflags = value.0.Reg64,
+                    _ => {
+                        // Given unexpected register
+                        return Err(FromWhpRegisterError::InvalidRegister(name_id));
+                    }
+                }
+            }
+        }
+
+        // Set of all expected register names
+        let expected_registers: HashSet<i32> =
+            WHP_REGS_NAMES.map(|name| name.0).into_iter().collect();
+
+        // Technically it should not be possible to have any missing registers at this point
+        // since we are guaranteed to have WHP_REGS_NAMES_LEN (18) non-duplicate registers that have passed the match-arm above, but leaving this here for safety anyway
+        let missing: HashSet<_> = expected_registers
+            .difference(&seen_registers)
+            .cloned()
+            .collect();
+
+        if !missing.is_empty() {
+            return Err(FromWhpRegisterError::MissingRegister(missing));
+        }
+
+        Ok(registers)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn common_regs() -> CommonRegisters {
+        CommonRegisters {
+            rax: 1,
+            rbx: 2,
+            rcx: 3,
+            rdx: 4,
+            rsi: 5,
+            rdi: 6,
+            rsp: 7,
+            rbp: 8,
+            r8: 9,
+            r9: 10,
+            r10: 11,
+            r11: 12,
+            r12: 13,
+            r13: 14,
+            r14: 15,
+            r15: 16,
+            rip: 17,
+            rflags: 18,
+        }
+    }
+    #[cfg(kvm)]
+    #[test]
+    fn round_trip_kvm_regs() {
+        let original = common_regs();
+        let kvm_regs: kvm_regs = (&original).into();
+        let converted: CommonRegisters = (&kvm_regs).into();
+        assert_eq!(original, converted);
+    }
+
+    #[cfg(mshv)]
+    #[test]
+    fn round_trip_mshv_regs() {
+        let original = common_regs();
+        let mshv_regs: StandardRegisters = (&original).into();
+        let converted: CommonRegisters = (&mshv_regs).into();
+        assert_eq!(original, converted);
+    }
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn round_trip_whp_regs() {
+        let original = common_regs();
+        let whp_regs: [(WHV_REGISTER_NAME, Align16<WHV_REGISTER_VALUE>); WHP_REGS_NAMES_LEN] =
+            (&original).into();
+        let converted: CommonRegisters = whp_regs.as_ref().try_into().unwrap();
+        assert_eq!(original, converted);
+
+        // test for duplicate register error handling
+        let original = common_regs();
+        let mut whp_regs: [(WHV_REGISTER_NAME, Align16<WHV_REGISTER_VALUE>); WHP_REGS_NAMES_LEN] =
+            (&original).into();
+        whp_regs[0].0 = WHvX64RegisterRbx;
+        let err = CommonRegisters::try_from(whp_regs.as_ref()).unwrap_err();
+        assert_eq!(
+            err,
+            FromWhpRegisterError::DuplicateRegister(WHvX64RegisterRbx.0)
+        );
+
+        // test for passing non-standard register (e.g. CR8)
+        let original = common_regs();
+        let mut whp_regs: [(WHV_REGISTER_NAME, Align16<WHV_REGISTER_VALUE>); WHP_REGS_NAMES_LEN] =
+            (&original).into();
+        whp_regs[0].0 = WHvX64RegisterCr8;
+        let err = CommonRegisters::try_from(whp_regs.as_ref()).unwrap_err();
+        assert_eq!(
+            err,
+            FromWhpRegisterError::InvalidRegister(WHvX64RegisterCr8.0)
+        );
+    }
+}

--- a/src/hyperlight_host/src/hypervisor/wrappers.rs
+++ b/src/hyperlight_host/src/hypervisor/wrappers.rs
@@ -18,7 +18,6 @@ use std::ffi::CString;
 
 use tracing::{Span, instrument};
 use windows::Win32::Foundation::{HANDLE, HMODULE};
-use windows::Win32::System::Hypervisor::WHV_REGISTER_VALUE;
 use windows::core::PSTR;
 
 use crate::{HyperlightError, Result};
@@ -57,29 +56,6 @@ impl From<&PSTRWrapper> for PSTR {
     }
 }
 
-// only used on windows. mshv and kvm already has this implemented
-#[derive(Debug, Default, Copy, Clone, PartialEq)]
-pub(super) struct WHvGeneralRegisters {
-    pub rax: u64,
-    pub rbx: u64,
-    pub rcx: u64,
-    pub rdx: u64,
-    pub rsi: u64,
-    pub rdi: u64,
-    pub rsp: u64,
-    pub rbp: u64,
-    pub r8: u64,
-    pub r9: u64,
-    pub r10: u64,
-    pub r11: u64,
-    pub r12: u64,
-    pub r13: u64,
-    pub r14: u64,
-    pub r15: u64,
-    pub rip: u64,
-    pub rflags: u64,
-}
-
 /// only used on widos for handling debug registers with the VMProcessor
 #[cfg(gdb)]
 #[derive(Debug, Default, Copy, Clone, PartialEq)]
@@ -90,61 +66,6 @@ pub(super) struct WHvDebugRegisters {
     pub dr3: u64,
     pub dr6: u64,
     pub dr7: u64,
-}
-
-#[derive(Debug, Default, Copy, Clone, PartialEq)]
-pub(super) struct WHvFPURegisters {
-    pub xmm0: u128,
-    pub xmm1: u128,
-    pub xmm2: u128,
-    pub xmm3: u128,
-    pub xmm4: u128,
-    pub xmm5: u128,
-    pub xmm6: u128,
-    pub xmm7: u128,
-    pub xmm8: u128,
-    pub xmm9: u128,
-    pub xmm10: u128,
-    pub xmm11: u128,
-    pub xmm12: u128,
-    pub xmm13: u128,
-    pub xmm14: u128,
-    pub xmm15: u128,
-
-    pub mmx0: u64,
-    pub mmx1: u64,
-    pub mmx2: u64,
-    pub mmx3: u64,
-    pub mmx4: u64,
-    pub mmx5: u64,
-    pub mmx6: u64,
-    pub mmx7: u64,
-
-    pub fp_control_word: u16,
-    pub fp_tag_word: u8,
-
-    pub mxcsr: u32,
-}
-
-#[derive(Default, Copy, Clone)]
-pub(super) struct WHvSpecialRegisters {
-    pub cr0: WHV_REGISTER_VALUE,
-    pub cr2: WHV_REGISTER_VALUE,
-    pub cr3: WHV_REGISTER_VALUE,
-    pub cr4: WHV_REGISTER_VALUE,
-    pub cr8: WHV_REGISTER_VALUE,
-    pub efer: WHV_REGISTER_VALUE,
-    pub apic_base: WHV_REGISTER_VALUE,
-    pub cs: WHV_REGISTER_VALUE,
-    pub ds: WHV_REGISTER_VALUE,
-    pub es: WHV_REGISTER_VALUE,
-    pub fs: WHV_REGISTER_VALUE,
-    pub gs: WHV_REGISTER_VALUE,
-    pub ss: WHV_REGISTER_VALUE,
-    pub tr: WHV_REGISTER_VALUE,
-    pub ldtr: WHV_REGISTER_VALUE,
-    pub gdtr: WHV_REGISTER_VALUE,
-    pub idtr: WHV_REGISTER_VALUE,
 }
 
 /// Wrapper for HANDLE, required since HANDLE is no longer Send.

--- a/typos.toml
+++ b/typos.toml
@@ -8,3 +8,4 @@ extend-exclude = ["**/*.patch", "src/hyperlight_guest_bin/third_party/**/*", "NO
 # typ is used for field name as type is a reserved keyword
 typ="typ"
 mmaped="mmapped"
+fpr="fpr"


### PR DESCRIPTION
This PR is part of my bigger effort to refactor VM trait (PR 1/3). This PR introduces registers structs that abstract over differences between kvm, mshv, and whp, for general registers, special registers, and fpu registers. It also fixes some UB where whp requires register values to be 16-aligned. 

The introduced abstractions are not too useful when just looking at this PR in isolation, but future PR will refactor and deduplicate a bunch of code, where this will be needed.

Closes #908
Closes #312