### PR TITLE
fix runs on for create guest binaries job

### DIFF
--- a/.github/workflows/dep_build_guest_binaries.yml
+++ b/.github/workflows/dep_build_guest_binaries.yml
@@ -15,7 +15,7 @@ permissions:
 jobs:
   # this job has no dependencies
   build-guest-binaries:
-    runs-on: ${{ matrix.os }}
+    runs-on: [self-hosted, linux, x64, "1ES.Pool=hld-kvm-amd"]
     strategy:
       fail-fast: true
       matrix:


### PR DESCRIPTION
The change from Windows to Linux for building guests broke things as the runs-on value is incorrect , this should fix that