### PR TITLE
Run co-pilot on 1ES KVM runner

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -6,8 +6,8 @@ on: workflow_dispatch
 jobs:
   # The job MUST be called `copilot-setup-steps` or it will not be picked up by Copilot.
   copilot-setup-steps:
-    # run on either intel or amd kvm runner based on run id last digit is even/odd
-    runs-on: ${{ (endsWith(github.run_id, '0') || endsWith(github.run_id, '2') || endsWith(github.run_id, '4') || endsWith(github.run_id, '6') || endsWith(github.run_id, '8')) && fromJSON('["self-hosted", "Linux", "X64", "1ES.Pool=hld-kvm-amd"]') || fromJSON('["self-hosted", "Linux", "X64", "1ES.Pool=hld-kvm-intel"]') }}
+    # run on AMD when the run_id is even, Intel when the run_id is odd
+    runs-on: ${{ (github.run_id % 2 == 0) && fromJSON('["self-hosted", "Linux", "X64", "1ES.Pool=hld-kvm-amd"]') || fromJSON('["self-hosted", "Linux", "X64", "1ES.Pool=hld-kvm-intel"]') }}
 
     # Set the permissions to the lowest permissions possible needed for your steps.
     # Copilot will be given its own token for its operations.


### PR DESCRIPTION
make /dev/kvm available to co-pilot agent