### PR TITLE
Remove old unused code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Prerelease] - Unreleased
 
+### Removed
+* Remove outdated `is_supported_platform` (use `is_hypervisor_present` instead) and unused `ExtraAllowedSyscall` by @ludfjig in https://github.com/hyperlight-dev/hyperlight/pull/1062
+
 
 ## [v0.11.0] - 2025-11-04
 

--- a/src/hyperlight_host/src/sandbox/mod.rs
+++ b/src/hyperlight_host/src/sandbox/mod.rs
@@ -56,26 +56,6 @@ pub use uninitialized::UninitializedSandbox;
 #[cfg(target_os = "windows")]
 use crate::hypervisor::windows_hypervisor_platform;
 
-// In case its not obvious why there are separate is_supported_platform and is_hypervisor_present functions its because
-// Hyperlight is designed to be able to run on a host that doesn't have a hypervisor.
-// In that case, the sandbox will be in process, we plan on making this a dev only feature and fixing up Linux support
-// so we should review the need for this function at that time.
-
-/// Determine if this is a supported platform for Hyperlight
-///
-/// Returns a boolean indicating whether this is a supported platform.
-#[instrument(skip_all, parent = Span::current())]
-pub fn is_supported_platform() -> bool {
-    #[cfg(not(target_os = "linux"))]
-    #[cfg(not(target_os = "windows"))]
-    return false;
-
-    true
-}
-
-/// Alias for the type of extra allowed syscalls.
-pub type ExtraAllowedSyscall = i64;
-
 /// Determine whether a suitable hypervisor is available to run
 /// this sandbox.
 ///


### PR DESCRIPTION
- Removed outdated is_supported_platform because hyperlight now **does** require a hypervisor to run (we used to be able to run in-process without hypervisor)

- Remove ExtraAllowedSyscall since it's no longer used after having removed seccomp features