### PR TITLE
Re-export host function types through hyperlight_host

### DIFF
--- a/src/hyperlight_host/src/func/mod.rs
+++ b/src/hyperlight_host/src/func/mod.rs
@@ -29,12 +29,18 @@ pub(crate) mod host_functions;
 
 /// Re-export for `HostFunction` trait
 pub use host_functions::{HostFunction, Registerable};
+/// Re-export for `ParameterType` enum
+pub use hyperlight_common::flatbuffer_wrappers::function_types::ParameterType;
 /// Re-export for `ParameterValue` enum
 pub use hyperlight_common::flatbuffer_wrappers::function_types::ParameterValue;
 /// Re-export for `ReturnType` enum
 pub use hyperlight_common::flatbuffer_wrappers::function_types::ReturnType;
 /// Re-export for `ReturnValue` enum
 pub use hyperlight_common::flatbuffer_wrappers::function_types::ReturnValue;
+/// Re-export for `HostFunctionDefinition`
+pub use hyperlight_common::flatbuffer_wrappers::host_function_definition::HostFunctionDefinition;
+/// Re-export for `HostFunctionDetails`
+pub use hyperlight_common::flatbuffer_wrappers::host_function_details::HostFunctionDetails;
 pub use hyperlight_common::func::{
     ParameterTuple, ResultType, SupportedParameterType, SupportedReturnType,
 };


### PR DESCRIPTION
fixes: #1286

Host function definition types (HostFunctionDefinition, HostFunctionDetails, ParameterType) are currently only accessible via hyperlight_common, even though they primarily serve the host-side API. This makes it awkward for downstream consumers (e.g., hyperlight-wasm, hyperlight-js) that need to import these types alongside other host constructs.

Signed-off-by: James Sturtevant <jsturtevant@gmail.com>