### PR TITLE
Move sregs to its own file

### DIFF
--- a/src/hyperlight_host/src/error.rs
+++ b/src/hyperlight_host/src/error.rs
@@ -14,9 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#[cfg(mshv3)]
-extern crate mshv_ioctls;
-
 use std::array::TryFromSliceError;
 use std::cell::{BorrowError, BorrowMutError};
 use std::convert::Infallible;

--- a/src/hyperlight_host/src/hypervisor/gdb/mshv_debug.rs
+++ b/src/hyperlight_host/src/hypervisor/gdb/mshv_debug.rs
@@ -14,11 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#[cfg(mshv3)]
-extern crate mshv_bindings;
-#[cfg(mshv3)]
-extern crate mshv_ioctls;
-
 use std::collections::HashMap;
 
 use mshv_bindings::{

--- a/src/hyperlight_host/src/hypervisor/hyperv_linux.rs
+++ b/src/hyperlight_host/src/hypervisor/hyperv_linux.rs
@@ -14,9 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-extern crate mshv_bindings;
-extern crate mshv_ioctls;
-
 use std::fmt::{Debug, Formatter};
 use std::sync::atomic::{AtomicBool, AtomicU8, AtomicU64};
 use std::sync::{Arc, Mutex};
@@ -68,7 +65,8 @@ use crate::{Result, log_then_return, new_error};
 
 #[cfg(gdb)]
 mod debug {
-    use super::mshv_bindings::hv_x64_exception_intercept_message;
+    use mshv_bindings::hv_x64_exception_intercept_message;
+
     use super::{HypervLinuxDriver, *};
     use crate::hypervisor::gdb::{DebugMemoryAccess, DebugMsg, DebugResponse, VcpuStopReason};
     use crate::{Result, new_error};

--- a/src/hyperlight_host/src/hypervisor/regs/fpu.rs
+++ b/src/hyperlight_host/src/hypervisor/regs/fpu.rs
@@ -13,10 +13,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-#[cfg(mshv3)]
-extern crate mshv_bindings;
-#[cfg(mshv3)]
-extern crate mshv_ioctls;
 
 #[cfg(target_os = "windows")]
 use std::collections::HashSet;

--- a/src/hyperlight_host/src/hypervisor/regs/standard_regs.rs
+++ b/src/hyperlight_host/src/hypervisor/regs/standard_regs.rs
@@ -14,11 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#[cfg(mshv3)]
-extern crate mshv_bindings;
-#[cfg(mshv3)]
-extern crate mshv_ioctls;
-
 #[cfg(kvm)]
 use kvm_bindings::kvm_regs;
 #[cfg(mshv3)]

--- a/src/hyperlight_host/src/mem/memory_region.rs
+++ b/src/hyperlight_host/src/mem/memory_region.rs
@@ -14,11 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#[cfg(mshv3)]
-extern crate mshv_bindings;
-#[cfg(mshv3)]
-extern crate mshv_ioctls;
-
 use std::ops::Range;
 
 use bitflags::bitflags;


### PR DESCRIPTION
Move sregs default values to its own file and removes some old `extern crate` usages