### PR TITLE
fix: wrong flag passed to get_memory_access_violation on VmExit::MmioRead

### DIFF
--- a/src/hyperlight_host/src/hypervisor/hyperlight_vm.rs
+++ b/src/hyperlight_host/src/hypervisor/hyperlight_vm.rs
@@ -897,7 +897,7 @@ impl HyperlightVm {
                     let all_regions = self.get_mapped_regions();
                     match get_memory_access_violation(
                         addr as usize,
-                        MemoryRegionFlags::WRITE,
+                        MemoryRegionFlags::READ,
                         all_regions,
                     ) {
                         Some(MemoryAccess::AccessViolation(region_flags)) => {


### PR DESCRIPTION
The bug just manifests as incorrect error message, nothing too important. I don't think adding tests for this particular code path is worth it either.