### PR TITLE
fix: handle empty namespace paths in component codegen

### DIFF
--- a/.github/workflows/dep_build_guests.yml
+++ b/.github/workflows/dep_build_guests.yml
@@ -113,3 +113,12 @@ jobs:
           path: src/tests/rust_guests/witguest/twoworlds.wasm
           retention-days: 1
           if-no-files-found: error
+
+      - name: Upload bindgen-test-cases.wasm
+        if: inputs.config == 'debug'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: bindgen-test-cases-wasm
+          path: src/tests/rust_guests/witguest/bindgen-test-cases.wasm
+          retention-days: 1
+          if-no-files-found: error

--- a/.github/workflows/dep_build_test.yml
+++ b/.github/workflows/dep_build_test.yml
@@ -94,6 +94,12 @@ jobs:
           name: twoworlds-wasm
           path: src/tests/rust_guests/witguest/
 
+      - name: Download bindgen-test-cases.wasm
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          name: bindgen-test-cases-wasm
+          path: src/tests/rust_guests/witguest/
+
       - name: Build
         run: just build ${{ inputs.config }}
 

--- a/Justfile
+++ b/Justfile
@@ -63,6 +63,7 @@ witguest-wit:
     cargo install --locked wasm-tools
     cd src/tests/rust_guests/witguest && wasm-tools component wit guest.wit -w -o interface.wasm
     cd src/tests/rust_guests/witguest && wasm-tools component wit two_worlds.wit -w -o twoworlds.wasm
+    cd src/tests/rust_guests/witguest && wasm-tools component wit bindgen-test-cases/ -w -o bindgen-test-cases.wasm
 
 build-rust-guests target=default-target features="": (witguest-wit) (ensure-cargo-hyperlight)
     @# --workspace unifies feature resolution so shared deps build once. Needed because witguest

--- a/src/hyperlight_component_util/src/host.rs
+++ b/src/hyperlight_component_util/src/host.rs
@@ -135,8 +135,13 @@ fn emit_export_instance<'a, 'b, 'c>(s: &'c mut State<'a, 'b>, wn: WitName, it: &
     let (root_ns, root_base_name) = s.root_component_name.unwrap();
     let wrapper_name = kebab_to_wrapper_name(root_base_name);
     let imports_name = kebab_to_imports_name(root_base_name);
+    let trait_path = if ns.is_empty() {
+        quote! { #trait_name }
+    } else {
+        quote! { #ns::#trait_name }
+    };
     s.root_mod.items.extend(quote! {
-        impl<I: #root_ns::#imports_name, S: ::hyperlight_host::sandbox::Callable> #ns::#trait_name <#(#tvs),*> for #wrapper_name<I, S> {
+        impl<I: #root_ns::#imports_name, S: ::hyperlight_host::sandbox::Callable> #trait_path <#(#tvs),*> for #wrapper_name<I, S> {
             #(#exports)*
         }
     });

--- a/src/hyperlight_component_util/src/rtypes.rs
+++ b/src/hyperlight_component_util/src/rtypes.rs
@@ -120,7 +120,12 @@ fn emit_resource_ref(s: &mut State, n: u32, path: Vec<ImportExport>) -> TokenStr
     trait_path.push(rtrait.clone());
     let t = s.resolve_trait_immut(true, &trait_path);
     let tvis = emit_tvis(s, t.tv_idxs());
-    quote! { <#sv::#extras #instance_type as #rp #tns::#instance_mod::#rtrait #tvis>::T }
+    let trait_ref = if tns.is_empty() {
+        quote! { #rp #instance_mod::#rtrait }
+    } else {
+        quote! { #rp #tns::#instance_mod::#rtrait }
+    };
+    quote! { <#sv::#extras #instance_type as #trait_ref #tvis>::T }
 }
 
 /// Try to find a way to refer to the given type variable from the
@@ -174,7 +179,11 @@ fn try_find_local_var_id(
             let rp = s.root_path();
             let tns = wn.namespace_path();
             let helper = kebab_to_namespace(wn.name);
-            Some(quote! { #rp #tns::#helper::#name })
+            if tns.is_empty() {
+                Some(quote! { #rp #helper::#name })
+            } else {
+                Some(quote! { #rp #tns::#helper::#name })
+            }
         } else {
             let hp = s.helper_path();
             Some(quote! { #hp #name })
@@ -735,8 +744,13 @@ fn emit_extern_decl<'a, 'b, 'c>(
             let rp = s.root_path();
             let tns = wn.namespace_path();
             let tn = kebab_to_type(wn.name);
+            let trait_bound = if tns.is_empty() {
+                quote! { #rp #tn }
+            } else {
+                quote! { #rp #tns::#tn }
+            };
             quote! {
-                type #tn: #rp #tns::#tn #vs;
+                type #tn: #trait_bound #vs;
                 fn #getter(&mut self) -> impl ::core::borrow::BorrowMut<Self::#tn>;
             }
         }

--- a/src/hyperlight_host/tests/wit_test.rs
+++ b/src/hyperlight_host/tests/wit_test.rs
@@ -471,3 +471,20 @@ mod pick_world_binding_test2 {
         assert_eq!(first_import.r#value, "dummyValue");
     }
 }
+
+mod bindgen_test_case_bindings {
+    hyperlight_component_macro::host_bindgen!(
+        "../tests/rust_guests/witguest/bindgen-test-cases.wasm"
+    );
+}
+mod bindgen_test_cases {
+    use crate::bindgen_test_case_bindings::*;
+
+    #[test]
+    fn plain_export_interface_types_are_generated() {
+        let result = test::bindgen_test_cases::executor::ExecutionResult {
+            message: String::from("executed"),
+        };
+        assert_eq!(result.message, "executed");
+    }
+}

--- a/src/tests/rust_guests/witguest/bindgen-test-cases/world.wit
+++ b/src/tests/rust_guests/witguest/bindgen-test-cases/world.wit
@@ -1,0 +1,13 @@
+package test:bindgen-test-cases;
+
+world bindgen-test-cases {
+    export executor;
+}
+
+interface executor {
+    record execution-result {
+        message: string,
+    }
+
+    execute: func() -> execution-result;
+}


### PR DESCRIPTION
Fixes #1329.

This updates component code generation so WIT interfaces without a namespace emit local Rust paths instead of paths with an invalid leading separator.

It also adds the shared `bindgen-test-cases` WIT fixture and CI artifact plumbing so stacked bindgen-focused PRs can extend the same fixture instead of adding one-off wasm artifacts. This is an simple with test case but it gets tricky to add all of the examples there so split this out to catch all the edge cases.