### PR TITLE
refactor: remove dead guest stackoverflow reporting code

### DIFF
--- a/src/hyperlight_host/src/error.rs
+++ b/src/hyperlight_host/src/error.rs
@@ -229,10 +229,6 @@ pub enum HyperlightError {
     #[error("Snapshot Size Mismatch: Memory Size {0:?} Snapshot Size {1:?}")]
     SnapshotSizeMismatch(usize, usize),
 
-    /// Stack overflow detected in guest
-    #[error("Stack overflow detected")]
-    StackOverflow(),
-
     /// Tried to restore snapshot to a sandbox that is not the same as the one the snapshot was taken from
     #[error("Snapshot was taken from a different sandbox")]
     SnapshotSandboxMismatch,
@@ -323,7 +319,6 @@ impl HyperlightError {
             | HyperlightError::ExecutionCanceledByHost()
             | HyperlightError::PoisonedSandbox
             | HyperlightError::ExecutionAccessViolation(_)
-            | HyperlightError::StackOverflow()
             | HyperlightError::MemoryAccessViolation(_, _, _)
             | HyperlightError::SnapshotSizeMismatch(_, _)
             | HyperlightError::MemoryRegionSizeMismatch(_, _, _)

--- a/src/hyperlight_host/tests/integration_test.rs
+++ b/src/hyperlight_host/tests/integration_test.rs
@@ -592,10 +592,6 @@ fn guest_panic_no_alloc() {
             )
             .unwrap_err();
 
-        if let HyperlightError::StackOverflow() = res {
-            panic!("panic on OOM caused stack overflow, this implies allocation in panic handler");
-        }
-
         assert!(
             matches!(
                 &res,


### PR DESCRIPTION
The guest self-reporting stackoverflow mechanism is dead code.

Closes #1161