### PR TITLE
fix: use app-slug output instead of /app API in dependabot workflow

### DIFF
--- a/.github/workflows/ValidatePullRequest.yml
+++ b/.github/workflows/ValidatePullRequest.yml
@@ -15,6 +15,7 @@ concurrency:
 
 permissions:
   contents: write
+  pull-requests: read
 
 jobs:
   docs-pr:
@@ -40,9 +41,24 @@ jobs:
             return all_file_count === docs_file_count;
           result-encoding: string
 
+  # Update guest Cargo.lock files for Dependabot PRs.
+  # Dependabot only updates the root Cargo.lock, leaving the guest crate
+  # Cargo.lock files stale. This job updates them before code-checks runs
+  # `cargo fetch --locked` so that the first CI run succeeds.
+  update-guest-locks:
+    if: >-
+      github.event.pull_request.user.login == 'dependabot[bot]' &&
+      github.actor == 'dependabot[bot]'
+    uses: ./.github/workflows/dep_update_guest_locks.yml
+    secrets: inherit
+
   # Build guests once, upload as artifacts for other jobs to download
   build-guests:
-    needs: docs-pr
+    needs: [docs-pr, update-guest-locks]
+    # Required because update-guest-locks is skipped on non-dependabot PRs,
+    # and a skipped dependency transitively skips all downstream jobs.
+    # See: https://github.com/actions/runner/issues/2205
+    if: ${{ !cancelled() && !failure() }}
     strategy:
       fail-fast: true
       matrix:
@@ -55,7 +71,11 @@ jobs:
 
   # Code checks (fmt, clippy, MSRV) - runs in parallel with build-guests
   code-checks:
-    needs: docs-pr
+    needs: [docs-pr, update-guest-locks]
+    # Required because update-guest-locks is skipped on non-dependabot PRs,
+    # and a skipped dependency transitively skips all downstream jobs.
+    # See: https://github.com/actions/runner/issues/2205
+    if: ${{ !cancelled() && !failure() }}
     uses: ./.github/workflows/dep_code_checks.yml
     secrets: inherit
     with:
@@ -66,6 +86,10 @@ jobs:
     needs:
       - docs-pr
       - build-guests
+    # Required because update-guest-locks is skipped on non-dependabot PRs,
+    # and a skipped dependency transitively skips all downstream jobs.
+    # See: https://github.com/actions/runner/issues/2205
+    if: ${{ !cancelled() && !failure() }}
     strategy:
       fail-fast: true
       matrix:
@@ -85,6 +109,10 @@ jobs:
     needs:
       - docs-pr
       - build-guests
+    # Required because update-guest-locks is skipped on non-dependabot PRs,
+    # and a skipped dependency transitively skips all downstream jobs.
+    # See: https://github.com/actions/runner/issues/2205
+    if: ${{ !cancelled() && !failure() }}
     strategy:
       fail-fast: true
       matrix:
@@ -104,6 +132,10 @@ jobs:
     needs:
       - docs-pr
       - build-guests
+    # Required because update-guest-locks is skipped on non-dependabot PRs,
+    # and a skipped dependency transitively skips all downstream jobs.
+    # See: https://github.com/actions/runner/issues/2205
+    if: ${{ !cancelled() && !failure() }}
     strategy:
       fail-fast: true
       matrix:
@@ -120,6 +152,10 @@ jobs:
     needs:
       - docs-pr
       - build-guests
+    # Required because update-guest-locks is skipped on non-dependabot PRs,
+    # and a skipped dependency transitively skips all downstream jobs.
+    # See: https://github.com/actions/runner/issues/2205
+    if: ${{ !cancelled() && !failure() }}
     uses: ./.github/workflows/dep_fuzzing.yml
     with:
       targets: '["fuzz_host_print", "fuzz_guest_call", "fuzz_host_call", "fuzz_guest_estimate_trace_event", "fuzz_guest_trace"]' # Pass as a JSON array
@@ -148,6 +184,7 @@ jobs:
   report-ci-status:
     needs:
       - docs-pr
+      - update-guest-locks
       - build-guests
       - code-checks
       - build-test

