### PR TITLE
Support wasmparser 0.244.0 breaking API changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3982,9 +3982,9 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.243.0"
+version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6d8db401b0528ec316dfbe579e6ab4152d61739cfe076706d2009127970159d"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags 2.10.0",
  "hashbrown 0.15.5",

--- a/src/hyperlight_component_macro/Cargo.toml
+++ b/src/hyperlight_component_macro/Cargo.toml
@@ -16,7 +16,7 @@ name = "hyperlight_component_macro"
 proc-macro = true
 
 [dependencies]
-wasmparser = { version = "0.243.0" }
+wasmparser = { version = "0.244.0" }
 quote = { version = "1.0.44" }
 proc-macro2 = { version = "1.0.106" }
 syn = { version = "2.0.114" }

--- a/src/hyperlight_component_util/Cargo.toml
+++ b/src/hyperlight_component_util/Cargo.toml
@@ -15,7 +15,7 @@ Shared implementation for the procedural macros that generate Hyperlight host an
 name = "hyperlight_component_util"
 
 [dependencies]
-wasmparser = { version = "0.243.0" }
+wasmparser = { version = "0.244.0" }
 quote = { version = "1.0.44" }
 proc-macro2 = { version = "1.0.106" }
 syn = { version = "2.0.114" }

--- a/src/hyperlight_component_util/src/elaborate.rs
+++ b/src/hyperlight_component_util/src/elaborate.rs
@@ -439,10 +439,16 @@ impl<'p, 'a> Ctx<'p, 'a> {
             ComponentDefinedType::Future(_) | ComponentDefinedType::Stream(_) => {
                 panic!("async not yet supported")
             }
+            ComponentDefinedType::Map(_, _) => {
+                panic!("map type not yet supported")
+            }
         }
     }
 
     fn elab_func<'c>(&'c mut self, ft: &ComponentFuncType<'a>) -> Result<Func<'a>, Error<'a>> {
+        if ft.async_ {
+            panic!("async not yet supported")
+        }
         Ok(Func {
             params: ft
                 .params


### PR DESCRIPTION
wasmparser 0.244.0 introduced breaking changes from PR #2376 which bakes async into component model function types. This adds an async_ field to ComponentFuncType and a new Map variant to ComponentDefinedType.

Since Hyperlight does not yet support async component model features, we handle these new API additions by panicking with clear error messages, consistent with how Future and Stream types are already handled.

This unblocks the Dependabot PR #1156 which was failing CI due to these breaking changes.

Signed-off-by: James Sturtevant <jsturtevant@gmail.com>