### PR TITLE
Fixes issues from merge and splits trait to expose only public method

### DIFF
--- a/src/hyperlight_host/src/hypervisor/hyperv_linux.rs
+++ b/src/hyperlight_host/src/hypervisor/hyperv_linux.rs
@@ -48,7 +48,7 @@ use super::gdb::{
     DebugCommChannel, DebugMemoryAccess, DebugMsg, DebugResponse, GuestDebug, MshvDebug,
     VcpuStopReason,
 };
-use super::{HyperlightExit, Hypervisor, InterruptHandle, LinuxInterruptHandle, VirtualCPU};
+use super::{HyperlightExit, Hypervisor, LinuxInterruptHandle, VirtualCPU};
 #[cfg(gdb)]
 use crate::HyperlightError;
 use crate::hypervisor::get_memory_access_violation;
@@ -647,11 +647,15 @@ impl Hypervisor for HypervLinuxDriver {
             .tid
             .store(unsafe { libc::pthread_self() as u64 }, Ordering::Release);
         // Note: if `InterruptHandle::kill()` is called while this thread is **here**
+        // Cast to internal trait for access to internal methods
+        let interrupt_handle_internal =
+            self.interrupt_handle.as_ref() as &dyn super::InterruptHandleInternal;
+
         // (after set_running_bit but before checking cancel_requested):
         // - kill() will stamp cancel_requested with the current generation
         // - We will check cancel_requested below and skip the VcpuFd::run() call
         // - This is the desired behavior - the kill takes effect immediately
-        let generation = self.interrupt_handle.set_running_bit();
+        let generation = interrupt_handle_internal.set_running_bit();
 
         #[cfg(not(gdb))]
         let debug_interrupt = false;
@@ -668,8 +672,7 @@ impl Hypervisor for HypervLinuxDriver {
         // - kill() will stamp cancel_requested with the current generation
         // - We will proceed with vcpu.run(), but signals will be sent to interrupt it
         // - The vcpu will be interrupted and return EINTR (handled below)
-        let exit_reason = if self
-            .interrupt_handle
+        let exit_reason = if interrupt_handle_internal
             .is_cancel_requested_for_generation(generation)
             || debug_interrupt
         {
@@ -690,9 +693,8 @@ impl Hypervisor for HypervLinuxDriver {
         // - kill() continues sending signals to this thread (running bit is still set)
         // - The signals are harmless (no-op handler), we just need to check cancel_requested
         // - We load cancel_requested below to determine if this run was cancelled
-        let cancel_requested = self
-            .interrupt_handle
-            .is_cancel_requested_for_generation(generation);
+        let cancel_requested =
+            interrupt_handle_internal.is_cancel_requested_for_generation(generation);
         #[cfg(gdb)]
         let debug_interrupt = self
             .interrupt_handle
@@ -704,7 +706,7 @@ impl Hypervisor for HypervLinuxDriver {
         // - kill() continues sending signals until running bit is cleared
         // - The newly stamped cancel_requested will affect the NEXT vcpu.run() call
         // - Signals sent now are harmless (no-op handler)
-        self.interrupt_handle.clear_running_bit();
+        interrupt_handle_internal.clear_running_bit();
         // At this point, running bit is clear so kill() will stop sending signals.
         // However, we may still receive delayed signals that were sent before clear_running_bit.
         // These stale signals are harmless because:
@@ -799,7 +801,7 @@ impl Hypervisor for HypervLinuxDriver {
                     // - A signal meant for a different sandbox on the same thread
                     // In these cases, we return Retry to continue execution.
                     if cancel_requested {
-                        self.interrupt_handle.clear_cancel_requested();
+                        interrupt_handle_internal.clear_cancel_requested();
                         HyperlightExit::Cancelled()
                     } else {
                         #[cfg(gdb)]
@@ -868,7 +870,7 @@ impl Hypervisor for HypervLinuxDriver {
         self as &mut dyn Hypervisor
     }
 
-    fn interrupt_handle(&self) -> Arc<dyn InterruptHandle> {
+    fn interrupt_handle(&self) -> Arc<dyn super::InterruptHandleInternal> {
         self.interrupt_handle.clone()
     }
 

--- a/src/hyperlight_host/src/hypervisor/kvm.rs
+++ b/src/hyperlight_host/src/hypervisor/kvm.rs
@@ -33,7 +33,7 @@ use super::gdb::{
     DebugCommChannel, DebugMemoryAccess, DebugMsg, DebugResponse, GuestDebug, KvmDebug,
     VcpuStopReason,
 };
-use super::{HyperlightExit, Hypervisor, InterruptHandle, LinuxInterruptHandle, VirtualCPU};
+use super::{HyperlightExit, Hypervisor, LinuxInterruptHandle, VirtualCPU};
 #[cfg(gdb)]
 use crate::HyperlightError;
 use crate::hypervisor::get_memory_access_violation;
@@ -623,11 +623,15 @@ impl Hypervisor for KVMDriver {
             .tid
             .store(unsafe { libc::pthread_self() as u64 }, Ordering::Release);
         // Note: if `InterruptHandle::kill()` is called while this thread is **here**
+        // Cast to internal trait for access to internal methods
+        let interrupt_handle_internal =
+            self.interrupt_handle.as_ref() as &dyn super::InterruptHandleInternal;
+
         // (after set_running_bit but before checking cancel_requested):
         // - kill() will stamp cancel_requested with the current generation
         // - We will check cancel_requested below and skip the VcpuFd::run() call
         // - This is the desired behavior - the kill takes effect immediately
-        let generation = self.interrupt_handle.set_running_bit();
+        let generation = interrupt_handle_internal.set_running_bit();
 
         #[cfg(not(gdb))]
         let debug_interrupt = false;
@@ -643,8 +647,7 @@ impl Hypervisor for KVMDriver {
         // - kill() will stamp cancel_requested with the current generation
         // - We will proceed with vcpu.run(), but signals will be sent to interrupt it
         // - The vcpu will be interrupted and return EINTR (handled below)
-        let exit_reason = if self
-            .interrupt_handle
+        let exit_reason = if interrupt_handle_internal
             .is_cancel_requested_for_generation(generation)
             || debug_interrupt
         {
@@ -666,9 +669,8 @@ impl Hypervisor for KVMDriver {
         // - kill() continues sending signals to this thread (running bit is still set)
         // - The signals are harmless (no-op handler), we just need to check cancel_requested
         // - We load cancel_requested below to determine if this run was cancelled
-        let cancel_requested = self
-            .interrupt_handle
-            .is_cancel_requested_for_generation(generation);
+        let cancel_requested =
+            interrupt_handle_internal.is_cancel_requested_for_generation(generation);
         #[cfg(gdb)]
         let debug_interrupt = self
             .interrupt_handle
@@ -680,7 +682,7 @@ impl Hypervisor for KVMDriver {
         // - kill() continues sending signals until running bit is cleared
         // - The newly stamped cancel_requested will affect the NEXT vcpu.run() call
         // - Signals sent now are harmless (no-op handler)
-        self.interrupt_handle.clear_running_bit();
+        interrupt_handle_internal.clear_running_bit();
         // At this point, running bit is clear so kill() will stop sending signals.
         // However, we may still receive delayed signals that were sent before clear_running_bit.
         // These stale signals are harmless because:
@@ -744,7 +746,7 @@ impl Hypervisor for KVMDriver {
                     // - A signal meant for a different sandbox on the same thread
                     // In these cases, we return Retry to continue execution.
                     if cancel_requested {
-                        self.interrupt_handle.clear_cancel_requested();
+                        interrupt_handle_internal.clear_cancel_requested();
                         HyperlightExit::Cancelled()
                     } else {
                         #[cfg(gdb)]
@@ -818,7 +820,7 @@ impl Hypervisor for KVMDriver {
         self as &mut dyn Hypervisor
     }
 
-    fn interrupt_handle(&self) -> Arc<dyn InterruptHandle> {
+    fn interrupt_handle(&self) -> Arc<dyn super::InterruptHandleInternal> {
         self.interrupt_handle.clone()
     }
 

--- a/src/hyperlight_host/src/sandbox/initialized_multi_use.rs
+++ b/src/hyperlight_host/src/sandbox/initialized_multi_use.rs
@@ -59,17 +59,17 @@ static SANDBOX_ID_COUNTER: AtomicU64 = AtomicU64::new(0);
 ///
 /// Only one guard can exist per interrupt handle at a time - attempting to create
 /// a second guard will return an error.
-struct CallActiveGuard {
-    interrupt_handle: Arc<dyn InterruptHandle>,
+struct CallActiveGuard<T: crate::hypervisor::InterruptHandleInternal + ?Sized> {
+    interrupt_handle: Arc<T>,
 }
 
-impl CallActiveGuard {
+impl<T: crate::hypervisor::InterruptHandleInternal + ?Sized> CallActiveGuard<T> {
     /// Creates a new guard and marks a guest function call as active.
     ///
     /// # Errors
     ///
     /// Returns an error if `call_active` is already true (i.e., another guard already exists).
-    fn new(interrupt_handle: Arc<dyn InterruptHandle>) -> Result<Self> {
+    fn new(interrupt_handle: Arc<T>) -> Result<Self> {
         // Atomically check that call_active is false and set it to true.
         // This prevents creating multiple guards for the same interrupt handle.
         let was_active = interrupt_handle.set_call_active();
@@ -82,7 +82,7 @@ impl CallActiveGuard {
     }
 }
 
-impl Drop for CallActiveGuard {
+impl<T: crate::hypervisor::InterruptHandleInternal + ?Sized> Drop for CallActiveGuard<T> {
     fn drop(&mut self) {
         self.interrupt_handle.clear_call_active();
     }


### PR DESCRIPTION
Merge issues with the mshv2 PR messed things up, we  also took the opportunity to refactor the `InterruptHandle` trait so we only exposed public methods