### PR TITLE
Don't allocate in exception handler

### DIFF
--- a/src/tests/rust_guests/simpleguest/src/main.rs
+++ b/src/tests/rust_guests/simpleguest/src/main.rs
@@ -336,6 +336,19 @@ fn call_malloc(size: i32) -> i32 {
     size
 }
 
+#[guest_function("FillHeapAndCauseException")]
+fn fill_heap_and_cause_exception() {
+    let layout: Layout = Layout::new::<u8>();
+    let mut ptr = unsafe { alloc::alloc::alloc_zeroed(layout) };
+    while !ptr.is_null() {
+        black_box(ptr);
+        ptr = unsafe { alloc::alloc::alloc_zeroed(layout) };
+    }
+
+    // trigger an undefined instruction exception
+    unsafe { core::arch::asm!("ud2") };
+}
+
 #[guest_function("ExhaustHeap")]
 fn exhaust_heap() {
     let layout: Layout = Layout::new::<u8>();


### PR DESCRIPTION
Partially addresses: https://github.com/hyperlight-dev/hyperlight/issues/1118

The test run with out this change fails with memory allocation:

```
assertion `left == right` failed: Full error: GuestAborted(8, "panicked at /home/jstur/.rustup/toolchains/1.89-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc/src/alloc.rs:438:13:\nmemory allocation of 182 bytes failed")
  left: 8
 right: 15
```

