### PR TITLE
Fix dev container and labels for periodic failures

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -58,6 +58,5 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y \
     && rustup target add x86_64-unknown-linux-musl \
     && rustup target add x86_64-unknown-none      \
     && rustup toolchain add nightly-x86_64-unknown-linux-gnu \
-    && rustup toolchain add nightly-x86_64-unknown-linux-musl \
     && cargo install just \
-    cargo install cross --locked --version 0.2.5
+    && cargo install cross --locked --version 0.2.5

--- a/.github/workflows/Fuzzing.yml
+++ b/.github/workflows/Fuzzing.yml
@@ -28,6 +28,6 @@ jobs:
         uses: actions/checkout@v5
         
       - name: Notify Fuzzing Failure
-        run: ./dev/notify-ci-failure.sh --labels="area/fuzzing,kind/bug,area/testing,lifecycle/needs-review,release-blocker"
+        run: ./dev/notify-ci-failure.sh --labels="area/fuzzing,area/testing,lifecycle/needs-review,release-blocker"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/RustNightly.yml
+++ b/.github/workflows/RustNightly.yml
@@ -39,6 +39,6 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Notify Nightly Failure
-        run: ./dev/notify-ci-failure.sh --title="Nightly musl Failure - ${{ github.run_number }}" --labels="area/ci-periodics,area/testing,kind/bug,lifecycle/needs-review,release-blocker"
+        run: ./dev/notify-ci-failure.sh --title="Nightly musl Failure - ${{ github.run_number }}" --labels="area/ci-periodics,area/testing,lifecycle/needs-review,release-blocker"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
There was a failure in the nightly job (triggered manually after the merge) and an issue wasn't created due to missing label: https://github.com/hyperlight-dev/hyperlight/actions/runs/18145763564/job/51647875396

Also the dev container failed to build after the last fix: https://github.com/hyperlight-dev/hyperlight/actions/runs/18145165877

I've built the dev container locally so we should be good after this change.

I will be working on a fix separately for the failed musl build.