### PR TITLE
Run shared memory tests with miri

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -212,9 +212,9 @@ test-doc target=default-target features="":
 
 miri-tests:
     rustup +nightly component list | grep -q "miri.*installed" || rustup component add miri --toolchain nightly
-    # For now only run miri tests on hyperlight-common with trace_guest feature
     # We can add more as needed
     cargo +nightly miri test -p hyperlight-common -F trace_guest
+    cargo +nightly miri test -p hyperlight-host --lib -- mem::shared_mem::tests
 
 ################
 ### LINTING ####

--- a/src/hyperlight_host/src/mem/mod.rs
+++ b/src/hyperlight_host/src/mem/mod.rs
@@ -36,5 +36,5 @@ pub mod ptr_offset;
 /// a memory region for a guest running in a sandbox.
 pub mod shared_mem;
 /// Utilities for writing shared memory tests
-#[cfg(test)]
+#[cfg(all(test, not(miri)))] // uses proptest which isn't miri-compatible
 pub(crate) mod shared_mem_tests;

--- a/src/tests/rust_guests/simpleguest/Cargo.lock
+++ b/src/tests/rust_guests/simpleguest/Cargo.lock
@@ -22,11 +22,11 @@ checksum = "34efbcccd345379ca2868b2b2c9d3782e9cc58ba87bc7d79d5b53d9c9ae6f25d"
 
 [[package]]
 name = "buddy_system_allocator"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1a0108968a3a2dab95b089c0fc3f1afa7759aa5ebe6f1d86d206d6f7ba726eb"
+checksum = "b672b945a3e4f4f40bfd4cd5ee07df9e796a42254ce7cd6d2599ad969244c44a"
 dependencies = [
- "spin 0.9.8",
+ "spin",
 ]
 
 [[package]]
@@ -79,7 +79,7 @@ dependencies = [
  "anyhow",
  "flatbuffers",
  "log",
- "spin 0.10.0",
+ "spin",
  "thiserror",
 ]
 
@@ -110,7 +110,7 @@ dependencies = [
  "hyperlight-guest-tracing",
  "linkme",
  "log",
- "spin 0.10.0",
+ "spin",
  "tracing",
 ]
 
@@ -129,7 +129,7 @@ name = "hyperlight-guest-tracing"
 version = "0.12.0"
 dependencies = [
  "hyperlight-common",
- "spin 0.10.0",
+ "spin",
  "tracing",
  "tracing-core",
 ]
@@ -309,15 +309,6 @@ dependencies = [
  "hyperlight-guest-tracing",
  "log",
  "tracing",
-]
-
-[[package]]
-name = "spin"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
-dependencies = [
- "lock_api",
 ]
 
 [[package]]


### PR DESCRIPTION
Enables 10 existing shared_memory tests to be run with Miri and adds them to CI. This allows us to exercise some of our unsafe code and increase confidence in correctness and not having UB.

Note:
- For this PR I first intended on adding another rust-native `Vec<u8>` backing for for HostMapping which does not use platform apis (`mmap`, `VirtualAlloc`), but it turns out `mmap` is partially supported by Miri, but not with MAP_SHARED so I did that instead because it is easier. Aside: I don't think we need to use MAP_SHARED  in general for hyperlight, but that not relevant to this PR.
- the change to `base_ptr()` is intentional because we used to cast pointer to integer, which loses pointer provenance. The fix is to use pointer arithmetics instead to preserve provenance.