--- a/.github/workflows/dep_update_guest_locks.yml
+++ b/.github/workflows/dep_update_guest_locks.yml
@@ -1,4 +1,6 @@
-# This workflow automatically updates the Cargo.lock files in guest crates when
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+
+# This reusable workflow updates the Cargo.lock files in guest crates when
 # Dependabot updates dependencies. Without this, Dependabot PRs only update the
 # root Cargo.lock, leaving the guest crate Cargo.lock files stale.
 #
@@ -7,24 +9,21 @@
 name: Update Guest Cargo.lock for Dependabot PRs
 
 on:
-  pull_request:
-    branches: [main]
-    paths:
-      - 'Cargo.toml'
-      - 'Cargo.lock'
-      - 'src/hyperlight_*/Cargo.toml'
-
-permissions:
-  contents: read       # Required for actions/checkout to clone the repo
-  pull-requests: read  # Required for dependabot/fetch-metadata to read PR info
+  workflow_call:
 
 env:
   CARGO_TERM_COLOR: always
 
+permissions:
+  contents: read
+  pull-requests: read
+
+defaults:
+  run:
+    shell: bash
+
 jobs:
   update-guest-locks:
-    # Only run for Dependabot PRs - check the PR author, not the actor
-    if: github.event.pull_request.user.login == 'dependabot[bot]'
     runs-on: [self-hosted, Linux, X64, "1ES.Pool=hld-kvm-amd"]
     timeout-minutes: 15
     steps:
@@ -109,6 +108,7 @@ jobs:
         if: steps.check-ecosystem.outputs.is_cargo == 'true'
         env:
           GH_TOKEN: ${{ steps.get-app-token.outputs.token }}
+          APP_SLUG: ${{ steps.get-app-token.outputs.app-slug }}
           DEPENDENCY_NAMES: ${{ steps.metadata.outputs.dependency-names }}
           BRANCH: ${{ github.head_ref }}
           REPO: ${{ github.repository }}
@@ -124,7 +124,9 @@ jobs:
           echo "Guest Cargo.lock files have changed, committing via API..."
 
           # Get app identity for DCO sign-off trailer
-          app_slug=$(gh api /app --jq .slug)
+          # Use the app-slug output from create-github-app-token (the /app API
+          # endpoint requires JWT auth, not an installation token).
+          app_slug="${APP_SLUG}"
           app_user_id=$(gh api "/users/${app_slug}[bot]" --jq .id)
 
           # Get current branch HEAD and its tree

--- a/src/tests/rust_guests/dummyguest/Cargo.lock
+++ b/src/tests/rust_guests/dummyguest/Cargo.lock
@@ -4,9 +4,9 @@ version = 4
 
 [[package]]
 name = "anyhow"
-version = "1.0.101"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "autocfg"

--- a/src/tests/rust_guests/simpleguest/Cargo.lock
+++ b/src/tests/rust_guests/simpleguest/Cargo.lock
@@ -4,9 +4,9 @@ version = 4
 
 [[package]]
 name = "anyhow"
-version = "1.0.101"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "bitflags"

--- a/src/tests/rust_guests/witguest/Cargo.lock
+++ b/src/tests/rust_guests/witguest/Cargo.lock
@@ -63,9 +63,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.101"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "bitflags"
@@ -213,11 +213,11 @@ name = "hyperlight-component-util"
 version = "0.12.0"
 dependencies = [
  "itertools",
- "log",
  "prettyplease",
  "proc-macro2",
  "quote",
  "syn",
+ "tracing",
  "wasmparser",
 ]
 
@@ -369,6 +369,12 @@ name = "memchr"
 version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+
+[[package]]
+name = "once_cell"
+version = "1.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -543,9 +549,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.114"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4d107df263a3013ef9b1879b0df87d706ff80f65a86ea879bd9c31f9b307c2a"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -608,6 +614,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -629,6 +636,9 @@ name = "tracing-core"
 version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+]
 
 [[package]]
 name = "unicode-ident"


### PR DESCRIPTION
The /app endpoint requires JWT auth but GH_TOKEN is an installation token, causing HTTP 401. Use the app-slug output from create-github-app-token instead. It's an output, see https://github.com/actions/create-github-app-token#outputs

follow up to https://github.com/hyperlight-dev/hyperlight/pull/1197