### PR TITLE
Fix fp ABI for C guest

### DIFF
--- a/c.just
+++ b/c.just
@@ -10,8 +10,8 @@ c-flags-release-elf := '-O3'
 
 build-c-guests target=default-target: (build-rust-capi target) (compile-c-guest target) (link-c-guest target)
 
-build-rust-capi target=default-target:
-    cd src/hyperlight_guest_capi && cargo build --profile {{ if target == "debug" { "dev" } else { target } }}
+build-rust-capi target=default-target: (ensure-cargo-hyperlight)
+    cd src/hyperlight_guest_capi && cargo hyperlight build --profile {{ if target == "debug" { "dev" } else { target } }}
 
 compile-c-guest target=default-target:
     # elf
@@ -19,7 +19,7 @@ compile-c-guest target=default-target:
 
 link-c-guest target=default-target:
     # elf
-    cd src/tests/c_guests/c_simpleguest && ld.lld -o out/{{target}}/simpleguest {{c-linker-options-elf}} out/{{target}}/main.o -l hyperlight_guest_capi -L "{{justfile_directory()}}/target/x86_64-unknown-none/{{target}}"
+    cd src/tests/c_guests/c_simpleguest && ld.lld -o out/{{target}}/simpleguest {{c-linker-options-elf}} out/{{target}}/main.o -l hyperlight_guest_capi -L "{{justfile_directory()}}/target/x86_64-hyperlight-none/{{target}}"
 
 move-c-guests target=default-target:
     # elf

--- a/src/hyperlight_guest_capi/.cargo/config.toml
+++ b/src/hyperlight_guest_capi/.cargo/config.toml
@@ -1,8 +1,0 @@
-[build]
-target = "x86_64-unknown-none"
-
-[profile.release]
-panic = "abort"
-
-[profile.dev]
-panic = "abort"

--- a/src/hyperlight_host/tests/integration_test.rs
+++ b/src/hyperlight_host/tests/integration_test.rs
@@ -849,10 +849,6 @@ fn test_if_guest_is_able_to_get_bool_return_values_from_host() {
 
 /// Tests whether host is able to return Float/f32 as return type
 /// or not
-/// Adding Ignore attribute, due known issues with float and double
-/// calculations - see Github issue #179. Once it is fixed we can
-/// remove ignore attribute
-#[ignore]
 #[test]
 fn test_if_guest_is_able_to_get_float_return_values_from_host() {
     let mut sbox1 = new_uninit_c().unwrap();
@@ -870,10 +866,6 @@ fn test_if_guest_is_able_to_get_float_return_values_from_host() {
 
 /// Tests whether host is able to return Double/f64 as return type
 /// or not
-/// Adding Ignore attribute, due known issues with float and double
-/// calculations - see Github issue #179. Once it is fixed we can
-/// remove ignore attribute
-#[ignore]
 #[test]
 fn test_if_guest_is_able_to_get_double_return_values_from_host() {
     let mut sbox1 = new_uninit_c().unwrap();

--- a/src/hyperlight_host/tests/sandbox_host_tests.rs
+++ b/src/hyperlight_host/tests/sandbox_host_tests.rs
@@ -45,7 +45,6 @@ fn pass_byte_array() {
 }
 
 #[test]
-#[ignore = "Fails with mismatched float only when c .exe guest?!"]
 fn float_roundtrip() {
     let doubles = [
         0.0,
@@ -83,8 +82,11 @@ fn float_roundtrip() {
     for f in doubles.iter() {
         let res: f64 = sandbox.call("EchoDouble", *f).unwrap();
 
+        // Use == for comparison (handles -0.0 == 0.0) with special case for NaN.
+        // Note: FlatBuffers doesn't preserve -0.0 (-0.0 round-trips to 0.0) because FlatBuffers skips
+        // storing values equal to the default (as an optimization), and -0.0 == 0.0 in IEEE 754.
         assert!(
-            res.total_cmp(f).is_eq(),
+            (res.is_nan() && f.is_nan()) || res == *f,
             "Expected {:?} but got {:?}",
             f,
             res
@@ -93,8 +95,11 @@ fn float_roundtrip() {
     for f in floats.iter() {
         let res: f32 = sandbox.call("EchoFloat", *f).unwrap();
 
+        // Use == for comparison (handles -0.0 == 0.0) with special case for NaN.
+        // Note: FlatBuffers doesn't preserve -0.0 (-0.0 round-trips to 0.0) because FlatBuffers skips
+        // storing values equal to the default (as an optimization), and -0.0 == 0.0 in IEEE 754.
         assert!(
-            res.total_cmp(f).is_eq(),
+            (res.is_nan() && f.is_nan()) || res == *f,
             "Expected {:?} but got {:?}",
             f,
             res

--- a/src/tests/rust_guests/witguest/Cargo.lock
+++ b/src/tests/rust_guests/witguest/Cargo.lock
@@ -427,9 +427,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.43"
+version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc74d9a594b72ae6656596548f56f667211f8a97b3d4c3d467150794690dc40a"
+checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
 dependencies = [
  "proc-macro2",
 ]


### PR DESCRIPTION
Update guest C api to use `cargo hyperlight build` which will use the right target. This fixes the previous ABI mismatch where clang used fp registers to pass floats, but rust didn't. 

Note: To compile simpleguest/main.c, we're still using clang's `x86_64-unknown-linux-none` target

Closes https://github.com/hyperlight-dev/hyperlight/issues/179

** For the curious, a small repro can be found here https://github.com/ludfjig/float-abi-test