### PR TITLE
Pin to Debian 12 (bookworm) for Dev image and fix for Nightly

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,6 +1,6 @@
 ## Dockerfile for devcontainer
 
-FROM mcr.microsoft.com/devcontainers/base:debian AS base
+FROM mcr.microsoft.com/devcontainers/base:bookworm AS base
 
 ARG USER=vscode
 ARG GROUP=vscode

--- a/.github/workflows/RustNightly.yml
+++ b/.github/workflows/RustNightly.yml
@@ -8,6 +8,10 @@ on:
     # 12:00 AM, every 2 days
     - cron: '0 0 */2 * *'
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   musl:
     strategy:


### PR DESCRIPTION
The Dev images jumped to `trixie` in the latest release which doesn't have some packages yet. This pins to the latest stable version

This fixes the builds for the dev container: https://github.com/hyperlight-dev/hyperlight/actions/workflows/CreateDevcontainerImage.yml  

Successful run:

```
#5 [base 2/3] RUN apt-get update     && apt-get -y install         build-essential         cmake         curl         gdb         git         gnupg         gnuplot         lsb-release         make         software-properties-common         sudo         wget
#5 0.221 Get:1 http://deb.debian.org/debian bookworm InRelease [151 kB]
#5 0.264 Get:2 http://deb.debian.org/debian bookworm-updates InRelease [55.4 kB]
#5 0.280 Get:3 http://deb.debian.org/debian-security bookworm-security InRelease [48.0 kB]
#5 0.326 Get:4 http://deb.debian.org/debian bookworm/main amd64 Packages [8793 kB]
#5 0.439 Get:5 http://deb.debian.org/debian bookworm-updates/main amd64 Packages [6924 B]
```

Latest runs that are failing:

```
#5 [base 2/3] RUN apt-get update     && apt-get -y install         build-essential         cmake         curl         gdb         git         gnupg         gnuplot         lsb-release         make         software-properties-common         sudo         wget         musl-tools
#5 0.255 Get:1 http://deb.debian.org/debian trixie InRelease [140 kB]
#5 0.305 Get:2 http://deb.debian.org/debian trixie-updates InRelease [47.3 kB]
#5 0.324 Get:3 http://deb.debian.org/debian-security trixie-security InRelease [43.4 kB]
#5 0.343 Get:4 http://deb.debian.org/debian trixie/main amd64 Packages [9669 kB]
#5 0.448 Get:5 http://deb.debian.org/debian trixie-updates/main amd64 Packages [5412 B]
#5 0.466 Get:6 http://deb.debian.org/debian-security trixie-security/main amd64 Packages [47.7 kB]



2.050 E: Unable to locate package software-properties-common
```

It also includes a fix for the Nightly job https://github.com/hyperlight-dev/hyperlight/actions/runs/18141663340  to fix `. The workflow is requesting 'id-token: write', but is only allowed 'id-token: none'.`