### PR TITLE
Remove the last vestiges of autodetecting heap/stack size from exes

### DIFF
--- a/src/hyperlight_host/src/mem/exe.rs
+++ b/src/hyperlight_host/src/mem/exe.rs
@@ -32,13 +32,6 @@ pub enum ExeInfo {
     Elf(ElfInfo),
 }
 
-// There isn't a commonly-used standard convention for heap and stack
-// limits to be included in ELF files as they are in
-// PEs. Consequently, we use these static defaults as the default
-// limits, unless overwritten when setting up the sandbox.
-const DEFAULT_ELF_STACK_RESERVE: u64 = 65536;
-const DEFAULT_ELF_HEAP_RESERVE: u64 = 131072;
-
 #[cfg(feature = "mem_profile")]
 pub(crate) trait UnwindInfo: Send + Sync {
     fn as_module(&self) -> framehop::Module<Vec<u8>>;
@@ -83,16 +76,6 @@ impl ExeInfo {
     }
     pub fn from_buf(buf: &[u8]) -> Result<Self> {
         ElfInfo::new(buf).map(ExeInfo::Elf)
-    }
-    pub fn stack_reserve(&self) -> u64 {
-        match self {
-            ExeInfo::Elf(_) => DEFAULT_ELF_STACK_RESERVE,
-        }
-    }
-    pub fn heap_reserve(&self) -> u64 {
-        match self {
-            ExeInfo::Elf(_) => DEFAULT_ELF_HEAP_RESERVE,
-        }
     }
     pub fn entrypoint(&self) -> Offset {
         match self {

--- a/src/hyperlight_host/src/mem/mgr.rs
+++ b/src/hyperlight_host/src/mem/mgr.rs
@@ -327,8 +327,8 @@ impl SandboxMemoryManager<ExclusiveSharedMemory> {
         let layout = SandboxMemoryLayout::new(
             cfg,
             exe_info.loaded_size(),
-            usize::try_from(cfg.get_stack_size(&exe_info))?,
-            usize::try_from(cfg.get_heap_size(&exe_info))?,
+            usize::try_from(cfg.get_stack_size())?,
+            usize::try_from(cfg.get_heap_size())?,
             guest_blob_size,
             guest_blob_mem_flags,
         )?;


### PR DESCRIPTION
When we supported loading guest binaries from PE files, we also supported autodetecting reasonable defaults for heap and stack size for the sandbox based on the loaded executable's stack/heap size hints.  ELF files did not have a similar convention for stack/heap size hints embedded in the file, so when loading an ELF file, we just used some vaguely reasonable small defaults (64k stack and 128k heap). Now that PE support is gone, these are in fact the defaults used for /all/ files, so it doesn't make much sense that we bother putting them into an executable information structure and passing it around.  This commit removes that vestigial use of the ExeInfo structure, replacing it with defaults inline in `sandbox::config`.