### PR TITLE
Fix fuzzing workflow to build guest artifacts before fuzzing

### DIFF
--- a/.github/workflows/Fuzzing.yml
+++ b/.github/workflows/Fuzzing.yml
@@ -9,7 +9,15 @@ permissions:
   contents: read
   
 jobs:
+  # Build guests first - fuzzing needs the release guest artifacts
+  build-guests:
+    uses: ./.github/workflows/dep_build_guests.yml
+    secrets: inherit
+    with:
+      config: release
+
   fuzzing:
+    needs: build-guests
     uses: ./.github/workflows/dep_fuzzing.yml
     with:
       targets: '["fuzz_host_print", "fuzz_guest_call", "fuzz_host_call", "fuzz_guest_estimate_trace_event", "fuzz_guest_trace"]' # Pass as a JSON array
@@ -18,8 +26,8 @@ jobs:
 
   notify-failure:
     runs-on: ubuntu-latest
-    needs: fuzzing
-    if: always() && needs.fuzzing.result == 'failure'
+    needs: [build-guests, fuzzing]
+    if: always() && (needs.build-guests.result == 'failure' || needs.fuzzing.result == 'failure')
     permissions:
       issues: write
     steps:


### PR DESCRIPTION
When the CI jobs were refactored to use reusable workflows (#1104), the dep_fuzzing.yml was changed to download guest artifacts instead of building them directly. However, the standalone Fuzzing.yml scheduled workflow was not updated to call dep_build_guests.yml first, causing all weekly fuzzing runs to fail with 'Artifact not found for name: rust-guests-release'. This adds the missing build-guests job as a dependency of the fuzzing job, matching the pattern used in ValidatePullRequest.yml.

fixes #1113 

Signed-off-by: James Sturtevant <jsturtevant@gmail.com>