### PR TITLE
Fix cross-compilation of Windows surrogate binary on Linux

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -240,6 +240,11 @@ fmt-apply:
 clippy target=default-target: (witguest-wit)
     {{ cargo-cmd }} clippy --all-targets --all-features --profile={{ if target == "debug" { "dev" } else { target } }}  {{ target-triple-flag }} -- -D warnings
 
+# for use on a linux host-machine when cross-compiling to windows. Uses the windows-gnu which should be sufficient for most purposes
+# Note: `--all-targets` does not work because build issues from tracy-crate
+clippyw target=default-target: (witguest-wit)
+    {{ cargo-cmd }} clippy --all-features --target x86_64-pc-windows-gnu --profile={{ if target == "debug" { "dev" } else { target } }}  -- -D warnings
+
 clippy-guests target=default-target: (witguest-wit)
     cd src/tests/rust_guests/simpleguest && cargo clippy --profile={{ if target == "debug" { "dev" } else { target } }} -- -D warnings
     cd src/tests/rust_guests/witguest && cargo clippy --profile={{ if target == "debug" { "dev" } else { target } }} -- -D warnings


### PR DESCRIPTION
- Changed the OS check to use `CARGO_CFG_TARGET_OS` instead of `#[cfg(target_os)]`. This ensures the Windows-specific surrogate build logic runs correctly when cross-compiling from a Linux host.
- Propagated the `TARGET` triple to the inner `cargo build` command so the surrogate binary is compiled for the correct target architecture.
- Switched from `output()` to `status()` for the inner build command. This ensures build errors are visible in the terminal and causes the main build to fail correctly if the surrogate build fails.

After this pr, commands like `cargo clippy --target x86_64-pc-windows-gnu` can be ran from a linux host without erroring out. 

The reason for doing this is that it is useful to be able to compile for windows on a linux host, for example to spot clippy issues without having to push to CI or try compiling on a different host machine. At least personally I often think I fixed all clippy errors, then CI spots some new ones when compiling for windows, and I'll have to go back and forth between machines