### PR TITLE
Closes #651 : Modify host_bindgen proc_macro to support selecting specific world

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -45,6 +45,7 @@ guests: build-and-move-rust-guests build-and-move-c-guests
 witguest-wit:
     cargo install --locked wasm-tools
     cd src/tests/rust_guests/witguest && wasm-tools component wit guest.wit -w -o interface.wasm
+    cd src/tests/rust_guests/witguest && wasm-tools component wit two_worlds.wit -w -o twoworlds.wasm
 
 build-rust-guests target=default-target features="": (witguest-wit)
     cargo install --locked cargo-hyperlight

--- a/src/hyperlight_host/tests/wit_test.rs
+++ b/src/hyperlight_host/tests/wit_test.rs
@@ -426,3 +426,49 @@ mod wit_test {
         drop(guard);
     }
 }
+
+mod pick_world_bindings {
+    hyperlight_component_macro::host_bindgen!({path: "../tests/rust_guests/witguest/twoworlds.wasm", world_name: "firstworld"});
+}
+mod pick_world_binding_test {
+    use crate::pick_world_bindings::r#twoworlds::r#wit::r#first_import::RecFirstImport;
+
+    impl crate::pick_world_bindings::r#twoworlds::r#wit::r#first_import::RecFirstImport {
+        fn new() -> Self {
+            Self {
+                r#key: String::from("dummyKey"),
+                r#value: String::from("dummyValue"),
+            }
+        }
+    }
+
+    #[test]
+    fn test_first_import_instance() {
+        let first_import = RecFirstImport::new();
+        assert_eq!(first_import.r#key, "dummyKey");
+        assert_eq!(first_import.r#value, "dummyValue");
+    }
+}
+
+mod pick_world_bindings2 {
+    hyperlight_component_macro::host_bindgen!({path: "../tests/rust_guests/witguest/twoworlds.wasm", world_name: "secondworld"});
+}
+mod pick_world_binding_test2 {
+    use crate::pick_world_bindings2::r#twoworlds::r#wit::r#second_export::RecSecondExport;
+
+    impl crate::pick_world_bindings2::r#twoworlds::r#wit::r#second_export::RecSecondExport {
+        fn new() -> Self {
+            Self {
+                r#key: String::from("dummyKey"),
+                r#value: String::from("dummyValue"),
+            }
+        }
+    }
+
+    #[test]
+    fn test_second_export_instance() {
+        let first_import = RecSecondExport::new();
+        assert_eq!(first_import.r#key, "dummyKey");
+        assert_eq!(first_import.r#value, "dummyValue");
+    }
+}

--- a/src/tests/rust_guests/witguest/two_worlds.wit
+++ b/src/tests/rust_guests/witguest/two_worlds.wit
@@ -1,0 +1,23 @@
+package twoworlds:wit;
+
+world secondworld {
+  export second-export;
+}
+
+world firstworld {
+  import first-import;
+}
+
+interface second-export {
+  record rec-second-export {
+    key: string,
+    value: string
+  }
+}
+
+interface first-import {
+    record rec-first-import {
+        key: string,
+        value : string
+    }
+}


### PR DESCRIPTION
fixes: #651
- adds support to select a specific world from a WIT file if multiple worlds are specified.

host_bindgen and guest_bindgen accepts two type of inputs now
1. old way - currently being used everywhere - directly giving path of the wasm compiled file.
2. path and world_name as input to choose a specific world name if you want that.