### PR TITLE
Save an unconditional clone of guest parameters for registered guest functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Prerelease] - Unreleased
 
+### Changed
+* **Breaking:** `GuestFunctionDefinition::new` now takes a typed function pointer instead of `usize` by @ludfjig in https://github.com/hyperlight-dev/hyperlight/pull/1241
+
 ## [v0.12.0] - 2025-12-09
 
 ### Fixed

--- a/src/hyperlight_component_util/src/guest.rs
+++ b/src/hyperlight_component_util/src/guest.rs
@@ -210,7 +210,7 @@ fn emit_export_extern_decl<'a, 'b, 'c>(
             let marshal_result = emit_hl_marshal_result(s, ret.clone(), &ft.result);
             let trait_path = s.cur_trait_path();
             quote! {
-                fn #n<T: Guest>(fc: &::hyperlight_common::flatbuffer_wrappers::function_call::FunctionCall) -> ::hyperlight_guest::error::Result<::alloc::vec::Vec<u8>> {
+                fn #n<T: Guest>(fc: ::hyperlight_common::flatbuffer_wrappers::function_call::FunctionCall) -> ::hyperlight_guest::error::Result<::alloc::vec::Vec<u8>> {
                     <T as Guest>::with_guest_state(|state| {
                         #(#pds)*
                         #(#get_instance)*
@@ -223,7 +223,7 @@ fn emit_export_extern_decl<'a, 'b, 'c>(
                         ::alloc::string::ToString::to_string(#fname),
                         ::alloc::vec![#(#pts),*],
                         ::hyperlight_common::flatbuffer_wrappers::function_types::ReturnType::VecBytes,
-                        #n::<T> as usize
+                        #n::<T>
                     )
                 );
             }

--- a/src/hyperlight_guest_bin/src/guest_function/call.rs
+++ b/src/hyperlight_guest_bin/src/guest_function/call.rs
@@ -27,8 +27,6 @@ use tracing::{Span, instrument};
 
 use crate::{GUEST_HANDLE, REGISTERED_GUEST_FUNCTIONS};
 
-type GuestFunc = fn(FunctionCall) -> Result<Vec<u8>>;
-
 #[instrument(skip_all, parent = Span::current(), level= "Trace")]
 pub(crate) fn call_guest_function(function_call: FunctionCall) -> Result<Vec<u8>> {
     // Validate this is a Guest Function Call
@@ -59,14 +57,10 @@ pub(crate) fn call_guest_function(function_call: FunctionCall) -> Result<Vec<u8>
         // Verify that the function call has the correct parameter types and length.
         registered_function_definition.verify_parameters(&function_call_parameter_types)?;
 
-        let p_function = unsafe {
-            let function_pointer = registered_function_definition.function_pointer;
-            core::mem::transmute::<usize, GuestFunc>(function_pointer)
-        };
-
-        p_function(function_call)
+        (registered_function_definition.function_pointer)(function_call)
     } else {
-        // The given function is not registered. The guest should implement a function called guest_dispatch_function to handle this.
+        // The given function is not registered. The guest should implement a function called
+        // guest_dispatch_function to handle this.
 
         // TODO: ideally we would define a default implementation of this with weak linkage so the guest is not required
         // to implement the function but its seems that weak linkage is an unstable feature so for now its probably better

--- a/src/hyperlight_guest_bin/src/guest_function/definition.rs
+++ b/src/hyperlight_guest_bin/src/guest_function/definition.rs
@@ -28,17 +28,23 @@ use hyperlight_common::func::{
 };
 use hyperlight_guest::error::{HyperlightGuestError, Result};
 
-/// The definition of a function exposed from the guest to the host
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct GuestFunctionDefinition {
+/// The function pointer type for Rust guest functions.
+pub type GuestFunc = fn(FunctionCall) -> Result<Vec<u8>>;
+
+/// The definition of a function exposed from the guest to the host.
+///
+/// The type parameter `F` is the function pointer type. For Rust guests this
+/// is [`GuestFunc`]; the C API uses its own `CGuestFunc` type.
+#[derive(Debug, Clone)]
+pub struct GuestFunctionDefinition<F: Copy> {
     /// The function name
     pub function_name: String,
     /// The type of the parameter values for the host function call.
     pub parameter_types: Vec<ParameterType>,
     /// The type of the return value from the host function call
     pub return_type: ReturnType,
-    /// The function pointer to the guest function
-    pub function_pointer: usize,
+    /// The function pointer to the guest function.
+    pub function_pointer: F,
 }
 
 /// Trait for functions that can be converted to a `fn(FunctionCall) -> Result<Vec<u8>>`
@@ -57,7 +63,7 @@ where
     fn into_guest_function(self) -> fn(FunctionCall) -> Result<Vec<u8>>;
 }
 
-/// Trait for functions that can be converted to a `GuestFunctionDefinition`
+/// Trait for functions that can be converted to a `GuestFunctionDefinition<GuestFunc>`
 pub trait AsGuestFunctionDefinition<Output, Args>
 where
     Self: Function<Output, Args, HyperlightGuestError>,
@@ -66,7 +72,10 @@ where
     Args: ParameterTuple,
 {
     /// Get the `GuestFunctionDefinition` for this function
-    fn as_guest_function_definition(&self, name: impl Into<String>) -> GuestFunctionDefinition;
+    fn as_guest_function_definition(
+        &self,
+        name: impl Into<String>,
+    ) -> GuestFunctionDefinition<GuestFunc>;
 }
 
 fn into_flatbuffer_result(value: ReturnValue) -> Vec<u8> {
@@ -147,11 +156,13 @@ where
     Args: ParameterTuple,
     Output: SupportedReturnType,
 {
-    fn as_guest_function_definition(&self, name: impl Into<String>) -> GuestFunctionDefinition {
+    fn as_guest_function_definition(
+        &self,
+        name: impl Into<String>,
+    ) -> GuestFunctionDefinition<GuestFunc> {
         let parameter_types = Args::TYPE.to_vec();
         let return_type = Output::TYPE;
         let function_pointer = self.into_guest_function();
-        let function_pointer = function_pointer as usize;
 
         GuestFunctionDefinition {
             function_name: name.into(),
@@ -164,13 +175,13 @@ where
 
 for_each_tuple!(impl_host_function);
 
-impl GuestFunctionDefinition {
+impl<F: Copy> GuestFunctionDefinition<F> {
     /// Create a new `GuestFunctionDefinition`.
     pub fn new(
         function_name: String,
         parameter_types: Vec<ParameterType>,
         return_type: ReturnType,
-        function_pointer: usize,
+        function_pointer: F,
     ) -> Self {
         Self {
             function_name,
@@ -180,12 +191,12 @@ impl GuestFunctionDefinition {
         }
     }
 
-    /// Create a new `GuestFunctionDefinition` from a function that implements
-    /// `AsGuestFunctionDefinition`.
+    /// Create a new `GuestFunctionDefinition<GuestFunc>` from a function that
+    /// implements `AsGuestFunctionDefinition`.
     pub fn from_fn<Output, Args>(
         function_name: String,
         function: impl AsGuestFunctionDefinition<Output, Args>,
-    ) -> Self
+    ) -> GuestFunctionDefinition<GuestFunc>
     where
         Args: ParameterTuple,
         Output: SupportedReturnType,

--- a/src/hyperlight_guest_bin/src/host_comm.rs
+++ b/src/hyperlight_guest_bin/src/host_comm.rs
@@ -80,12 +80,12 @@ pub fn read_n_bytes_from_user_memory(num: u64) -> Result<Vec<u8>> {
 ///
 /// This function requires memory to be setup to be used. In particular, the
 /// existence of the input and output memory regions.
-pub fn print_output_with_host_print(function_call: &FunctionCall) -> Result<Vec<u8>> {
+pub fn print_output_with_host_print(function_call: FunctionCall) -> Result<Vec<u8>> {
     let handle = unsafe { GUEST_HANDLE };
-    if let ParameterValue::String(message) = function_call.parameters.clone().unwrap()[0].clone() {
+    if let ParameterValue::String(message) = function_call.parameters.unwrap().remove(0) {
         let res = handle.call_host_function::<i32>(
             "HostPrint",
-            Some(Vec::from(&[ParameterValue::String(message.to_string())])),
+            Some(Vec::from(&[ParameterValue::String(message)])),
             ReturnType::Int,
         )?;
 

--- a/src/hyperlight_guest_bin/src/lib.rs
+++ b/src/hyperlight_guest_bin/src/lib.rs
@@ -116,7 +116,7 @@ pub(crate) static HEAP_ALLOCATOR: ProfiledLockedHeap<32> =
     ProfiledLockedHeap(LockedHeap::<32>::empty());
 
 pub static mut GUEST_HANDLE: GuestHandle = GuestHandle::new();
-pub(crate) static mut REGISTERED_GUEST_FUNCTIONS: GuestFunctionRegister =
+pub(crate) static mut REGISTERED_GUEST_FUNCTIONS: GuestFunctionRegister<GuestFunc> =
     GuestFunctionRegister::new();
 
 /// The size of one page in the host OS, which may have some impacts
@@ -278,3 +278,5 @@ pub mod __private {
 
 #[cfg(feature = "macros")]
 pub use hyperlight_guest_macro::{guest_function, host_function};
+
+pub use crate::guest_function::definition::GuestFunc;

--- a/src/hyperlight_guest_capi/src/dispatch.rs
+++ b/src/hyperlight_guest_capi/src/dispatch.rs
@@ -18,7 +18,6 @@ use alloc::boxed::Box;
 use alloc::slice;
 use alloc::vec::Vec;
 use core::ffi::{CStr, c_char};
-use core::mem;
 
 use hyperlight_common::flatbuffer_wrappers::function_call::FunctionCall;
 use hyperlight_common::flatbuffer_wrappers::function_types::{ParameterType, ReturnType};
@@ -29,7 +28,8 @@ use hyperlight_guest_bin::guest_function::register::GuestFunctionRegister;
 use hyperlight_guest_bin::host_comm::call_host_function_without_returning_result;
 
 use crate::types::{FfiFunctionCall, FfiVec};
-static mut REGISTERED_C_GUEST_FUNCTIONS: GuestFunctionRegister = GuestFunctionRegister::new();
+static mut REGISTERED_C_GUEST_FUNCTIONS: GuestFunctionRegister<CGuestFunc> =
+    GuestFunctionRegister::new();
 
 type CGuestFunc = extern "C" fn(&FfiFunctionCall) -> Box<FfiVec>;
 
@@ -55,10 +55,7 @@ pub fn guest_dispatch_function(function_call: FunctionCall) -> Result<Vec<u8>> {
         registered_func.verify_parameters(&function_call_parameter_types)?;
 
         let ffi_func_call = FfiFunctionCall::from_function_call(function_call)?;
-
-        let guest_func =
-            unsafe { mem::transmute::<usize, CGuestFunc>(registered_func.function_pointer) };
-        let function_result = guest_func(&ffi_func_call);
+        let function_result = (registered_func.function_pointer)(&ffi_func_call);
 
         unsafe { Ok(FfiVec::into_vec(*function_result)) }
     } else {
@@ -94,8 +91,7 @@ pub extern "C" fn hl_register_function_definition(
 
     let func_params = unsafe { slice::from_raw_parts(params_type, param_no).to_vec() };
 
-    let func_def =
-        GuestFunctionDefinition::new(func_name, func_params, return_type, func_ptr as usize);
+    let func_def = GuestFunctionDefinition::new(func_name, func_params, return_type, func_ptr);
 
     // Use &raw mut to get a mutable raw pointer, then dereference it
     // this is to avoid the clippy warning "shared reference to mutable static"

--- a/src/tests/rust_guests/simpleguest/src/main.rs
+++ b/src/tests/rust_guests/simpleguest/src/main.rs
@@ -44,7 +44,7 @@ use hyperlight_common::flatbuffer_wrappers::util::get_flatbuffer_result;
 use hyperlight_guest::error::{HyperlightGuestError, Result};
 use hyperlight_guest::exit::{abort_with_code, abort_with_code_and_message};
 use hyperlight_guest_bin::exception::arch::{Context, ExceptionInfo};
-use hyperlight_guest_bin::guest_function::definition::GuestFunctionDefinition;
+use hyperlight_guest_bin::guest_function::definition::{GuestFunc, GuestFunctionDefinition};
 use hyperlight_guest_bin::guest_function::register::register_function;
 use hyperlight_guest_bin::host_comm::{
     call_host_function, call_host_function_without_returning_result, get_host_return_value_raw,
@@ -652,11 +652,11 @@ fn call_host_expect_error(hostfuncname: String) -> Result<()> {
 #[no_mangle]
 #[instrument(skip_all, parent = Span::current(), level= "Trace")]
 pub extern "C" fn hyperlight_main() {
-    let print_output_def = GuestFunctionDefinition::new(
+    let print_output_def = GuestFunctionDefinition::<GuestFunc>::new(
         "PrintOutputWithHostPrint".to_string(),
         Vec::from(&[ParameterType::String]),
         ReturnType::Int,
-        print_output_with_host_print as usize,
+        print_output_with_host_print,
     );
     register_function(print_output_def);
 }


### PR DESCRIPTION
vs main:
<img width="800" height="90" alt="image" src="https://github.com/user-attachments/assets/1ee80c72-f598-4061-b26a-7a5183768632" />

Only affects registered guest functions (not c api, nor when someone implements their own `guest_dispatch_function`).

GuestFunctionDefinition was made generic to be able to contain both GuestFunc and CGuestFunc (for use with c-api), also removes some unsafe code and adds some type-safety