### PR TITLE
Add poison state to sandbox

### DIFF
--- a/src/hyperlight_host/src/error.rs
+++ b/src/hyperlight_host/src/error.rs
@@ -191,6 +191,27 @@ pub enum HyperlightError {
     #[error("Failure processing PE File {0:?}")]
     PEFileProcessingFailure(#[from] goblin::error::Error),
 
+    /// The sandbox becomes **poisoned** when the guest is not run to completion, leaving it in
+    /// an inconsistent state that could compromise memory safety, data integrity, or security.
+    ///
+    /// ### When Does Poisoning Occur?
+    ///
+    /// Poisoning happens when guest execution is interrupted before normal completion:
+    ///
+    /// - **Guest panics or aborts** - When a guest function panics, crashes, or calls `abort()`,
+    ///   the normal cleanup and unwinding process is interrupted
+    /// - **Invalid memory access** - Attempts to read/write/execute memory outside allowed regions
+    /// - **Stack overflow** - Guest exhausts its stack space during execution
+    /// - **Heap exhaustion** - Guest runs out of heap memory
+    /// - **Host-initiated cancellation** - Calling [`InterruptHandle::kill()`] to forcefully
+    ///   terminate an in-progress guest function
+    ///
+    /// ## Recovery
+    ///
+    /// Use [`crate::MultiUseSandbox::restore()`] to recover from a poisoned sandbox.
+    #[error("The sandbox was poisoned")]
+    PoisonedSandbox,
+
     /// Raw pointer is less than base address
     #[error("Raw pointer ({0:?}) was less than the base address ({1})")]
     RawPointerLessThanBaseAddress(RawPtr, u64),
@@ -283,6 +304,89 @@ impl<T> From<PoisonError<MutexGuard<'_, T>>> for HyperlightError {
             None => String::from(""),
         };
         HyperlightError::LockAttemptFailed(source)
+    }
+}
+
+impl HyperlightError {
+    /// Internal helper to determines if the given error has potential to poison the sandbox.
+    ///
+    /// Errors that poison the sandbox are those that can leave the sandbox in an inconsistent
+    /// state where memory, resources, or data structures may be corrupted or leaked. Usually
+    /// due to the guest not running to completion.
+    ///
+    /// If this method returns `true`, the sandbox will be poisoned and all further operations
+    /// will fail until the sandbox is restored from a non-poisoned snapshot using
+    /// [`crate::MultiUseSandbox::restore()`].
+    pub(crate) fn is_poison_error(&self) -> bool {
+        // wildcard _ or matches! not used here purposefully to ensure that new error variants
+        // are explicitly considered for poisoning behavior.
+        match self {
+            // These errors poison the sandbox because they can leave it in an inconsistent state due
+            // to the guest not running to completion.
+            HyperlightError::GuestAborted(_, _)
+            | HyperlightError::ExecutionCanceledByHost()
+            | HyperlightError::PoisonedSandbox
+            | HyperlightError::ExecutionAccessViolation(_)
+            | HyperlightError::StackOverflow()
+            | HyperlightError::MemoryAccessViolation(_, _, _) => true,
+
+            // All other errors do not poison the sandbox.
+            HyperlightError::AnyhowError(_)
+            | HyperlightError::BoundsCheckFailed(_, _)
+            | HyperlightError::CheckedAddOverflow(_, _)
+            | HyperlightError::CStringConversionError(_)
+            | HyperlightError::Error(_)
+            | HyperlightError::FailedToGetValueFromParameter()
+            | HyperlightError::FieldIsMissingInGuestLogData(_)
+            | HyperlightError::GuestError(_, _)
+            | HyperlightError::GuestExecutionHungOnHostFunctionCall()
+            | HyperlightError::GuestFunctionCallAlreadyInProgress()
+            | HyperlightError::GuestInterfaceUnsupportedType(_)
+            | HyperlightError::GuestOffsetIsInvalid(_)
+            | HyperlightError::HostFunctionNotFound(_)
+            | HyperlightError::IOError(_)
+            | HyperlightError::IntConversionFailure(_)
+            | HyperlightError::InvalidFlatBuffer(_)
+            | HyperlightError::JsonConversionFailure(_)
+            | HyperlightError::LockAttemptFailed(_)
+            | HyperlightError::MemoryAllocationFailed(_)
+            | HyperlightError::MemoryProtectionFailed(_)
+            | HyperlightError::MemoryRequestTooBig(_, _)
+            | HyperlightError::MetricNotFound(_)
+            | HyperlightError::MmapFailed(_)
+            | HyperlightError::MprotectFailed(_)
+            | HyperlightError::NoHypervisorFound()
+            | HyperlightError::NoMemorySnapshot
+            | HyperlightError::ParameterValueConversionFailure(_, _)
+            | HyperlightError::PEFileProcessingFailure(_)
+            | HyperlightError::RawPointerLessThanBaseAddress(_, _)
+            | HyperlightError::RefCellBorrowFailed(_)
+            | HyperlightError::RefCellMutBorrowFailed(_)
+            | HyperlightError::ReturnValueConversionFailure(_, _)
+            | HyperlightError::SnapshotSandboxMismatch
+            | HyperlightError::SystemTimeError(_)
+            | HyperlightError::TryFromSliceError(_)
+            | HyperlightError::UnexpectedNoOfArguments(_, _)
+            | HyperlightError::UnexpectedParameterValueType(_, _)
+            | HyperlightError::UnexpectedReturnValueType(_, _)
+            | HyperlightError::UTF8StringConversionFailure(_)
+            | HyperlightError::VectorCapacityIncorrect(_, _, _) => false,
+
+            #[cfg(target_os = "windows")]
+            HyperlightError::CrossBeamReceiveError(_) => false,
+            #[cfg(target_os = "windows")]
+            HyperlightError::CrossBeamSendError(_) => false,
+            #[cfg(target_os = "windows")]
+            HyperlightError::WindowsAPIError(_) => false,
+            #[cfg(target_os = "linux")]
+            HyperlightError::VmmSysError(_) => false,
+            #[cfg(kvm)]
+            HyperlightError::KVMError(_) => false,
+            #[cfg(mshv)]
+            HyperlightError::MSHVError(_) => false,
+            #[cfg(gdb)]
+            HyperlightError::TranslateGuestAddress(_) => false,
+        }
     }
 }
 

