### PR TITLE
Richer errors for HyperlightVm

### DIFF
--- a/src/hyperlight_host/src/hypervisor/mod.rs
+++ b/src/hyperlight_host/src/hypervisor/mod.rs
@@ -554,7 +554,8 @@ pub(crate) mod tests {
             guest_max_log_level,
             #[cfg(gdb)]
             dbg_mem_access_fn,
-        )?;
+        )
+        .unwrap();
 
         Ok(())
     }

--- a/src/hyperlight_host/src/hypervisor/virtual_machine/kvm.rs
+++ b/src/hyperlight_host/src/hypervisor/virtual_machine/kvm.rs
@@ -24,13 +24,15 @@ use kvm_ioctls::{Kvm, VcpuExit, VcpuFd, VmFd};
 use tracing::{Span, instrument};
 
 #[cfg(gdb)]
-use crate::hypervisor::gdb::DebuggableVm;
+use crate::hypervisor::gdb::{DebugError, DebuggableVm};
 use crate::hypervisor::regs::{
     CommonDebugRegs, CommonFpu, CommonRegisters, CommonSpecialRegisters,
 };
-use crate::hypervisor::virtual_machine::{VirtualMachine, VmExit};
+use crate::hypervisor::virtual_machine::{
+    CreateVmError, MapMemoryError, RegisterError, RunVcpuError, UnmapMemoryError, VirtualMachine,
+    VmExit,
+};
 use crate::mem::memory_region::MemoryRegion;
-use crate::{Result, new_error};
 
 /// Return `true` if the KVM API is available, version 12, and has UserMemory capability, or `false` otherwise
 #[instrument(skip_all, parent = Span::current(), level = "Trace")]
@@ -65,18 +67,21 @@ pub(crate) struct KvmVm {
     debug_regs: kvm_guest_debug,
 }
 
