### PR TITLE
Defer clearing tlb flush flag

### DIFF
--- a/src/hyperlight_host/src/hypervisor/hyperlight_vm/x86_64.rs
+++ b/src/hyperlight_host/src/hypervisor/hyperlight_vm/x86_64.rs
@@ -292,7 +292,6 @@ impl HyperlightVm {
         let mut rflags = 1 << 1; // RFLAGS.1 is RES1
         if self.pending_tlb_flush {
             rflags |= 1 << 6; // set ZF if we need a tlb flush done before anything else executes
-            self.pending_tlb_flush = false;
         }
         // set RIP and RSP, reset others
         let regs = CommonRegisters {
@@ -319,13 +318,20 @@ impl HyperlightVm {
             .set_fpu(&CommonFpu::default())
             .map_err(DispatchGuestCallError::SetupRegs)?;
 
-        self.run(
-            mem_mgr,
-            host_funcs,
-            #[cfg(gdb)]
-            dbg_mem_access_fn,
-        )
-        .map_err(DispatchGuestCallError::Run)
+        let result = self
+            .run(
+                mem_mgr,
+                host_funcs,
+                #[cfg(gdb)]
+                dbg_mem_access_fn,
+            )
+            .map_err(DispatchGuestCallError::Run);
+
+        // Clear the TLB flush flag only after run() returns. The guest
+        // may have been cancelled before it executed the flush.
+        self.pending_tlb_flush = false;
+
+        result
     }
 
     /// Resets the following vCPU state:


### PR DESCRIPTION
Defer clearing TLB flush flag until after `run` to prevent losing it if the guest is cancelled before executing the flush. This can happen on windows for example. I noticed this on AMD cpus where guest would sometimes read old/stale memory. 

Note: if `run` returns `Ok`, the guest hit HLT, meaning it ran through the stub which checks ZF and did the flush. If `run` returns `Err` the flush may not have happened but doesn't matter since caller is required to store the sandbox before next dispatch anyway (sandbox is poisoned), which will set the tlb flush flag to true again. 