### PR TITLE
Remove mshv restrictions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,12 +14,6 @@ updates:
       time: "03:00"
     labels:
       - "kind/dependencies"
-    ignore:
-    # The way we are using 2 different versions of the mshv crates seems to break dependabot
-      - dependency-name: "mshv-ioctls"
-        versions: [ ">=0.2.1" ]
-      - dependency-name: "mshv-bindings"
-        versions: [ ">=0.2.1" ]
     open-pull-requests-limit: 20
   - package-ecosystem: "cargo"
     directory: "/src/tests/rust_guests/dummyguest"


### PR DESCRIPTION
This pull request makes a minor update to the `.github/dependabot.yml` configuration. The change removes the `ignore` rules for two dependencies, which previously prevented Dependabot from updating them as this is no longer needed,