-static KVM: LazyLock<Result<Kvm>> =
-    LazyLock::new(|| Kvm::new().map_err(|e| new_error!("Failed to open /dev/kvm: {}", e)));
+static KVM: LazyLock<std::result::Result<Kvm, CreateVmError>> =
+    LazyLock::new(|| Kvm::new().map_err(|e| CreateVmError::HypervisorNotAvailable(e.into())));
 
 impl KvmVm {
     /// Create a new instance of a `KvmVm`
     #[instrument(err(Debug), skip_all, parent = Span::current(), level = "Trace")]
-    pub(crate) fn new() -> Result<Self> {
-        let hv = KVM
-            .as_ref()
-            .map_err(|e| new_error!("Failed to create KVM instance: {}", e))?;
-        let vm_fd = hv.create_vm_with_type(0)?;
-        let vcpu_fd = vm_fd.create_vcpu(0)?;
+    pub(crate) fn new() -> std::result::Result<Self, CreateVmError> {
+        let hv = KVM.as_ref().map_err(|e| e.clone())?;
+
+        let vm_fd = hv
+            .create_vm_with_type(0)
+            .map_err(|e| CreateVmError::CreateVmFd(e.into()))?;
+        let vcpu_fd = vm_fd
+            .create_vcpu(0)
+            .map_err(|e| CreateVmError::CreateVcpuFd(e.into()))?;
 
         Ok(Self {
             vm_fd,
@@ -88,25 +93,31 @@ impl KvmVm {
 }
 
 impl VirtualMachine for KvmVm {
-    unsafe fn map_memory(&mut self, (slot, region): (u32, &MemoryRegion)) -> Result<()> {
+    unsafe fn map_memory(
+        &mut self,
+        (slot, region): (u32, &MemoryRegion),
+    ) -> std::result::Result<(), MapMemoryError> {
         let mut kvm_region: kvm_userspace_memory_region = region.into();
         kvm_region.slot = slot;
-        unsafe { self.vm_fd.set_user_memory_region(kvm_region)? };
-        Ok(())
+        unsafe { self.vm_fd.set_user_memory_region(kvm_region) }
+            .map_err(|e| MapMemoryError::Hypervisor(e.into()))
     }
 
-    fn unmap_memory(&mut self, (slot, region): (u32, &MemoryRegion)) -> Result<()> {
+    fn unmap_memory(
+        &mut self,
+        (slot, region): (u32, &MemoryRegion),
+    ) -> std::result::Result<(), UnmapMemoryError> {
         let mut kvm_region: kvm_userspace_memory_region = region.into();
         kvm_region.slot = slot;
         // Setting memory_size to 0 unmaps the slot's region
         // From https://docs.kernel.org/virt/kvm/api.html
         // > Deleting a slot is done by passing zero for memory_size.
         kvm_region.memory_size = 0;
-        unsafe { self.vm_fd.set_user_memory_region(kvm_region) }?;
-        Ok(())
+        unsafe { self.vm_fd.set_user_memory_region(kvm_region) }
+            .map_err(|e| UnmapMemoryError::Hypervisor(e.into()))
     }
 
-    fn run_vcpu(&mut self) -> Result<VmExit> {
+    fn run_vcpu(&mut self) -> std::result::Result<VmExit, RunVcpuError> {
         match self.vcpu_fd.run() {
             Ok(VcpuExit::Hlt) => Ok(VmExit::Halt()),
             Ok(VcpuExit::IoOut(port, data)) => Ok(VmExit::IoOut(port, data.to_vec())),
@@ -121,7 +132,7 @@ impl VirtualMachine for KvmVm {
                 // InterruptHandle::kill() sends a signal (SIGRTMIN+offset) to interrupt the vcpu, which causes EINTR
                 libc::EINTR => Ok(VmExit::Cancelled()),
                 libc::EAGAIN => Ok(VmExit::Retry()),
-                _ => Ok(VmExit::Unknown(format!("Unknown KVM VCPU error: {}", e))),
+                _ => Err(RunVcpuError::Unknown(e.into())),
             },
             Ok(other) => Ok(VmExit::Unknown(format!(
                 "Unknown KVM VCPU exit: {:?}",
@@ -130,53 +141,76 @@ impl VirtualMachine for KvmVm {
         }
     }
 
-    fn regs(&self) -> Result<CommonRegisters> {
-        let kvm_regs = self.vcpu_fd.get_regs()?;
+    fn regs(&self) -> std::result::Result<CommonRegisters, RegisterError> {
+        let kvm_regs = self
+            .vcpu_fd
+            .get_regs()
+            .map_err(|e| RegisterError::GetRegs(e.into()))?;
         Ok((&kvm_regs).into())
     }
 
-    fn set_regs(&self, regs: &CommonRegisters) -> Result<()> {
+    fn set_regs(&self, regs: &CommonRegisters) -> std::result::Result<(), RegisterError> {
         let kvm_regs: kvm_regs = regs.into();
-        self.vcpu_fd.set_regs(&kvm_regs)?;
+        self.vcpu_fd
+            .set_regs(&kvm_regs)
+            .map_err(|e| RegisterError::SetRegs(e.into()))?;
         Ok(())
     }
 
-    fn fpu(&self) -> Result<CommonFpu> {
-        let kvm_fpu = self.vcpu_fd.get_fpu()?;
+    fn fpu(&self) -> std::result::Result<CommonFpu, RegisterError> {
+        let kvm_fpu = self
+            .vcpu_fd
+            .get_fpu()
+            .map_err(|e| RegisterError::GetFpu(e.into()))?;
         Ok((&kvm_fpu).into())
     }
 
-    fn set_fpu(&self, fpu: &CommonFpu) -> Result<()> {
+    fn set_fpu(&self, fpu: &CommonFpu) -> std::result::Result<(), RegisterError> {
         let kvm_fpu: kvm_fpu = fpu.into();
-        self.vcpu_fd.set_fpu(&kvm_fpu)?;
+        self.vcpu_fd
+            .set_fpu(&kvm_fpu)
+            .map_err(|e| RegisterError::SetFpu(e.into()))?;
         Ok(())
     }
 
-    fn sregs(&self) -> Result<CommonSpecialRegisters> {
-        let kvm_sregs = self.vcpu_fd.get_sregs()?;
+    fn sregs(&self) -> std::result::Result<CommonSpecialRegisters, RegisterError> {
+        let kvm_sregs = self
+            .vcpu_fd
+            .get_sregs()
+            .map_err(|e| RegisterError::GetSregs(e.into()))?;
         Ok((&kvm_sregs).into())
     }
 
-    fn set_sregs(&self, sregs: &CommonSpecialRegisters) -> Result<()> {
+    fn set_sregs(&self, sregs: &CommonSpecialRegisters) -> std::result::Result<(), RegisterError> {
         let kvm_sregs: kvm_sregs = sregs.into();
-        self.vcpu_fd.set_sregs(&kvm_sregs)?;
+        self.vcpu_fd
+            .set_sregs(&kvm_sregs)
+            .map_err(|e| RegisterError::SetSregs(e.into()))?;
         Ok(())
     }
 
-    fn debug_regs(&self) -> Result<CommonDebugRegs> {
-        let kvm_debug_regs = self.vcpu_fd.get_debug_regs()?;
+    fn debug_regs(&self) -> std::result::Result<CommonDebugRegs, RegisterError> {
+        let kvm_debug_regs = self
+            .vcpu_fd
+            .get_debug_regs()
+            .map_err(|e| RegisterError::GetDebugRegs(e.into()))?;
         Ok(kvm_debug_regs.into())
     }
 
-    fn set_debug_regs(&self, drs: &CommonDebugRegs) -> Result<()> {
+    fn set_debug_regs(&self, drs: &CommonDebugRegs) -> std::result::Result<(), RegisterError> {
         let kvm_debug_regs: kvm_debugregs = drs.into();
-        self.vcpu_fd.set_debug_regs(&kvm_debug_regs)?;
+        self.vcpu_fd
+            .set_debug_regs(&kvm_debug_regs)
+            .map_err(|e| RegisterError::SetDebugRegs(e.into()))?;
         Ok(())
     }
 
     #[cfg(crashdump)]
-    fn xsave(&self) -> Result<Vec<u8>> {
-        let xsave = self.vcpu_fd.get_xsave()?;
+    fn xsave(&self) -> std::result::Result<Vec<u8>, RegisterError> {
+        let xsave = self
+            .vcpu_fd
+            .get_xsave()
+            .map_err(|e| RegisterError::GetXsave(e.into()))?;
         Ok(xsave
             .region
             .into_iter()
@@ -187,18 +221,19 @@ impl VirtualMachine for KvmVm {
 
 #[cfg(gdb)]
 impl DebuggableVm for KvmVm {
-    fn translate_gva(&self, gva: u64) -> Result<u64> {
-        use crate::HyperlightError;
-
-        let gpa = self.vcpu_fd.translate_gva(gva)?;
+    fn translate_gva(&self, gva: u64) -> std::result::Result<u64, DebugError> {
+        let gpa = self
+            .vcpu_fd
+            .translate_gva(gva)
+            .map_err(|_| DebugError::TranslateGva(gva))?;
         if gpa.valid == 0 {
-            Err(HyperlightError::TranslateGuestAddress(gva))
+            Err(DebugError::TranslateGva(gva))
         } else {
             Ok(gpa.physical_address)
         }
     }
 
-    fn set_debug(&mut self, enable: bool) -> Result<()> {
+    fn set_debug(&mut self, enable: bool) -> std::result::Result<(), DebugError> {
         use kvm_bindings::{KVM_GUESTDBG_ENABLE, KVM_GUESTDBG_USE_HW_BP, KVM_GUESTDBG_USE_SW_BP};
 
         log::info!("Setting debug to {}", enable);
@@ -209,11 +244,13 @@ impl DebuggableVm for KvmVm {
             self.debug_regs.control &=
                 !(KVM_GUESTDBG_ENABLE | KVM_GUESTDBG_USE_HW_BP | KVM_GUESTDBG_USE_SW_BP);
         }
-        self.vcpu_fd.set_guest_debug(&self.debug_regs)?;
+        self.vcpu_fd
+            .set_guest_debug(&self.debug_regs)
+            .map_err(|e| RegisterError::SetDebugRegs(e.into()))?;
         Ok(())
     }
 
-    fn set_single_step(&mut self, enable: bool) -> Result<()> {
+    fn set_single_step(&mut self, enable: bool) -> std::result::Result<(), DebugError> {
         use kvm_bindings::KVM_GUESTDBG_SINGLESTEP;
 
         log::info!("Setting single step to {}", enable);
@@ -222,7 +259,9 @@ impl DebuggableVm for KvmVm {
         } else {
             self.debug_regs.control &= !KVM_GUESTDBG_SINGLESTEP;
         }
-        self.vcpu_fd.set_guest_debug(&self.debug_regs)?;
+        self.vcpu_fd
+            .set_guest_debug(&self.debug_regs)
+            .map_err(|e| RegisterError::SetDebugRegs(e.into()))?;
 
         // Set TF Flag to enable Traps
         let mut regs = self.regs()?;
@@ -235,7 +274,7 @@ impl DebuggableVm for KvmVm {
         Ok(())
     }
 
-    fn add_hw_breakpoint(&mut self, addr: u64) -> Result<()> {
+    fn add_hw_breakpoint(&mut self, addr: u64) -> std::result::Result<(), DebugError> {
         use crate::hypervisor::gdb::arch::MAX_NO_OF_HW_BP;
 
         // Check if breakpoint already exists
@@ -246,7 +285,7 @@ impl DebuggableVm for KvmVm {
         // Find the first available LOCAL (L0–L3) slot
         let i = (0..MAX_NO_OF_HW_BP)
             .position(|i| self.debug_regs.arch.debugreg[7] & (1 << (i * 2)) == 0)
-            .ok_or_else(|| new_error!("Tried to add more than 4 hardware breakpoints"))?;
+            .ok_or(DebugError::TooManyHwBreakpoints(MAX_NO_OF_HW_BP))?;
 
         // Assign to corresponding debug register
         self.debug_regs.arch.debugreg[i] = addr;
@@ -254,16 +293,18 @@ impl DebuggableVm for KvmVm {
         // Enable LOCAL bit
         self.debug_regs.arch.debugreg[7] |= 1 << (i * 2);
 
-        self.vcpu_fd.set_guest_debug(&self.debug_regs)?;
+        self.vcpu_fd
+            .set_guest_debug(&self.debug_regs)
+            .map_err(|e| RegisterError::SetDebugRegs(e.into()))?;
         Ok(())
     }
 
-    fn remove_hw_breakpoint(&mut self, addr: u64) -> Result<()> {
+    fn remove_hw_breakpoint(&mut self, addr: u64) -> std::result::Result<(), DebugError> {
         // Find the index of the breakpoint
         let index = self.debug_regs.arch.debugreg[..4]
             .iter()
             .position(|&a| a == addr)
-            .ok_or_else(|| new_error!("Tried to remove non-existing hw-breakpoint"))?;
+            .ok_or(DebugError::HwBreakpointNotFound(addr))?;
 
         // Clear the address
         self.debug_regs.arch.debugreg[index] = 0;
@@ -271,7 +312,9 @@ impl DebuggableVm for KvmVm {
         // Disable LOCAL bit
         self.debug_regs.arch.debugreg[7] &= !(1 << (index * 2));
 
-        self.vcpu_fd.set_guest_debug(&self.debug_regs)?;
+        self.vcpu_fd
+            .set_guest_debug(&self.debug_regs)
+            .map_err(|e| RegisterError::SetDebugRegs(e.into()))?;
         Ok(())
     }
 }

--- a/src/hyperlight_host/tests/integration_test.rs
+++ b/src/hyperlight_host/tests/integration_test.rs
@@ -557,6 +557,22 @@ fn guest_malloc_abort() {
     ));
 }
 
+/// Test that executing an OUT instruction with an invalid port causes an error and poisons the sandbox.
+#[test]
+fn guest_outb_with_invalid_port_poisons_sandbox() {
+    let mut sbox = new_uninit_rust().unwrap().evolve().unwrap();
+
+    // Port 0x1234 is not a valid hyperlight port
+    let res = sbox.call::<()>("OutbWithPort", (0x1234_u32, 0_u32));
+    assert!(res.is_err(), "Expected error from invalid OUT port");
+
+    // The sandbox should be poisoned because the guest didn't complete normally
+    assert!(
+        sbox.poisoned(),
+        "Sandbox should be poisoned after invalid OUT"
+    );
+}
+
 #[test]
 fn guest_panic_no_alloc() {
     let heap_size = 0x4000;

--- a/src/tests/rust_guests/simpleguest/src/main.rs
+++ b/src/tests/rust_guests/simpleguest/src/main.rs
@@ -516,6 +516,20 @@ fn trigger_exception() {
     unsafe { core::arch::asm!("ud2") };
 }
 
+/// Execute an OUT instruction with an arbitrary port and value.
+/// This is used to test that invalid OUT ports cause errors.
+#[guest_function("OutbWithPort")]
+fn outb_with_port(port: u32, value: u32) {
+    unsafe {
+        core::arch::asm!(
+            "out dx, eax",
+            in("dx") port as u16,
+            in("eax") value,
+            options(preserves_flags, nomem, nostack)
+        );
+    }
+}
+
 static mut COUNTER: i32 = 0;
 
 #[guest_function("AddToStatic")]


### PR DESCRIPTION
This pr adds a new types of Errors for all possible operations possible on struct `HyperlightVm`. The main purpose for doing so if to more accurately being able to determine whether a sandbox should be poisoned, since any error that doesn't let the guest properly unwind should poison a sandbox. However, another benefit with this PR is that errors surfaced to the user will be much richer in information about what went wrong. Due to these errors having tree-like structure, they almost serve as a kind of backtrace. To accomplish this, new richer errors types have been added to all possible code paths taken by all `HyperlightVm`, and existing HyperlightErrors are entirely avoided in these codepaths (with a couple of small exceptions).

To remain backwards compatible (with tests and not to break users relying on certain existing errors), some of these internal errors are surfaced as existing errors. For example, stack overflow errors will be turned into the existing top-level error `HyperlightError::StackOverflow`, and when guest execution is canceleld by host, the old error will be returned similarly.

This PR does not change any logic at all, it only modifies returned error types.

My eventual (far away) goal is to add richer errors to all hyperlight modules, and very carefully distinguish between internal errors (that are not supposed to happen) and other errors that indeed are supposed to be able to happen. All new errors in this PR are "internal errors" in that they should not be relied upon to adhere to semver, etc, and may change heavily between versions. That said, they are still `pub` since they are returned to users. The errors in this PR can be visualized like this:

<details>
  <summary>Spoiler warning</summary>
<pre>
HyperlightVmError
├── DispatchGuestCall(DispatchGuestCallError)
│   ├── ConvertRspPointer(String)
│   ├── SetupRegs(RegisterError)              ──► [A]
│   └── Run(RunVmError)                       ──► [B]
│
├── Initialize(InitializeError)
│   ├── ConvertPointer(String)
│   ├── SetupRegs(RegisterError)              ──► [A]
│   └── Run(RunVmError)                       ──► [B]
│
├── Create(CreateHyperlightVmError)
│   ├── NoHypervisorFound
│   ├── Vm(VmError)                           ──► [C]
│   ├── ConvertRspPointer(Box<HyperlightError>)
│   ├── SendDbgMsg(SendDbgMsgError)           ──► [D] [gdb]
│   └── AddHwBreakpoint(DebugError)           ──► [G] [gdb]
│
├── MapRegion(MapRegionError)
│   ├── NotPageAligned { page_size, region }
│   └── MapMemory(MapMemoryError)
│
└── UnmapRegion(UnmapRegionError)
    ├── RegionNotFound(MemoryRegion)
    └── UnmapMemory(UnmapMemoryError)



[A] RegisterError
    ├── GetRegs(HypervisorImplError)
    ├── SetRegs(HypervisorImplError)
    ├── GetFpu(HypervisorImplError)
    ├── SetFpu(HypervisorImplError)
    ├── GetSregs(HypervisorImplError)
    ├── SetSregs(HypervisorImplError)
    ├── GetDebugRegs(HypervisorImplError)
    ├── SetDebugRegs(HypervisorImplError)
    ├── GetXsave(HypervisorImplError)
    └── XsaveSizeMismatch { expected, actual }


[B] RunVmError
    ├── StackOverflow
    ├── MemoryAccessViolation { addr, access_type, region_flags }
    ├── MmioReadUnmapped(u64)
    ├── MmioWriteUnmapped(u64)
    ├── ExecutionCancelledByHost
    ├── UnexpectedVmExit(String)
    ├── RunVcpu(RunVcpuError)
    ├── HandleIo(HandleIoError)               ──► [E]
    ├── GetRegs(RegisterError)                ──► [A] [trace_guest]
    ├── CheckStackGuard(Box<HyperlightError>)
    ├── DebugHandler(HandleDebugError)        ──► [F] [gdb]
    ├── VcpuStopReason(VcpuStopReasonError)   [gdb]
    └── CrashdumpGeneration(Box<HyperlightError>) [crashdump]


[C] VmError
    ├── CreateVm(CreateVmError)
    ├── RunVcpu(RunVcpuError)
    ├── Register(RegisterError)               ──► [A]
    ├── MapMemory(MapMemoryError)
    ├── UnmapMemory(UnmapMemoryError)
    └── Debug(DebugError)                     ──► [G] [gdb]


[D] SendDbgMsgError [gdb]
    ├── DebugNotEnabled
    └── SendFailed(GdbTargetError)


[E] HandleIoError
    ├── NoData
    ├── GetRegs(RegisterError)                ──► [A] [mem_profile]
    └── Outb(HandleOutbError)
        ├── StackOverflow
        ├── GuestAborted { code, message }
        ├── InvalidPort(String)
        ├── ReadLogData(String)
        ├── TraceFormat(String)
        ├── ReadHostFunctionCall(String)
        ├── LockFailed(&str, u32, String)
        ├── WriteHostFunctionResponse(String)
        ├── InvalidDebugPrintChar(u32)
        └── MemProfile(String)                [mem_profile]


[F] HandleDebugError [gdb]
    ├── DebugNotEnabled
    ├── SendMessage(SendDbgMsgError)          ──► [D]
    ├── ReceiveMessage(RecvDbgMsgError)
    │   ├── DebugNotEnabled
    │   └── RecvFailed(GdbTargetError)
    └── ProcessRequest(ProcessDebugRequestError)
        ├── DebugNotEnabled
        ├── TryLockError(&str, u32)
        ├── Vm(VmError)                       ──► [C]
        ├── Debug(DebugError)                 ──► [G]
        ├── SwBreakpointNotFound(u64)
        ├── ReadMemory(DebugMemoryAccessError)
        └── WriteMemory(DebugMemoryAccessError)


[G] DebugError [gdb]
    ├── HwBreakpointNotFound(u64)
    ├── TooManyHwBreakpoints(usize)
    ├── Register(RegisterError)               ──► [A]
    ├── TranslateGva(u64)
    └── Intercept { enable, inner: HypervisorImplError }
</pre>
</details>

Partially addresses #998 (fixes the bug, but doesn't update the errors everywhere)