### PR TITLE
Allow windows more time to enter guest func for interrupt benchmark

### DIFF
--- a/src/hyperlight_host/benches/benchmarks.rs
+++ b/src/hyperlight_host/benches/benchmarks.rs
@@ -142,9 +142,9 @@ fn guest_call_benchmark(c: &mut Criterion) {
                     start_barrier_clone.wait();
 
                     // Small delay to ensure the guest function is running in VM before interrupting
-                    thread::sleep(std::time::Duration::from_millis(1));
+                    thread::sleep(std::time::Duration::from_millis(10));
                     let kill_start = Instant::now();
-                    interrupt_handle.kill();
+                    assert!(interrupt_handle.kill());
                     kill_start
                 });
 


### PR DESCRIPTION
This benchmark is flaky on windows because sometimes the guest call has not started before issuing the `kill`, causing the benchmark to run forever. For an example where this happened, see [here](https://github.com/hyperlight-dev/hyperlight/actions/runs/19022845389/job/54320982829?pr=1003). The fix is just to sleep for a little longer, hopefully allowing the guest function thread to enter the guest function. This test started being flaky after https://github.com/hyperlight-dev/hyperlight/pull/959 was merged, since we can no longer cancel guest functions in advance.