### PR TITLE
feat: use i686 layout for nanvix-unstable guests and make snapshot RWX

### DIFF
--- a/src/hyperlight_common/src/arch/i686/layout.rs
+++ b/src/hyperlight_common/src/arch/i686/layout.rs
@@ -17,11 +17,9 @@ limitations under the License.
 // This file is just dummy definitions at the moment, in order to
 // allow compiling the guest for real mode boot scenarios.
 
-pub const MAX_GVA: usize = 0xffff_efff;
-pub const SNAPSHOT_PT_GVA_MIN: usize = 0xef00_0000;
-pub const SNAPSHOT_PT_GVA_MAX: usize = 0xefff_efff;
+pub const MAX_GVA: usize = 0xffff_ffff;
 pub const MAX_GPA: usize = 0xffff_ffff;
 
-pub fn min_scratch_size() -> usize {
-    1 * crate::vmem::PAGE_SIZE
+pub fn min_scratch_size(_input_data_size: usize, _output_data_size: usize) -> usize {
+    crate::vmem::PAGE_SIZE
 }

--- a/src/hyperlight_common/src/layout.rs
+++ b/src/hyperlight_common/src/layout.rs
@@ -14,11 +14,20 @@ See the License for the specific language governing permissions and
 limitations under the License.
  */
 
-#[cfg_attr(target_arch = "x86_64", path = "arch/amd64/layout.rs")]
 #[cfg_attr(target_arch = "x86", path = "arch/i686/layout.rs")]
+#[cfg_attr(
+    all(target_arch = "x86_64", not(feature = "nanvix-unstable")),
+    path = "arch/amd64/layout.rs"
+)]
+#[cfg_attr(
+    all(target_arch = "x86_64", feature = "nanvix-unstable"),
+    path = "arch/i686/layout.rs"
+)]
 mod arch;
 
-pub use arch::{MAX_GPA, MAX_GVA, SNAPSHOT_PT_GVA_MAX, SNAPSHOT_PT_GVA_MIN};
+pub use arch::{MAX_GPA, MAX_GVA};
+#[cfg(all(target_arch = "x86_64", not(feature = "nanvix-unstable")))]
+pub use arch::{SNAPSHOT_PT_GVA_MAX, SNAPSHOT_PT_GVA_MIN};
 
 // offsets down from the top of scratch memory for various things
 pub const SCRATCH_TOP_SIZE_OFFSET: u64 = 0x08;

--- a/src/hyperlight_host/Cargo.toml
+++ b/src/hyperlight_host/Cargo.toml
@@ -137,7 +137,7 @@ mshv3 = ["dep:mshv-bindings", "dep:mshv-ioctls"]
 gdb = ["dep:gdbstub", "dep:gdbstub_arch"]
 fuzzing = ["hyperlight-common/fuzzing"]
 build-metadata = ["dep:built"]
-nanvix-unstable = []
+nanvix-unstable = ["hyperlight-common/nanvix-unstable"]
 
 [[bench]]
 name = "benchmarks"

--- a/src/hyperlight_host/src/mem/shared_mem.rs
+++ b/src/hyperlight_host/src/mem/shared_mem.rs
@@ -679,7 +679,22 @@ impl GuestSharedMemory {
             MemoryRegionType::Scratch => {
                 MemoryRegionFlags::READ | MemoryRegionFlags::WRITE | MemoryRegionFlags::EXECUTE
             }
-            MemoryRegionType::Snapshot => MemoryRegionFlags::READ | MemoryRegionFlags::EXECUTE,
+            // Without nanvix-unstable (default), the snapshot is read-only
+            // because guest page tables provide CoW semantics for writable
+            // pages.  With nanvix-unstable there are no guest page tables,
+            // so the snapshot must be writable — otherwise writes (including
+            // the CPU setting the "Accessed" bit in GDT descriptors during
+            // segment loads) cause EPT violations that KVM retries forever.
+            MemoryRegionType::Snapshot => {
+                #[cfg(not(feature = "nanvix-unstable"))]
+                {
+                    MemoryRegionFlags::READ | MemoryRegionFlags::EXECUTE
+                }
+                #[cfg(feature = "nanvix-unstable")]
+                {
+                    MemoryRegionFlags::READ | MemoryRegionFlags::WRITE | MemoryRegionFlags::EXECUTE
+                }
+            }
             #[allow(clippy::panic)]
             // In the future, all the host side knowledge about memory
             // region types should collapse down to Snapshot vs

--- a/src/hyperlight_host/src/sandbox/snapshot.rs
+++ b/src/hyperlight_host/src/sandbox/snapshot.rs
@@ -265,6 +265,7 @@ fn filtered_mappings<'a>(
             return None;
         }
         // neither does the mapping of the snapshot's own page tables
+        #[cfg(not(feature = "nanvix-unstable"))]
         if mapping.virt_base >= hyperlight_common::layout::SNAPSHOT_PT_GVA_MIN as u64
             && mapping.virt_base <= hyperlight_common::layout::SNAPSHOT_PT_GVA_MAX as u64
         {


### PR DESCRIPTION
## Summary

When `nanvix-unstable` is enabled, selects the i686 hyperlight-common memory layout on x86_64 hosts and makes the snapshot memory region writable. Also propagates the `nanvix-unstable` feature from `hyperlight-host` to `hyperlight-common` so both crates share the same cfg gates.

## Motivation

Nanvix runs as a 32-bit (i386) guest without CoW guest paging. Two things need to change for this to work:

1. **i686 layout**: The amd64 layout defines `MAX_GPA`/`MAX_GVA` for a 36-bit/48-bit address space and includes `SNAPSHOT_PT_GVA_*` constants for the CoW page table region. A 32-bit guest needs 32-bit address limits (`0xFFFF_FFFF`) and has no snapshot page tables. With `nanvix-unstable`, the i686 layout module is used even on x86_64 hosts.

2. **Snapshot RWX**: Without CoW, the guest writes directly to snapshot pages — `.data`, `.bss`, kernel page pool, and even GDT descriptors (the CPU sets the "Accessed" bit during segment loads). If the snapshot isn't writable, these writes cause EPT violations that KVM retries forever.

## Changes

- `hyperlight_host/Cargo.toml`: `nanvix-unstable = ["hyperlight-common/nanvix-unstable"]` — propagates the feature
- `hyperlight_common/src/layout.rs`: Three-way `cfg_attr` selects i686 layout for native x86 OR x86_64 with `nanvix-unstable`; gates `SNAPSHOT_PT_GVA_*` exports behind `all(target_arch = "x86_64", not(nanvix-unstable))`
- `hyperlight_common/src/arch/i686/layout.rs`: Removes stale `SNAPSHOT_PT_GVA_*` constants and fixes `MAX_GVA` to `0xFFFF_FFFF`; updates `min_scratch_size` signature to match the amd64 layout
- `hyperlight_host/src/mem/shared_mem.rs`: Snapshot region is `READ | EXECUTE` by default (CoW handles writes), `READ | WRITE | EXECUTE` with `nanvix-unstable`
- `hyperlight_host/src/sandbox/snapshot.rs`: Gates the snapshot page-table GVA filter behind `not(nanvix-unstable)`