--- a/src/tests/rust_guests/dummyguest/Cargo.lock
+++ b/src/tests/rust_guests/dummyguest/Cargo.lock
@@ -85,9 +85,9 @@ dependencies = [
 
 [[package]]
 name = "heapless"
-version = "0.8.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
+checksum = "b1edcd5a338e64688fbdcb7531a846cfd3476a54784dcb918a0844682bc7ada5"
 dependencies = [
  "hash32",
  "serde",

--- a/src/tests/rust_guests/simpleguest/Cargo.lock
+++ b/src/tests/rust_guests/simpleguest/Cargo.lock
@@ -77,9 +77,9 @@ dependencies = [
 
 [[package]]
 name = "heapless"
-version = "0.8.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
+checksum = "b1edcd5a338e64688fbdcb7531a846cfd3476a54784dcb918a0844682bc7ada5"
 dependencies = [
  "hash32",
  "serde",

--- a/src/tests/rust_guests/witguest/Cargo.lock
+++ b/src/tests/rust_guests/witguest/Cargo.lock
@@ -193,9 +193,9 @@ dependencies = [
 
 [[package]]
 name = "heapless"
-version = "0.8.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
+checksum = "b1edcd5a338e64688fbdcb7531a846cfd3476a54784dcb918a0844682bc7ada5"
 dependencies = [
  "hash32",
  "serde",
@@ -396,9 +396,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e0f6df8eaa422d97d72edcd152e1451618fed47fabbdbd5a8864167b1d4aff7"
+checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
 dependencies = [
  "unicode-ident",
 ]
@@ -532,9 +532,9 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "syn"
-version = "2.0.107"
+version = "2.0.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a26dbd934e5451d21ef060c018dae56fc073894c5a7896f882928a76e6d081b"
+checksum = "da58917d35242480a05c2897064da0a80589a2a0476c9a3f2fdc83b53502e917"
 dependencies = [
  "proc-macro2",
  "quote",


### PR DESCRIPTION
This PR adds a poison state to sandbox in order to prevent further operations when the sandbox is left in an inconsistent state that could compromise memory safety, data integrity, or security. The sandbox becomes poisoned when guest functions abort/panic or when host-initiated execution cancellation occurs, leaving behind leaked heap allocations, corrupted data structures, or unreleased resources. For example, interrupting execution while guest is allocating can leave the global allocation lock in an inconsistent state, making future allocations impossible in subsequent runs due to infinite locking/spinning.

Poisoned sandboxes will reject all further operations (guest calls, snapshots, memory mapping) until the inconsistent state is resolved through either restoring to a snapshot or manually (unsafely) clearing the poison state.

Closes #848

Round 2:

I've changed the docs and implementation slightly. `is_poison_error` has been made private. Removed unsafe way of clearing poision. Users of hyperlight are expected on-error to check if the sandbox is poisoned, and deal with it accordingly, for example.

```rust
let result = sandbox.call::<()>("guest_panic", ());
if result.is_err() {
    if sandbox.poisoned() {
        // Restore from snapshot to clear poison
        sandbox.restore(&snapshot)?;
        assert!(!sandbox.poisoned());
        
        // Sandbox is now usable again
        sandbox.call::<String>("Echo", "hello".to_string())?;
    }
}
```