### PR TITLE
fix: host_bindgen! returns Result instead of panicking on guest errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Fixed
 * Fix symbol resolution in guest core dumps for sandboxes created from snapshots by @ludfjig in https://github.com/hyperlight-dev/hyperlight/pull/1618
 * Reject malformed OCI snapshot metadata and non-regular artifact files during load.
+* Return guest call failures from `host_bindgen!` functions as `HyperlightError` values.
 
 ## [v0.16.0] - 2026-06-26
 

--- a/src/hyperlight_component_util/src/emit.rs
+++ b/src/hyperlight_component_util/src/emit.rs
@@ -149,6 +149,10 @@ pub struct Trait {
     pub tvs: BTreeMap<Ident, (Option<u32>, TokenStream)>,
     /// Raw tokens of the contents of the trait
     pub items: TokenStream,
+    /// Trait items keyed by their WIT names. A resource can be reached
+    /// more than once, e.g. via both the import-side and the export-side
+    /// trait of an instance, and its trait is shared.
+    pub extern_decls: BTreeMap<String, TokenStream>,
 }
 impl Trait {
     pub fn new() -> Self {
@@ -156,6 +160,7 @@ impl Trait {
             supertraits: BTreeMap::new(),
             tvs: BTreeMap::new(),
             items: TokenStream::new(),
+            extern_decls: BTreeMap::new(),
         }
     }
     /// Collect the component tyvar indices that correspond to the
@@ -217,8 +222,9 @@ impl Trait {
             .collect::<Vec<_>>();
         let tvs = self.tv_toks();
         let items = &self.items;
+        let extern_decls = self.extern_decls.values();
         quote! {
-            pub trait #n #tvs #trait_colon #(#supertraits)+* { #items }
+            pub trait #n #tvs #trait_colon #(#supertraits)+* { #items #(#extern_decls)* }
         }
     }
 }
