### PR TITLE
ci: add nanvix-unstable compile checks to CI and Justfile

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -261,6 +261,7 @@ test-rust-tracing target=default-target features="":
 check-i686 target=default-target:
     cargo check -p hyperlight-common --target i686-unknown-linux-gnu --profile={{ if target == "debug" { "dev" } else { target } }}
     cargo check -p hyperlight-guest --target i686-unknown-linux-gnu --profile={{ if target == "debug" { "dev" } else { target } }}
+    cargo check -p hyperlight-common --target i686-unknown-linux-gnu --features nanvix-unstable --profile={{ if target == "debug" { "dev" } else { target } }}
     # Verify that trace_guest correctly fails on i686 (compile_error should trigger)
     ! cargo check -p hyperlight-guest --target i686-unknown-linux-gnu --features trace_guest --profile={{ if target == "debug" { "dev" } else { target } }} 2>/dev/null
 
@@ -283,6 +284,8 @@ check:
     {{ cargo-cmd }} check -p hyperlight-host --features print_debug  {{ target-triple-flag }}
     {{ cargo-cmd }} check -p hyperlight-host --features gdb  {{ target-triple-flag }}
     {{ cargo-cmd }} check -p hyperlight-host --features trace_guest,mem_profile  {{ target-triple-flag }}
+    {{ cargo-cmd }} check -p hyperlight-host --features nanvix-unstable  {{ target-triple-flag }}
+    {{ cargo-cmd }} check -p hyperlight-host --features nanvix-unstable,executable_heap  {{ target-triple-flag }}
 
 fmt-check:
     rustup +nightly component list | grep -q "rustfmt.*installed" || rustup component add rustfmt --toolchain nightly


### PR DESCRIPTION
## Summary

Adds compile-time CI coverage for the `nanvix-unstable` feature flag introduced in #1291 to catch regressions on the non-CoW code path.

Only compile checks are added — not test runs — because the standard Hyperlight test guests require CoW paging, which is disabled under `nanvix-unstable`.

## Changes

- `Justfile` `check`: verify `nanvix-unstable` and `nanvix-unstable,executable_heap` compile on the host
- `Justfile` `check-i686`: verify `hyperlight-common` builds for i686 with `nanvix-unstable` enabled

The `check` recipe is already invoked by both `test-like-ci` and `code-checks-like-ci`, so these checks run automatically in CI without needing a new workflow step.