### PR TITLE
Make mem::exe::LoadInfo a struct, instead of an alias

### DIFF
--- a/src/hyperlight_host/src/mem/elf.rs
+++ b/src/hyperlight_host/src/mem/elf.rs
@@ -27,6 +27,7 @@ use goblin::elf32::program_header::PT_LOAD;
 #[cfg(feature = "init-paging")]
 use goblin::elf64::program_header::PT_LOAD;
 
+use super::exe::LoadInfo;
 use crate::{Result, log_then_return, new_error};
 
 #[cfg(feature = "mem_profile")]
@@ -161,11 +162,7 @@ impl ElfInfo {
             .unwrap();
         (max_phdr.p_vaddr + max_phdr.p_memsz - self.get_base_va()) as usize
     }
-    pub(crate) fn load_at(
-        self,
-        load_addr: usize,
-        target: &mut [u8],
-    ) -> Result<super::exe::LoadInfo> {
+    pub(crate) fn load_at(self, load_addr: usize, target: &mut [u8]) -> Result<LoadInfo> {
         let base_va = self.get_base_va();
         for phdr in self.phdrs.iter().filter(|phdr| phdr.p_type == PT_LOAD) {
             let start_va = (phdr.p_vaddr - base_va) as usize;
@@ -209,15 +206,17 @@ impl ElfInfo {
             if #[cfg(feature = "mem_profile")] {
                 let va_size = self.get_va_size() as u64;
                 let base_svma = self.get_base_va();
-                Ok(Arc::new(UnwindInfo {
-                    payload: self.payload,
-                    load_addr: load_addr as u64,
-                    va_size,
-                    base_svma,
-                    shdrs: self.shdrs,
-                }))
+                Ok(LoadInfo {
+                    info: Arc::new(UnwindInfo {
+                        payload: self.payload,
+                        load_addr: load_addr as u64,
+                        va_size,
+                        base_svma,
+                        shdrs: self.shdrs,
+                    })
+                })
             } else {
-                Ok(())
+                Ok(LoadInfo {})
             }
         }
     }

--- a/src/hyperlight_host/src/mem/exe.rs
+++ b/src/hyperlight_host/src/mem/exe.rs
@@ -58,10 +58,11 @@ impl<A> framehop::ModuleSectionInfo<A> for &DummyUnwindInfo {
     }
 }
 
-#[cfg(feature = "mem_profile")]
-pub(crate) type LoadInfo = Arc<dyn UnwindInfo>;
-#[cfg(not(feature = "mem_profile"))]
-pub(crate) type LoadInfo = ();
+#[derive(Clone)]
+pub(crate) struct LoadInfo {
+    #[cfg(feature = "mem_profile")]
+    pub(crate) info: Arc<dyn UnwindInfo>,
+}
 
 impl ExeInfo {
     pub fn from_file(path: &str) -> Result<Self> {

--- a/src/hyperlight_host/src/sandbox/uninitialized_evolve.rs
+++ b/src/hyperlight_host/src/sandbox/uninitialized_evolve.rs
@@ -163,7 +163,7 @@ pub(crate) fn set_up_hypervisor_partition(
     };
 
     #[cfg(feature = "mem_profile")]
-    let trace_info = MemTraceInfo::new(_load_info)?;
+    let trace_info = MemTraceInfo::new(_load_info.info)?;
 
     HyperlightVm::new(
         regions,


### PR DESCRIPTION
This has the major advantage that it makes it easy to impl Clone on the struct, which will be useful shortly when snapshots start to keep copies of the load info around.