### PR TITLE
fix(windows): prevent WHvDeletePartition race

### DIFF
--- a/src/hyperlight_host/src/hypervisor/hyperv_windows.rs
+++ b/src/hyperlight_host/src/hypervisor/hyperv_windows.rs
@@ -669,6 +669,11 @@ impl DebuggableVm for WhpVm {
 
 impl Drop for WhpVm {
     fn drop(&mut self) {
+        // HyperlightVm::drop() calls set_dropped() before this runs.
+        // set_dropped() ensures no WHvCancelRunVirtualProcessor calls are in progress
+        // or will be made in the future, so it's safe to delete the partition.
+        // (HyperlightVm::drop() runs before its fields are dropped, so
+        // set_dropped() completes before this Drop impl runs.)
         if let Err(e) = unsafe { WHvDeletePartition(self.partition) } {
             log::error!("Failed to delete partition: {}", e);
         }


### PR DESCRIPTION
prevent race between WHvCancelRunVirtualProcessor and WHvDeletePartition

kill() could call WHvCancelRunVirtualProcessor while WhpVm::drop() was calling WHvDeletePartition, causing use-after-free crashes (STATUS_ACCESS_VIOLATION or STATUS_HEAP_CORRUPTION).

Fix by protecting the partition handle with an RwLock. kill() takes a read lock, and set_dropped() takes a write lock to block until all in-flight cancel calls complete before the partition is deleted.