### PR TITLE
[trace-dump] Fix `MemFree` writing to file for `mem_profile` feature

### DIFF
--- a/src/hyperlight_host/src/sandbox/trace/mem_profile.rs
+++ b/src/hyperlight_host/src/sandbox/trace/mem_profile.rs
@@ -155,11 +155,22 @@ impl MemTraceInfo {
         let amt = regs.rax;
         let ptr = regs.rcx;
 
-        self.record_trace_frame(self.epoch, trace_identifier as u64, |f| {
-            let _ = f.write_all(&ptr.to_ne_bytes());
-            let _ = f.write_all(&amt.to_ne_bytes());
-            self.write_stack(f, &stack);
-        })
+        match trace_identifier {
+            TraceFrameType::MemAlloc => {
+                self.record_trace_frame(self.epoch, trace_identifier as u64, |f| {
+                    let _ = f.write_all(&ptr.to_ne_bytes());
+                    let _ = f.write_all(&amt.to_ne_bytes());
+                    self.write_stack(f, &stack);
+                })
+            }
+            // The MemFree case does not expect an amount, only a pointer
+            TraceFrameType::MemFree => {
+                self.record_trace_frame(self.epoch, trace_identifier as u64, |f| {
+                    let _ = f.write_all(&ptr.to_ne_bytes());
+                    self.write_stack(f, &stack);
+                })
+            }
+        }
     }
 
     #[inline(always)]


### PR DESCRIPTION
The `trace-dump` utility tool expects only a pointer when a free operation is reported.
The place where the `mem_trace` file is read can be checked at [trace_dump/main.rs#L593](https://github.com/hyperlight-dev/hyperlight/blob/main/src/trace_dump/main.rs#L593)  where you can see that for `frame_id==3` there is no `amount` read.

When `mem_trace` feature is enabled for both host and guest, this works as follows:
- the guest makes a VMExit for each Alloc/Free.
- It passes `ptr, len` to the host for the alloc/free which represent: the allocated/freed pointer, the length of the allocated memory
- The host then unwinds the stack (using the shared memory) to re-construct the call tree for the specific allocation.
- It writes to a `<uuid>.trace` file the following info: `time, trace_id, ptr, amount, stack`. Trace ID represents the type of allocation.
- The tool expects only `ptr, stack` for the `Free` variant, hence the fix here.
- The trace_dump tool takes the debug symbols file as a parameter to know how to translate the pointers of the stack frames.
- It the lists all the operations listed in the `<uuid>.trace` file 