### PR TITLE
fix: add id-token permission for cargo publish workflow

### DIFF
--- a/.github/workflows/CreateRelease.yml
+++ b/.github/workflows/CreateRelease.yml
@@ -85,6 +85,7 @@ jobs:
     secrets: inherit
     permissions:
       contents: read
+      id-token: write
 
   publish:
     # see https://github.com/orgs/community/discussions/26286#discussioncomment-3251208 for why we need to check the ref


### PR DESCRIPTION
The cargo-publish job needs id-token: write permission to use trusted publishing with crates.io via OIDC authentication and since it is a re-usable workflow we need to give it permissions here

follow up to #1109 