### PR TITLE
Make map_region public

### DIFF
--- a/src/hyperlight_host/src/mem/memory_region.rs
+++ b/src/hyperlight_host/src/mem/memory_region.rs
@@ -133,7 +133,7 @@ pub enum MemoryRegionType {
 /// A trait that distinguishes between different kinds of memory region representations.
 ///
 /// This trait is used to parameterize [`MemoryRegion_`]
-pub(crate) trait MemoryRegionKind {
+pub trait MemoryRegionKind {
     /// The type used to represent host memory addresses.
     type HostBaseType: Copy;
 
@@ -152,7 +152,7 @@ pub(crate) trait MemoryRegionKind {
 /// Type for memory regions that track both host and guest addresses.
 ///
 #[derive(Debug, PartialEq, Eq, Copy, Clone, Hash)]
-pub(crate) struct HostGuestMemoryRegion {}
+pub struct HostGuestMemoryRegion {}
 
 #[cfg(not(target_os = "windows"))]
 impl MemoryRegionKind for HostGuestMemoryRegion {
@@ -233,7 +233,7 @@ impl MemoryRegionKind for GuestMemoryRegion {
 /// represents a single memory region inside the guest. All memory within a region has
 /// the same memory permissions
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub(crate) struct MemoryRegion_<K: MemoryRegionKind> {
+pub struct MemoryRegion_<K: MemoryRegionKind> {
     /// the range of guest memory addresses
     pub guest_region: Range<usize>,
     /// the range of host memory addresses
@@ -246,7 +246,8 @@ pub(crate) struct MemoryRegion_<K: MemoryRegionKind> {
     pub region_type: MemoryRegionType,
 }
 
-pub(crate) type MemoryRegion = MemoryRegion_<HostGuestMemoryRegion>;
+/// A memory region that tracks both host and guest addresses.
+pub type MemoryRegion = MemoryRegion_<HostGuestMemoryRegion>;
 
 /// A [`MemoryRegionKind`] for crash dump regions that always uses raw
 /// `usize` host addresses.  The crash dump path only reads host memory

--- a/src/hyperlight_host/src/sandbox/initialized_multi_use.rs
+++ b/src/hyperlight_host/src/sandbox/initialized_multi_use.rs
@@ -527,7 +527,7 @@ impl MultiUseSandbox {
     /// for the lifetime of `self`.
     #[instrument(err(Debug), skip(self, rgn), parent = Span::current())]
     #[cfg(target_os = "linux")]
-    unsafe fn map_region(&mut self, rgn: &MemoryRegion) -> Result<()> {
+    pub unsafe fn map_region(&mut self, rgn: &MemoryRegion) -> Result<()> {
         if self.poisoned {
             return Err(crate::HyperlightError::PoisonedSandbox);
         }


### PR DESCRIPTION
Hyperlight-wasm requires this for memory mapping in the components.  This was removed during an early iteration where this did not work but now that CoW has been released this can be exposed again for use in HL-wasm


hyperlight-dev/hyperlight#1293