@@ -230,18 +236,21 @@ impl Trait {
 pub struct Mod {
     pub submods: BTreeMap<Ident, Mod>,
     pub items: TokenStream,
+    /// Definitions keyed by their WIT names. An instance can be reached
+    /// more than once, e.g. as both an import and an export of a component,
+    /// and its helper module is shared.
+    pub extern_decls: BTreeMap<String, TokenStream>,
     pub traits: BTreeMap<Ident, Trait>,
     pub impls: BTreeMap<(Vec<Ident>, Ident), TokenStream>,
-    pub emitted_type_names: BTreeSet<Ident>,
 }
 impl Mod {
     pub fn empty() -> Self {
         Self {
             submods: BTreeMap::new(),
             items: TokenStream::new(),
+            extern_decls: BTreeMap::new(),
             traits: BTreeMap::new(),
             impls: BTreeMap::new(),
-            emitted_type_names: BTreeSet::new(),
         }
     }
     /// Get a reference to a sub-module, creating it if necessary
@@ -295,6 +304,9 @@ impl Mod {
         }
         for (n, mut t) in self.traits {
             tt.extend(t.into_tokens(n));
+        }
+        for (_, decl) in self.extern_decls {
+            tt.extend(decl);
         }
         tt.extend(self.items);
         for ((ns, i), t) in self.impls {

--- a/src/hyperlight_component_util/src/emit.rs
+++ b/src/hyperlight_component_util/src/emit.rs
@@ -232,6 +232,7 @@ pub struct Mod {
     pub items: TokenStream,
     pub traits: BTreeMap<Ident, Trait>,
     pub impls: BTreeMap<(Vec<Ident>, Ident), TokenStream>,
+    pub emitted_type_names: BTreeSet<Ident>,
 }
 impl Mod {
     pub fn empty() -> Self {
@@ -240,6 +241,7 @@ impl Mod {
             items: TokenStream::new(),
             traits: BTreeMap::new(),
             impls: BTreeMap::new(),
+            emitted_type_names: BTreeSet::new(),
         }
     }
     /// Get a reference to a sub-module, creating it if necessary

--- a/src/hyperlight_component_util/src/host.rs
+++ b/src/hyperlight_component_util/src/host.rs
@@ -47,6 +47,7 @@ fn emit_export_extern_decl<'a, 'b, 'c>(
                         .map(|p| rtypes::emit_func_param(s, p))
                         .collect::<Vec<_>>();
                     let result_decl = rtypes::emit_func_result(s, &ft.result);
+                    let result_decl = quote! { ::std::result::Result<#result_decl, ::hyperlight_host::error::HyperlightError> };
                     let hln = emit_fn_hl_name(s, ed.kebab_name);
                     let ret = format_ident!("ret");
                     let marshal = ft
@@ -67,11 +68,11 @@ fn emit_export_extern_decl<'a, 'b, 'c>(
                                 #hln,
                                 marshalled,
                             );
-                            let ::std::result::Result::Ok(#ret) = #ret else { panic!("bad return from guest {:?}", #ret) };
+                            let #ret = #ret?;
                             #[allow(clippy::unused_unit)]
                             let mut rts = self.rt.lock().unwrap();
                             #[allow(clippy::unused_unit)]
-                            #unmarshal
+                            Ok(#unmarshal)
                         }
                     }
                 }
@@ -122,7 +123,7 @@ fn emit_export_instance<'a, 'b, 'c>(s: &'c mut State<'a, 'b>, wn: WitName, it: &
 
     let ns = wn.namespace_path();
     let nsi = wn.namespace_idents();
-    let trait_name = kebab_to_type(wn.name);
+    let trait_name = kebab_to_exports_name(wn.name);
     let r#trait = s.r#trait(&nsi, trait_name.clone());
     let tvs = r#trait
         .tvs

--- a/src/hyperlight_component_util/src/host.rs
+++ b/src/hyperlight_component_util/src/host.rs
@@ -47,7 +47,6 @@ fn emit_export_extern_decl<'a, 'b, 'c>(
                         .map(|p| rtypes::emit_func_param(s, p))
                         .collect::<Vec<_>>();
                     let result_decl = rtypes::emit_func_result(s, &ft.result);
-                    let result_decl = quote! { ::std::result::Result<#result_decl, ::hyperlight_host::error::HyperlightError> };
                     let hln = emit_fn_hl_name(s, ed.kebab_name);
                     let ret = format_ident!("ret");
                     let marshal = ft
@@ -60,17 +59,16 @@ fn emit_export_extern_decl<'a, 'b, 'c>(
                         fn #n(&mut self, #(#param_decls),*) -> #result_decl {
                             let mut to_cleanup = Vec::<Box<dyn Drop>>::new();
                             let marshalled = {
-                                let mut rts = self.rt.lock().unwrap();
+                                let mut rts = self.rt.lock()?;
                                 #[allow(clippy::unused_unit)]
                                 (#(#marshal,)*)
                             };
                             let #ret = ::hyperlight_host::sandbox::Callable::call::<::std::vec::Vec::<u8>>(&mut self.sb,
                                 #hln,
                                 marshalled,
-                            );
-                            let #ret = #ret?;
+                            )?;
                             #[allow(clippy::unused_unit)]
-                            let mut rts = self.rt.lock().unwrap();
+                            let mut rts = self.rt.lock()?;
                             #[allow(clippy::unused_unit)]
                             Ok(#unmarshal)
                         }
@@ -167,7 +165,7 @@ impl SelfInfo {
             orig_id,
             type_id: vec![format_ident!("I")],
             inner_preamble: quote! {
-                let mut #inner_id = #outer_id.lock().unwrap();
+                let mut #inner_id = #outer_id.lock()?;
                 let mut #inner_id = ::std::ops::DerefMut::deref_mut(&mut #inner_id);
             },
             outer_id,
@@ -246,7 +244,7 @@ fn emit_import_extern_decl<'a, 'b, 'c>(
                 let #outer_id = #orig_id.clone();
                 let captured_rts = rts.clone();
                 sb.register_host_function(#hln, move |#(#pds),*| {
-                    let mut rts = captured_rts.lock().unwrap();
+                    let mut rts = captured_rts.lock()?;
                     #inner_preamble
                     let #ret = #callname(
                         ::std::borrow::BorrowMut::<#(#type_id)::*>::borrow_mut(

--- a/src/hyperlight_component_util/src/resource.rs
+++ b/src/hyperlight_component_util/src/resource.rs
@@ -99,7 +99,7 @@ pub fn emit_tables<'a, 'b, 'c>(
             #sphantom
         }
         impl<I: #bound #sv> #rtsid<I #svs> {
-            fn new() -> Self {
+            pub(crate) fn new() -> Self {
                 #rtsid {
                     #(#inits,)*
                     _phantomI: ::core::marker::PhantomData,

--- a/src/hyperlight_component_util/src/rtypes.rs
+++ b/src/hyperlight_component_util/src/rtypes.rs
@@ -674,6 +674,11 @@ fn emit_extern_decl<'a, 'b, 'c>(
                         .map(|p| emit_func_param(&mut s, p))
                         .collect::<Vec<_>>();
                     let result = emit_func_result(&mut s, &ft.result);
+                    let result = if !s.is_guest && s.is_export {
+                        quote! { ::std::result::Result<#result, ::hyperlight_host::error::HyperlightError> }
+                    } else {
+                        result
+                    };
                     quote! {
                         fn #n(&mut self, #(#params),*) -> #result;
                     }
@@ -696,12 +701,22 @@ fn emit_extern_decl<'a, 'b, 'c>(
                         }
                         ResourceItemName::Method(n) => {
                             let result = emit_func_result(&mut sv, &ft.result);
+                            let result = if !sv.is_guest && sv.is_export {
+                                quote! { ::std::result::Result<#result, ::hyperlight_host::error::HyperlightError> }
+                            } else {
+                                result
+                            };
                             sv.cur_trait().items.extend(quote! {
                                 fn #n(&mut self, #(#params),*) -> #result;
                             });
                         }
                         ResourceItemName::Static(n) => {
                             let result = emit_func_result(&mut sv, &ft.result);
+                            let result = if !sv.is_guest && sv.is_export {
+                                quote! { ::std::result::Result<#result, ::hyperlight_host::error::HyperlightError> }
+                            } else {
+                                result
+                            };
                             sv.cur_trait().items.extend(quote! {
                                 fn #n(&mut self, #(#params),*) -> #result;
                             });
@@ -724,6 +739,9 @@ fn emit_extern_decl<'a, 'b, 'c>(
             ) -> TokenStream {
                 let id = kebab_to_type(ed.kebab_name);
                 let mut s = s.helper();
+                if !s.cur_mod().emitted_type_names.insert(id.clone()) {
+                    return TokenStream::new();
+                }
 
                 let t = emit_defined(&mut s, v, id, t);
                 s.cur_mod().items.extend(t);
@@ -745,6 +763,9 @@ fn emit_extern_decl<'a, 'b, 'c>(
                         let rn = kebab_to_type(ed.kebab_name);
                         s.add_helper_supertrait(rn.clone());
                         let mut s = s.helper();
+                        if !s.cur_mod().emitted_type_names.insert(rn.clone()) {
+                            return quote! {};
+                        }
                         s.cur_trait = Some(rn.clone());
                         s.cur_trait().items.extend(quote! {
                             type T: ::core::marker::Send;
@@ -762,7 +783,12 @@ fn emit_extern_decl<'a, 'b, 'c>(
             emit_instance(&mut s, wn.clone(), it);
 
             let nsids = wn.namespace_idents();
-            let repr = s.r#trait(&nsids, kebab_to_type(wn.name));
+            let trait_name = if !s.is_guest && s.is_export {
+                kebab_to_exports_name(wn.name)
+            } else {
+                kebab_to_type(wn.name)
+            };
+            let repr = s.r#trait(&nsids, trait_name.clone());
             let vs = if !repr.tvs.is_empty() {
                 let vs = repr.tvs.clone();
                 let tvs = vs
@@ -780,11 +806,10 @@ fn emit_extern_decl<'a, 'b, 'c>(
             };
             let rp = s.root_path();
             let tns = wn.namespace_path();
-            let trait_tn = kebab_to_type(wn.name);
             let trait_bound = if tns.is_empty() {
-                quote! { #rp #trait_tn }
+                quote! { #rp #trait_name }
             } else {
-                quote! { #rp #tns::#trait_tn }
+                quote! { #rp #tns::#trait_name }
             };
             quote! {
                 type #member_tn: #trait_bound #vs;
@@ -803,7 +828,11 @@ fn emit_instance<'a, 'b, 'c>(s: &'c mut State<'a, 'b>, wn: WitName, it: &'c Inst
     tracing::debug!("emitting instance {:?}", wn);
     let mut s = s.with_cursor(wn.namespace_idents());
 
-    let name = kebab_to_type(wn.name);
+    let name = if !s.is_guest && s.is_export {
+        kebab_to_exports_name(wn.name)
+    } else {
+        kebab_to_type(wn.name)
+    };
 
     s.cur_helper_mod = Some(kebab_to_namespace(wn.name));
     s.cur_trait = Some(name.clone());

--- a/src/hyperlight_component_util/src/rtypes.rs
+++ b/src/hyperlight_component_util/src/rtypes.rs
@@ -573,9 +573,14 @@ pub fn emit_func_param(s: &mut State, p: &Param) -> TokenStream {
 /// Precondition: the result type must only be a named result if there
 /// are no names in it (i.e. a unit type)
 pub fn emit_func_result(s: &mut State, r: &etypes::Result<'_>) -> TokenStream {
-    match r {
+    let result = match r {
         Some(vt) => emit_value(s, vt),
         None => quote! { () },
+    };
+    if !s.is_guest && s.is_export {
+        quote! { ::hyperlight_host::Result<#result> }
+    } else {
+        result
     }
 }
 
@@ -674,11 +679,6 @@ fn emit_extern_decl<'a, 'b, 'c>(
                         .map(|p| emit_func_param(&mut s, p))
                         .collect::<Vec<_>>();
                     let result = emit_func_result(&mut s, &ft.result);
-                    let result = if !s.is_guest && s.is_export {
-                        quote! { ::std::result::Result<#result, ::hyperlight_host::error::HyperlightError> }
-                    } else {
-                        result
-                    };
                     quote! {
                         fn #n(&mut self, #(#params),*) -> #result;
                     }
@@ -686,6 +686,9 @@ fn emit_extern_decl<'a, 'b, 'c>(
                 FnName::Associated(r, n) => {
                     let mut s = s.helper();
                     s.cur_trait = Some(r.clone());
+                    if s.cur_trait().extern_decls.contains_key(ed.kebab_name) {
+                        return quote! {};
+                    }
                     let mut needs_vars = BTreeSet::new();
                     let mut sv = s.with_needs_vars(&mut needs_vars);
                     let params = ft
@@ -695,31 +698,24 @@ fn emit_extern_decl<'a, 'b, 'c>(
                         .collect::<Vec<_>>();
                     match n {
                         ResourceItemName::Constructor => {
-                            sv.cur_trait().items.extend(quote! {
-                                fn new(&mut self, #(#params),*) -> Self::T;
-                            });
+                            sv.cur_trait().extern_decls.insert(
+                                ed.kebab_name.to_string(),
+                                quote! { fn new(&mut self, #(#params),*) -> Self::T; },
+                            );
                         }
                         ResourceItemName::Method(n) => {
                             let result = emit_func_result(&mut sv, &ft.result);
-                            let result = if !sv.is_guest && sv.is_export {
-                                quote! { ::std::result::Result<#result, ::hyperlight_host::error::HyperlightError> }
-                            } else {
-                                result
-                            };
-                            sv.cur_trait().items.extend(quote! {
-                                fn #n(&mut self, #(#params),*) -> #result;
-                            });
+                            sv.cur_trait().extern_decls.insert(
+                                ed.kebab_name.to_string(),
+                                quote! { fn #n(&mut self, #(#params),*) -> #result; },
+                            );
                         }
                         ResourceItemName::Static(n) => {
                             let result = emit_func_result(&mut sv, &ft.result);
-                            let result = if !sv.is_guest && sv.is_export {
-                                quote! { ::std::result::Result<#result, ::hyperlight_host::error::HyperlightError> }
-                            } else {
-                                result
-                            };
-                            sv.cur_trait().items.extend(quote! {
-                                fn #n(&mut self, #(#params),*) -> #result;
-                            });
+                            sv.cur_trait().extern_decls.insert(
+                                ed.kebab_name.to_string(),
+                                quote! { fn #n(&mut self, #(#params),*) -> #result; },
+                            );
                         }
                     }
                     for v in needs_vars {
@@ -739,12 +735,14 @@ fn emit_extern_decl<'a, 'b, 'c>(
             ) -> TokenStream {
                 let id = kebab_to_type(ed.kebab_name);
                 let mut s = s.helper();
-                if !s.cur_mod().emitted_type_names.insert(id.clone()) {
+                if s.cur_mod().extern_decls.contains_key(ed.kebab_name) {
                     return TokenStream::new();
                 }
 
                 let t = emit_defined(&mut s, v, id, t);
-                s.cur_mod().items.extend(t);
+                s.cur_mod()
+                    .extern_decls
+                    .insert(ed.kebab_name.to_string(), t);
                 TokenStream::new()
             }
             let edn: &'b str = ed.kebab_name;
@@ -763,13 +761,13 @@ fn emit_extern_decl<'a, 'b, 'c>(
                         let rn = kebab_to_type(ed.kebab_name);
                         s.add_helper_supertrait(rn.clone());
                         let mut s = s.helper();
-                        if !s.cur_mod().emitted_type_names.insert(rn.clone()) {
-                            return quote! {};
-                        }
                         s.cur_trait = Some(rn.clone());
-                        s.cur_trait().items.extend(quote! {
-                            type T: ::core::marker::Send;
-                        });
+                        if !s.cur_trait().extern_decls.contains_key(ed.kebab_name) {
+                            s.cur_trait().extern_decls.insert(
+                                ed.kebab_name.to_string(),
+                                quote! { type T: ::core::marker::Send; },
+                            );
+                        }
                         quote! {}
                     }
                 }
@@ -783,12 +781,12 @@ fn emit_extern_decl<'a, 'b, 'c>(
             emit_instance(&mut s, wn.clone(), it);
 
             let nsids = wn.namespace_idents();
-            let trait_name = if !s.is_guest && s.is_export {
+            let trait_tn = if !s.is_guest && s.is_export {
                 kebab_to_exports_name(wn.name)
             } else {
                 kebab_to_type(wn.name)
             };
-            let repr = s.r#trait(&nsids, trait_name.clone());
+            let repr = s.r#trait(&nsids, trait_tn.clone());
             let vs = if !repr.tvs.is_empty() {
                 let vs = repr.tvs.clone();
                 let tvs = vs
@@ -807,9 +805,9 @@ fn emit_extern_decl<'a, 'b, 'c>(
             let rp = s.root_path();
             let tns = wn.namespace_path();
             let trait_bound = if tns.is_empty() {
-                quote! { #rp #trait_name }
+                quote! { #rp #trait_tn }
             } else {
-                quote! { #rp #tns::#trait_name }
+                quote! { #rp #tns::#trait_tn }
             };
             quote! {
                 type #member_tn: #trait_bound #vs;
@@ -886,7 +884,6 @@ fn emit_instance<'a, 'b, 'c>(s: &'c mut State<'a, 'b>, wn: WitName, it: &'c Inst
         let id = s.noff_var_id(v);
         s.cur_trait().tvs.insert(id, (Some(v), TokenStream::new()));
     }
-
     s.cur_trait().items.extend(quote! { #(#exports)* });
 }
 

--- a/src/hyperlight_host/tests/wit_test.rs
+++ b/src/hyperlight_host/tests/wit_test.rs
@@ -293,9 +293,12 @@ fn sb() -> TestSandbox<Host, MultiUseSandbox> {
 
 mod wit_test {
 
+    use hyperlight_host::error::HyperlightError;
     use proptest::prelude::*;
 
-    use crate::bindings::test::wit::{Roundtrip, TestExports, TestHostResource, roundtrip};
+    use crate::bindings::test::wit::{
+        FailableExports, RoundtripExports, TestExports, TestHostResourceExports, roundtrip,
+    };
     use crate::sb;
 
     prop_compose! {
@@ -347,7 +350,7 @@ mod wit_test {
             proptest! {
                 #[test]
                 fn $fn(x $($ty)*) {
-                    assert_eq!(x, sb().roundtrip().$fn(x.clone()))
+                    assert_eq!(x, sb().roundtrip().$fn(x.clone()).unwrap())
                 }
             }
         }
@@ -394,7 +397,7 @@ mod wit_test {
 
     #[test]
     fn test_roundtrip_no_result() {
-        sb().roundtrip().roundtrip_no_result(42);
+        sb().roundtrip().roundtrip_no_result(42).unwrap();
     }
 
     use std::sync::atomic::Ordering::Relaxed;
@@ -404,7 +407,7 @@ mod wit_test {
         let guard = crate::SERIALIZE_TEST_RESOURCE_TESTS.lock();
         crate::HAS_BEEN_DROPPED.store(false, Relaxed);
         {
-            sb().test_host_resource().test_uses_locally();
+            sb().test_host_resource().test_uses_locally().unwrap();
         }
         assert!(crate::HAS_BEEN_DROPPED.load(Relaxed));
         drop(guard);
@@ -416,13 +419,23 @@ mod wit_test {
         {
             let mut sb = sb();
             let inst = sb.test_host_resource();
-            let r = inst.test_makes();
-            inst.test_accepts_borrow(&r);
-            inst.test_accepts_own(r);
-            inst.test_returns();
+            let r = inst.test_makes().unwrap();
+            inst.test_accepts_borrow(&r).unwrap();
+            inst.test_accepts_own(r).unwrap();
+            inst.test_returns().unwrap();
         }
         assert!(crate::HAS_BEEN_DROPPED.load(Relaxed));
         drop(guard);
+    }
+
+    #[test]
+    fn test_guest_call_error_returns_error() {
+        let mut sb = sb();
+        let err = sb.failable().guest_panic().unwrap_err();
+        assert!(matches!(
+            err,
+            HyperlightError::GuestAborted(_, msg) if msg.contains("deliberate guest panic")
+        ));
     }
 }
 

--- a/src/hyperlight_host/tests/wit_test.rs
+++ b/src/hyperlight_host/tests/wit_test.rs
@@ -293,7 +293,7 @@ fn sb() -> TestSandbox<Host, MultiUseSandbox> {
 
 mod wit_test {
 
-    use hyperlight_host::error::HyperlightError;
+    use hyperlight_host::HyperlightError;
     use proptest::prelude::*;
 
     use crate::bindings::test::wit::{
@@ -400,6 +400,15 @@ mod wit_test {
         sb().roundtrip().roundtrip_no_result(42).unwrap();
     }
 
+    #[test]
+    fn test_guest_trap_returns_error() {
+        let err = sb().failable().will_trap().unwrap_err();
+        assert!(
+            matches!(err, HyperlightError::GuestAborted(_, _)),
+            "unexpected error: {err:?}"
+        );
+    }
+
     use std::sync::atomic::Ordering::Relaxed;
 
     #[test]
@@ -426,16 +435,6 @@ mod wit_test {
         }
         assert!(crate::HAS_BEEN_DROPPED.load(Relaxed));
         drop(guard);
-    }
-
-    #[test]
-    fn test_guest_call_error_returns_error() {
-        let mut sb = sb();
-        let err = sb.failable().guest_panic().unwrap_err();
-        assert!(matches!(
-            err,
-            HyperlightError::GuestAborted(_, msg) if msg.contains("deliberate guest panic")
-        ));
     }
 }
 
@@ -508,29 +507,35 @@ mod bindgen_test_cases {
     #[allow(dead_code)]
     struct ExportHost;
 
-    impl test::bindgen_test_cases::Executor for ExportHost {
-        fn execute(&mut self) -> test::bindgen_test_cases::executor::ExecutionResult {
-            test::bindgen_test_cases::executor::ExecutionResult {
+    impl test::bindgen_test_cases::ExecutorExports for ExportHost {
+        fn execute(
+            &mut self,
+        ) -> hyperlight_host::Result<test::bindgen_test_cases::executor::ExecutionResult> {
+            Ok(test::bindgen_test_cases::executor::ExecutionResult {
                 message: String::from("executed"),
-            }
+            })
         }
     }
 
-    impl test::bindgen_test_cases::Types for ExportHost {
-        fn get_status(&mut self) -> test::bindgen_test_cases::types::Status {
-            test::bindgen_test_cases::types::Status {
+    impl test::bindgen_test_cases::TypesExports for ExportHost {
+        fn get_status(
+            &mut self,
+        ) -> hyperlight_host::Result<test::bindgen_test_cases::types::Status> {
+            Ok(test::bindgen_test_cases::types::Status {
                 message: String::from("ok"),
-            }
+            })
         }
     }
 
-    impl test::bindgen_test_cases::UsesExportedTypes<test::bindgen_test_cases::types::Status>
+    impl test::bindgen_test_cases::UsesExportedTypesExports<test::bindgen_test_cases::types::Status>
         for ExportHost
     {
-        fn get_status(&mut self) -> test::bindgen_test_cases::types::Status {
-            test::bindgen_test_cases::types::Status {
+        fn get_status(
+            &mut self,
+        ) -> hyperlight_host::Result<test::bindgen_test_cases::types::Status> {
+            Ok(test::bindgen_test_cases::types::Status {
                 message: String::from("ok"),
-            }
+            })
         }
     }
 
@@ -583,4 +588,26 @@ mod inline_bindgen_test {
         };
         assert_eq!(result.value, "inline");
     }
+}
+
+/// The import and export traits share one helper module. Its type definitions
+/// must be emitted once to avoid duplicate definitions during macro expansion.
+mod shared_interface_bindings {
+    hyperlight_component_macro::host_bindgen!({
+        inline: r#"
+            package test:shared-iface;
+
+            world shared-world {
+                import shared;
+                export shared;
+            }
+
+            interface shared {
+                record item {
+                    value: u32,
+                }
+            }
+        "#,
+        world: "shared-world",
+    });
 }

--- a/src/tests/rust_guests/witguest/guest.wit
+++ b/src/tests/rust_guests/witguest/guest.wit
@@ -5,6 +5,7 @@ world test {
   import host-resource;
   export roundtrip;
   export test-host-resource;
+  export failable;
 }
 
 interface roundtrip {
@@ -89,4 +90,8 @@ interface test-host-resource {
   test-accepts-borrow: func(x: borrow<testresource>);
   test-accepts-own: func(x: own<testresource>);
   test-returns: func() -> own<testresource>;
+}
+
+interface failable {
+  guest-panic: func() -> string;
 }

--- a/src/tests/rust_guests/witguest/guest.wit
+++ b/src/tests/rust_guests/witguest/guest.wit
@@ -93,5 +93,5 @@ interface test-host-resource {
 }
 
 interface failable {
-  guest-panic: func() -> string;
+  will-trap: func() -> string;
 }

--- a/src/tests/rust_guests/witguest/src/main.rs
+++ b/src/tests/rust_guests/witguest/src/main.rs
@@ -166,6 +166,12 @@ impl test::wit::Roundtrip for Guest {
     }
 }
 
+impl test::wit::Failable for Guest {
+    fn guest_panic(&mut self) -> alloc::string::String {
+        panic!("deliberate guest panic")
+    }
+}
+
 use alloc::string::ToString;
 
 use test::wit::host_resource::Testresource;
@@ -212,6 +218,10 @@ impl test::wit::TestExports<Host> for Guest {
     }
     type TestHostResource = Self;
     fn test_host_resource(&mut self) -> &mut Self {
+        self
+    }
+    type Failable = Self;
+    fn failable(&mut self) -> &mut Self {
         self
     }
 }

--- a/src/tests/rust_guests/witguest/src/main.rs
+++ b/src/tests/rust_guests/witguest/src/main.rs
@@ -166,12 +166,6 @@ impl test::wit::Roundtrip for Guest {
     }
 }
 
-impl test::wit::Failable for Guest {
-    fn guest_panic(&mut self) -> alloc::string::String {
-        panic!("deliberate guest panic")
-    }
-}
-
 use alloc::string::ToString;
 
 use test::wit::host_resource::Testresource;
@@ -207,6 +201,12 @@ impl test::wit::TestHostResource<<Host as Testresource>::T> for Guest {
         let r = self.host_resource.take().unwrap();
         <Host as Testresource>::append_char(&mut host, &r, 'c');
         r
+    }
+}
+
+impl test::wit::Failable for Guest {
+    fn will_trap(&mut self) -> String {
+        panic!("deliberate guest crash")
     }
 }
 


### PR DESCRIPTION
fixes: #1316

`host_bindgen!` export wrappers no longer panic when `Callable::call()` returns `Err` (guest abort/trap/timeout). Host callers now receive the `HyperlightError`.

## Breaking change

Host-side guest export traits are now fallible and use a `*Exports` suffix. Host functions imported by the guest keep the original WIT signatures.

Example WIT:

```wit
world test {
  import roundtrip;
  export roundtrip;
}

interface roundtrip {
  echo: func(x: string) -> string;
}
```

Generated/used Rust shape:

```rust
// Guest -> host import implementation: unchanged.
impl test::wit::Roundtrip for Host {
    fn echo(&mut self, x: String) -> String { x }
}

// Host -> guest export call: renamed trait and fallible result.
use test::wit::{RoundtripExports, TestExports};

let value: Result<String, HyperlightError> = sandbox.roundtrip().echo("hi".into());
```

Signed-off-by: James Sturtevant <jsturtevant@gmail.com>