### PR TITLE
Update the interrupt handler for 16byte alignment

### DIFF
--- a/src/hyperlight_host/tests/common/mod.rs
+++ b/src/hyperlight_host/tests/common/mod.rs
@@ -14,9 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 use hyperlight_host::func::HostFunction;
-use hyperlight_host::{GuestBinary, MultiUseSandbox, Result, UninitializedSandbox};
 #[cfg(gdb)]
 use hyperlight_host::sandbox::config::DebugInfo;
+use hyperlight_host::{GuestBinary, MultiUseSandbox, Result, UninitializedSandbox};
 use hyperlight_testing::{c_simple_guest_as_string, simple_guest_as_string};
 
 /// Returns a rust/c simpleguest depending on environment variable GUEST.
@@ -37,13 +37,13 @@ pub fn new_uninit_rust() -> Result<UninitializedSandbox> {
         let mut cfg = SandboxConfiguration::default();
         let debug_info = DebugInfo { port: 8080 };
         cfg.set_guest_debug_info(debug_info);
-        
+
         UninitializedSandbox::new(
             GuestBinary::FilePath(simple_guest_as_string().unwrap()),
             Some(cfg),
         )
     }
-    
+
     #[cfg(not(gdb))]
     UninitializedSandbox::new(
         GuestBinary::FilePath(simple_guest_as_string().unwrap()),


### PR DESCRIPTION
fixes: https://github.com/hyperlight-dev/hyperlight/issues/1047

Adds tests for exception handling but doesn't specifically test the logic for page faulting logic as described in (https://github.com/hyperlight-dev/hyperlight/issues/698)

This pull request updates the exception context saving and restoring logic to properly ensure correct 16-byte stack alignment. It adds a test that demonstrates the failure and then does some additional validation.

