### PR TITLE
Use WHvResetPartition on windows

### DIFF
--- a/src/hyperlight_host/src/hypervisor/hyperlight_vm/aarch64.rs
+++ b/src/hyperlight_host/src/hypervisor/hyperlight_vm/aarch64.rs
@@ -89,11 +89,15 @@ impl HyperlightVm {
         unimplemented!("get_snapshot_sregs")
     }
 
-    pub(crate) fn reset_vcpu(
+    pub(crate) fn reset_vm_state(&mut self) -> std::result::Result<(), RegisterError> {
+        unimplemented!("reset_vm_state")
+    }
+
+    pub(crate) fn restore_sregs(
         &mut self,
         _cr3: u64,
         _sregs: &CommonSpecialRegisters,
     ) -> std::result::Result<(), RegisterError> {
-        unimplemented!("reset_vcpu")
+        unimplemented!("restore_sregs")
     }
 }

--- a/src/hyperlight_host/src/hypervisor/hyperlight_vm/aarch64.rs
+++ b/src/hyperlight_host/src/hypervisor/hyperlight_vm/aarch64.rs
@@ -205,16 +205,20 @@ impl HyperlightVm {
         Ok(x)
     }
 
-    pub(crate) fn reset_vcpu(
-        &mut self,
-        cr3: u64,
-        sregs: &CommonSpecialRegisters,
-    ) -> std::result::Result<(), ResetVcpuError> {
+    pub(crate) fn reset_vm_state(&mut self) -> std::result::Result<(), ResetVcpuError> {
         debug_assert!(
             self.vm_can_reset_vcpu,
             "No fallback path for vcpu reset on aarch64"
         );
         self.vm.reset_vcpu()?;
+        Ok(())
+    }
+
+    pub(crate) fn restore_sregs(
+        &mut self,
+        cr3: u64,
+        sregs: &CommonSpecialRegisters,
+    ) -> std::result::Result<(), ResetVcpuError> {
         self.apply_sregs(cr3, sregs)?;
         Ok(())
     }

--- a/src/hyperlight_host/src/hypervisor/hyperlight_vm/x86_64.rs
+++ b/src/hyperlight_host/src/hypervisor/hyperlight_vm/x86_64.rs
@@ -40,9 +40,9 @@ use crate::hypervisor::gdb::{
 };
 #[cfg(gdb)]
 use crate::hypervisor::gdb::{DebugError, DebugMemoryAccessError};
-use crate::hypervisor::regs::{
-    CommonDebugRegs, CommonFpu, CommonRegisters, CommonSpecialRegisters,
-};
+#[cfg(not(target_os = "windows"))]
+use crate::hypervisor::regs::CommonDebugRegs;
+use crate::hypervisor::regs::{CommonFpu, CommonRegisters, CommonSpecialRegisters};
 #[cfg(not(gdb))]
 use crate::hypervisor::virtual_machine::VirtualMachine;
 #[cfg(kvm)]
@@ -335,23 +335,37 @@ impl HyperlightVm {
     }
 
     /// Resets the following vCPU state:
-    /// - General purpose registers
-    /// - Debug registers
-    /// - XSAVE (includes FPU/SSE state with proper FCW and MXCSR defaults)
-    /// - Special registers (restored from snapshot, with CR3 updated to new page table location)
+    /// - On Windows: calls WHvResetPartition (resets all per-VP state including
+    ///   GP registers, debug registers, XSAVE, MSRs, APIC, etc.)
+    /// - On Linux: explicitly resets GP registers, debug registers, and XSAVE
+    ///
+    /// This does NOT restore special registers (except on windows). Call `restore_sregs` separately
+    /// after memory mappings are established.
     // TODO: check if other state needs to be reset
-    pub(crate) fn reset_vcpu(
+    pub(crate) fn reset_vm_state(&mut self) -> std::result::Result<(), RegisterError> {
+        #[cfg(target_os = "windows")]
+        self.vm.reset_partition()?;
+
+        #[cfg(not(target_os = "windows"))]
+        {
+            self.vm.set_regs(&CommonRegisters {
+                rflags: 1 << 1, // Reserved bit always set
+                ..Default::default()
+            })?;
+            self.vm.set_debug_regs(&CommonDebugRegs::default())?;
+            self.vm.reset_xsave()?;
+        }
+
+        Ok(())
+    }
+
+    /// Restores special registers from snapshot with CR3 updated to the
+    /// new page table location.
+    pub(crate) fn restore_sregs(
         &mut self,
         cr3: u64,
         sregs: &CommonSpecialRegisters,
     ) -> std::result::Result<(), RegisterError> {
-        self.vm.set_regs(&CommonRegisters {
-            rflags: 1 << 1, // Reserved bit always set
-            ..Default::default()
-        })?;
-        self.vm.set_debug_regs(&CommonDebugRegs::default())?;
-        self.vm.reset_xsave()?;
-
         #[cfg(not(feature = "nanvix-unstable"))]
         {
             // Restore the full special registers from snapshot, but update CR3
@@ -885,7 +899,9 @@ mod tests {
     use super::*;
     #[cfg(kvm)]
     use crate::hypervisor::regs::FP_CONTROL_WORD_DEFAULT;
-    use crate::hypervisor::regs::{CommonSegmentRegister, CommonTableRegister, MXCSR_DEFAULT};
+    use crate::hypervisor::regs::{
+        CommonDebugRegs, CommonSegmentRegister, CommonTableRegister, MXCSR_DEFAULT,
+    };
     use crate::hypervisor::virtual_machine::VirtualMachine;
     use crate::mem::layout::SandboxMemoryLayout;
     use crate::mem::memory_region::{GuestMemoryRegion, MemoryRegionFlags};
@@ -1206,16 +1222,44 @@ mod tests {
     }
 
     /// Assert that general-purpose registers are in reset state.
-    /// After reset, all registers should be zeroed except rflags which has
-    /// reserved bit 1 always set.
+    ///
+    /// On Linux (KVM/MSHV): reset_vm_state explicitly zeroes all GP regs and sets
+    /// rflags = 0x2, so we verify all-zeros.
+    ///
+    /// On Windows: WHvResetPartition sets architectural power-on defaults
+    /// per Intel SDM Vol. 3, Table 10-1:
+    /// RIP = 0xFFF0 (reset vector)
+    /// RDX = CPUID signature (CPU-dependent stepping/model/family)
+    /// RFLAGS = 0x2 (only reserved bit 1 set)
+    /// All other GP regs = 0
+    /// These are overwritten by dispatch_call_from_host before guest execution,
+    /// but we still verify the power-on state is correct.
     fn assert_regs_reset(vm: &dyn VirtualMachine) {
+        let regs = vm.regs().unwrap();
+        #[cfg(not(target_os = "windows"))]
         assert_eq!(
-            vm.regs().unwrap(),
+            regs,
             CommonRegisters {
-                rflags: 1 << 1, // Reserved bit 1 is always set
+                rflags: 1 << 1,
                 ..Default::default()
             }
         );
+        #[cfg(target_os = "windows")]
+        {
+            // WHvResetPartition sets x86 power-on reset values
+            // (Intel SDM Vol. 3, Table 10-1)
+            let expected = CommonRegisters {
+                rip: 0xFFF0,   // Reset vector
+                rdx: regs.rdx, // CPUID signature (CPU-dependent)
+                rflags: 0x2,   // Reserved bit 1
+                ..Default::default()
+            };
+            assert_ne!(
+                regs.rdx, 0x4444444444444444,
+                "RDX should not retain dirty value"
+            );
+            assert_eq!(regs, expected);
+        }
     }
 
     /// Assert that FPU state is in reset state.
@@ -1629,7 +1673,8 @@ mod tests {
         assert_eq!(got_sregs, expected_sregs);
 
         // Reset the vCPU
-        hyperlight_vm.reset_vcpu(0, &default_sregs()).unwrap();
+        hyperlight_vm.reset_vm_state().unwrap();
+        hyperlight_vm.restore_sregs(0, &default_sregs()).unwrap();
 
         // Verify registers are reset to defaults
         assert_regs_reset(hyperlight_vm.vm.as_ref());
@@ -1694,7 +1739,7 @@ mod tests {
             "xsave should be zeroed except for hypervisor-specific fields"
         );
 
-        // Verify sregs are reset to defaults (CR3 is 0 as passed to reset_vcpu)
+        // Verify sregs are reset to defaults
         assert_sregs_reset(hyperlight_vm.vm.as_ref(), 0);
     }
 
@@ -1758,7 +1803,8 @@ mod tests {
             assert_eq!(regs, expected_dirty);
 
             // Reset vcpu
-            hyperlight_vm.reset_vcpu(0, &default_sregs()).unwrap();
+            hyperlight_vm.reset_vm_state().unwrap();
+            hyperlight_vm.restore_sregs(0, &default_sregs()).unwrap();
 
             // Check registers are reset to defaults
             assert_regs_reset(hyperlight_vm.vm.as_ref());
@@ -1882,7 +1928,8 @@ mod tests {
             }
 
             // Reset vcpu
-            hyperlight_vm.reset_vcpu(0, &default_sregs()).unwrap();
+            hyperlight_vm.reset_vm_state().unwrap();
+            hyperlight_vm.restore_sregs(0, &default_sregs()).unwrap();
 
             // Check FPU is reset to defaults
             assert_fpu_reset(hyperlight_vm.vm.as_ref());
@@ -1933,7 +1980,8 @@ mod tests {
             assert_eq!(debug_regs, expected_dirty);
 
             // Reset vcpu
-            hyperlight_vm.reset_vcpu(0, &default_sregs()).unwrap();
+            hyperlight_vm.reset_vm_state().unwrap();
+            hyperlight_vm.restore_sregs(0, &default_sregs()).unwrap();
 
             // Check debug registers are reset to default values
             assert_debug_regs_reset(hyperlight_vm.vm.as_ref());
@@ -1982,9 +2030,10 @@ mod tests {
             assert_eq!(sregs, expected_dirty);
 
             // Reset vcpu
-            hyperlight_vm.reset_vcpu(0, &default_sregs()).unwrap();
+            hyperlight_vm.reset_vm_state().unwrap();
+            hyperlight_vm.restore_sregs(0, &default_sregs()).unwrap();
 
-            // Check registers are reset to defaults (CR3 is 0 as passed to reset_vcpu)
+            // Check registers are reset to defaults
             let sregs = hyperlight_vm.vm.sregs().unwrap();
             let mut expected_reset = CommonSpecialRegisters::standard_64bit_defaults(0);
             normalize_sregs_for_run_tests(&mut expected_reset, &sregs);
@@ -2020,7 +2069,11 @@ mod tests {
             let root_pt_addr = ctx.ctx.vm.get_root_pt().unwrap();
             let segment_state = ctx.ctx.vm.get_snapshot_sregs().unwrap();
 
-            ctx.ctx.vm.reset_vcpu(root_pt_addr, &segment_state).unwrap();
+            ctx.ctx.vm.reset_vm_state().unwrap();
+            ctx.ctx
+                .vm
+                .restore_sregs(root_pt_addr, &segment_state)
+                .unwrap();
 
             // Re-run from entrypoint (flag=1 means guest skips dirty phase, just does FXSAVE)
             // Use stack_top - 8 to match initialise()'s behavior (simulates call pushing return addr)

--- a/src/hyperlight_host/src/hypervisor/hyperlight_vm/x86_64.rs
+++ b/src/hyperlight_host/src/hypervisor/hyperlight_vm/x86_64.rs
@@ -40,9 +40,9 @@ use crate::hypervisor::gdb::{
 };
 #[cfg(gdb)]
 use crate::hypervisor::gdb::{DebugError, DebugMemoryAccessError};
-use crate::hypervisor::regs::{
-    CommonDebugRegs, CommonFpu, CommonRegisters, CommonSpecialRegisters,
-};
+#[cfg(not(target_os = "windows"))]
+use crate::hypervisor::regs::CommonDebugRegs;
+use crate::hypervisor::regs::{CommonFpu, CommonRegisters, CommonSpecialRegisters};
 #[cfg(not(gdb))]
 use crate::hypervisor::virtual_machine::VirtualMachine;
 #[cfg(kvm)]
@@ -333,23 +333,37 @@ impl HyperlightVm {
     }
 
     /// Resets the following vCPU state:
-    /// - General purpose registers
-    /// - Debug registers
-    /// - XSAVE (includes FPU/SSE state with proper FCW and MXCSR defaults)
-    /// - Special registers (restored from snapshot, with CR3 updated to new page table location)
+    /// - On Windows: calls WHvResetPartition (resets all per-VP state including
+    ///   GP registers, debug registers, XSAVE, MSRs, APIC, etc.)
+    /// - On Linux: explicitly resets GP registers, debug registers, and XSAVE
+    ///
+    /// This does NOT restore special registers (except on windows). Call `restore_sregs` separately
+    /// after memory mappings are established.
     // TODO: check if other state needs to be reset
-    pub(crate) fn reset_vcpu(
+    pub(crate) fn reset_vm_state(&mut self) -> std::result::Result<(), ResetVcpuError> {
+        #[cfg(target_os = "windows")]
+        self.vm.reset_partition()?;
+
+        #[cfg(not(target_os = "windows"))]
+        {
+            self.vm.set_regs(&CommonRegisters {
+                rflags: 1 << 1, // Reserved bit always set
+                ..Default::default()
+            })?;
+            self.vm.set_debug_regs(&CommonDebugRegs::default())?;
+            self.vm.reset_xsave()?;
+        }
+
+        Ok(())
+    }
+
+    /// Restores special registers from snapshot with CR3 updated to the
+    /// new page table location.
+    pub(crate) fn restore_sregs(
         &mut self,
         cr3: u64,
         sregs: &CommonSpecialRegisters,
     ) -> std::result::Result<(), ResetVcpuError> {
-        self.vm.set_regs(&CommonRegisters {
-            rflags: 1 << 1, // Reserved bit always set
-            ..Default::default()
-        })?;
-        self.vm.set_debug_regs(&CommonDebugRegs::default())?;
-        self.vm.reset_xsave()?;
-
         self.apply_sregs(cr3, sregs)?;
 
         Ok(())
@@ -882,7 +896,9 @@ mod tests {
     use super::*;
     #[cfg(kvm)]
     use crate::hypervisor::regs::FP_CONTROL_WORD_DEFAULT;
-    use crate::hypervisor::regs::{CommonSegmentRegister, CommonTableRegister, MXCSR_DEFAULT};
+    use crate::hypervisor::regs::{
+        CommonDebugRegs, CommonSegmentRegister, CommonTableRegister, MXCSR_DEFAULT,
+    };
     use crate::hypervisor::virtual_machine::VirtualMachine;
     use crate::mem::layout::SandboxMemoryLayout;
     use crate::mem::memory_region::{GuestMemoryRegion, MemoryRegionFlags};
@@ -1203,16 +1219,44 @@ mod tests {
     }
 
     /// Assert that general-purpose registers are in reset state.
-    /// After reset, all registers should be zeroed except rflags which has
-    /// reserved bit 1 always set.
+    ///
+    /// On Linux (KVM/MSHV): reset_vm_state explicitly zeroes all GP regs and sets
+    /// rflags = 0x2, so we verify all-zeros.
+    ///
+    /// On Windows: WHvResetPartition sets architectural power-on defaults
+    /// per Intel SDM Vol. 3, Table 10-1:
+    /// RIP = 0xFFF0 (reset vector)
+    /// RDX = CPUID signature (CPU-dependent stepping/model/family)
+    /// RFLAGS = 0x2 (only reserved bit 1 set)
+    /// All other GP regs = 0
+    /// These are overwritten by dispatch_call_from_host before guest execution,
+    /// but we still verify the power-on state is correct.
     fn assert_regs_reset(vm: &dyn VirtualMachine) {
+        let regs = vm.regs().unwrap();
+        #[cfg(not(target_os = "windows"))]
         assert_eq!(
-            vm.regs().unwrap(),
+            regs,
             CommonRegisters {
-                rflags: 1 << 1, // Reserved bit 1 is always set
+                rflags: 1 << 1,
                 ..Default::default()
             }
         );
+        #[cfg(target_os = "windows")]
+        {
+            // WHvResetPartition sets x86 power-on reset values
+            // (Intel SDM Vol. 3, Table 10-1)
+            let expected = CommonRegisters {
+                rip: 0xFFF0,   // Reset vector
+                rdx: regs.rdx, // CPUID signature (CPU-dependent)
+                rflags: 0x2,   // Reserved bit 1
+                ..Default::default()
+            };
+            assert_ne!(
+                regs.rdx, 0x4444444444444444,
+                "RDX should not retain dirty value"
+            );
+            assert_eq!(regs, expected);
+        }
     }
 
     /// Assert that FPU state is in reset state.
@@ -1632,7 +1676,8 @@ mod tests {
         assert_eq!(got_sregs, expected_sregs);
 
         // Reset the vCPU
-        hyperlight_vm.reset_vcpu(0, &default_sregs()).unwrap();
+        hyperlight_vm.reset_vm_state().unwrap();
+        hyperlight_vm.restore_sregs(0, &default_sregs()).unwrap();
 
         // Verify registers are reset to defaults
         assert_regs_reset(hyperlight_vm.vm.as_ref());
@@ -1730,7 +1775,7 @@ mod tests {
             reset_xsave.len()
         );
 
-        // Verify sregs are reset to defaults (CR3 is 0 as passed to reset_vcpu)
+        // Verify sregs are reset to defaults
         assert_sregs_reset(hyperlight_vm.vm.as_ref(), 0);
     }
 
@@ -1794,7 +1839,8 @@ mod tests {
             assert_eq!(regs, expected_dirty);
 
             // Reset vcpu
-            hyperlight_vm.reset_vcpu(0, &default_sregs()).unwrap();
+            hyperlight_vm.reset_vm_state().unwrap();
+            hyperlight_vm.restore_sregs(0, &default_sregs()).unwrap();
 
             // Check registers are reset to defaults
             assert_regs_reset(hyperlight_vm.vm.as_ref());
@@ -1918,7 +1964,8 @@ mod tests {
             }
 
             // Reset vcpu
-            hyperlight_vm.reset_vcpu(0, &default_sregs()).unwrap();
+            hyperlight_vm.reset_vm_state().unwrap();
+            hyperlight_vm.restore_sregs(0, &default_sregs()).unwrap();
 
             // Check FPU is reset to defaults
             assert_fpu_reset(hyperlight_vm.vm.as_ref());
@@ -1969,7 +2016,8 @@ mod tests {
             assert_eq!(debug_regs, expected_dirty);
 
             // Reset vcpu
-            hyperlight_vm.reset_vcpu(0, &default_sregs()).unwrap();
+            hyperlight_vm.reset_vm_state().unwrap();
+            hyperlight_vm.restore_sregs(0, &default_sregs()).unwrap();
 
             // Check debug registers are reset to default values
             assert_debug_regs_reset(hyperlight_vm.vm.as_ref());
@@ -2018,9 +2066,10 @@ mod tests {
             assert_eq!(sregs, expected_dirty);
 
             // Reset vcpu
-            hyperlight_vm.reset_vcpu(0, &default_sregs()).unwrap();
+            hyperlight_vm.reset_vm_state().unwrap();
+            hyperlight_vm.restore_sregs(0, &default_sregs()).unwrap();
 
-            // Check registers are reset to defaults (CR3 is 0 as passed to reset_vcpu)
+            // Check registers are reset to defaults
             let sregs = hyperlight_vm.vm.sregs().unwrap();
             let mut expected_reset = CommonSpecialRegisters::standard_64bit_defaults(0);
             normalize_sregs_for_run_tests(&mut expected_reset, &sregs);
@@ -2056,7 +2105,11 @@ mod tests {
             let root_pt_addr = ctx.ctx.vm.get_root_pt().unwrap();
             let segment_state = ctx.ctx.vm.get_snapshot_sregs().unwrap();
 
-            ctx.ctx.vm.reset_vcpu(root_pt_addr, &segment_state).unwrap();
+            ctx.ctx.vm.reset_vm_state().unwrap();
+            ctx.ctx
+                .vm
+                .restore_sregs(root_pt_addr, &segment_state)
+                .unwrap();
 
             // Re-run from entrypoint (flag=1 means guest skips dirty phase, just does FXSAVE)
             // Use stack_top - 8 to match initialise()'s behavior (simulates call pushing return addr)

--- a/src/hyperlight_host/src/hypervisor/virtual_machine/mod.rs
+++ b/src/hyperlight_host/src/hypervisor/virtual_machine/mod.rs
@@ -107,7 +107,7 @@ pub(crate) enum HypervisorType {
 /// Minimum XSAVE buffer size: 512 bytes legacy region + 64 bytes header.
 /// Only used by MSHV and WHP which use compacted XSAVE format and need to
 /// validate buffer size before accessing XCOMP_BV.
-#[cfg(any(mshv3, target_os = "windows"))]
+#[cfg(mshv3)]
 pub(crate) const XSAVE_MIN_SIZE: usize = 576;
 
 /// Standard XSAVE buffer size (4KB) used by KVM and MSHV.
@@ -244,6 +244,9 @@ pub enum RegisterError {
     #[cfg(target_os = "windows")]
     #[error("Failed to convert WHP registers: {0}")]
     ConversionFailed(String),
+    #[cfg(target_os = "windows")]
+    #[error("Failed to reset partition: {0}")]
+    ResetPartition(HypervisorError),
 }
 
 /// Map memory error
@@ -341,17 +344,31 @@ pub(crate) trait VirtualMachine: Debug + Send {
     #[allow(dead_code)]
     fn debug_regs(&self) -> std::result::Result<CommonDebugRegs, RegisterError>;
     /// Set the debug registers of the vCPU
+    #[allow(dead_code)] // Called on Linux (reset_vm_state) and via gdb, but dead on Windows release builds without gdb
     fn set_debug_regs(&self, drs: &CommonDebugRegs) -> std::result::Result<(), RegisterError>;
 
     /// Get xsave
     #[allow(dead_code)]
     fn xsave(&self) -> std::result::Result<Vec<u8>, RegisterError>;
     /// Reset xsave to default state
+    #[cfg(any(kvm, mshv3))]
     fn reset_xsave(&self) -> std::result::Result<(), RegisterError>;
     /// Set xsave - only used for tests
     #[cfg(test)]
     #[cfg(not(feature = "nanvix-unstable"))]
     fn set_xsave(&self, xsave: &[u32]) -> std::result::Result<(), RegisterError>;
+
+    /// Reset the partition using WHvResetPartition.
+    ///
+    /// Resets all per-VP state to architectural defaults: GP registers, segment
+    /// registers, control registers, EFER, MSRs, debug registers, full XSAVE
+    /// state (x87/SSE/AVX/AVX-512/AMX), XCR0, APIC/LAPIC, pending interrupts,
+    /// and VMCS/VMCB internals.
+    ///
+    /// Does NOT reset: GPA memory mappings or contents, partition configuration,
+    /// notification ports, or VPCI device state.
+    #[cfg(target_os = "windows")]
+    fn reset_partition(&mut self) -> std::result::Result<(), RegisterError>;
 
     /// Get partition handle
     #[cfg(target_os = "windows")]

--- a/src/hyperlight_host/src/hypervisor/virtual_machine/mod.rs
+++ b/src/hyperlight_host/src/hypervisor/virtual_machine/mod.rs
@@ -107,7 +107,7 @@ pub(crate) enum HypervisorType {
 /// Minimum XSAVE buffer size: 512 bytes legacy region + 64 bytes header.
 /// Only used by MSHV and WHP which use compacted XSAVE format and need to
 /// validate buffer size before accessing XCOMP_BV.
-#[cfg(all(target_arch = "x86_64", any(mshv3, target_os = "windows")))]
+#[cfg(all(target_arch = "x86_64", mshv3))]
 pub(crate) const XSAVE_MIN_SIZE: usize = 576;
 
 /// Standard XSAVE buffer size (4KB) used by KVM and MSHV.
@@ -247,6 +247,9 @@ pub enum RegisterError {
     #[cfg(target_os = "windows")]
     #[error("Failed to convert WHP registers: {0}")]
     ConversionFailed(String),
+    #[cfg(target_os = "windows")]
+    #[error("Failed to reset partition: {0}")]
+    ResetPartition(HypervisorError),
 }
 
 #[derive(Debug, Clone, thiserror::Error)]
@@ -356,7 +359,7 @@ pub(crate) trait VirtualMachine: Debug + Send {
     #[allow(dead_code)]
     fn debug_regs(&self) -> std::result::Result<CommonDebugRegs, RegisterError>;
     /// Set the debug registers of the vCPU
-    #[allow(dead_code)]
+    #[allow(dead_code)] // Called on Linux (reset_vm_state) and via gdb, but dead on Windows release builds without gdb
     fn set_debug_regs(&self, drs: &CommonDebugRegs) -> std::result::Result<(), RegisterError>;
 
     /// Get xsave
@@ -364,7 +367,7 @@ pub(crate) trait VirtualMachine: Debug + Send {
     #[cfg(not(target_arch = "aarch64"))]
     fn xsave(&self) -> std::result::Result<Vec<u8>, RegisterError>;
     /// Reset xsave to default state
-    #[cfg(not(target_arch = "aarch64"))]
+    #[cfg(all(target_arch = "x86_64", any(kvm, mshv3)))]
     fn reset_xsave(&self) -> std::result::Result<(), RegisterError>;
     /// Set xsave - only used for tests
     #[cfg(test)]
@@ -380,6 +383,19 @@ pub(crate) trait VirtualMachine: Debug + Send {
     fn reset_vcpu(&mut self) -> std::result::Result<(), ResetVcpuError> {
         Err(ResetVcpuError::NotSupported)
     }
+
+    /// Reset the partition using WHvResetPartition.
+    ///
+    /// Resets all per-VP state to architectural defaults: GP registers, segment
+    /// registers, control registers, EFER, MSRs, debug registers, full XSAVE
+    /// state (x87/SSE/AVX/AVX-512/AMX), XCR0, APIC/LAPIC, pending interrupts,
+    /// and VMCS/VMCB internals.
+    ///
+    /// Does NOT reset: GPA memory mappings or contents, partition configuration,
+    /// notification ports, or VPCI device state.
+    #[cfg(target_os = "windows")]
+    fn reset_partition(&mut self) -> std::result::Result<(), RegisterError>;
+
     /// Get partition handle
     #[cfg(target_os = "windows")]
     fn partition_handle(&self) -> windows::Win32::System::Hypervisor::WHV_PARTITION_HANDLE;

--- a/src/hyperlight_host/src/hypervisor/virtual_machine/whp.rs
+++ b/src/hyperlight_host/src/hypervisor/virtual_machine/whp.rs
@@ -32,9 +32,8 @@ use windows_result::HRESULT;
 use crate::hypervisor::gdb::{DebugError, DebuggableVm};
 use crate::hypervisor::regs::{
     Align16, CommonDebugRegs, CommonFpu, CommonRegisters, CommonSpecialRegisters,
-    FP_CONTROL_WORD_DEFAULT, MXCSR_DEFAULT, WHP_DEBUG_REGS_NAMES, WHP_DEBUG_REGS_NAMES_LEN,
-    WHP_FPU_NAMES, WHP_FPU_NAMES_LEN, WHP_REGS_NAMES, WHP_REGS_NAMES_LEN, WHP_SREGS_NAMES,
-    WHP_SREGS_NAMES_LEN,
+    WHP_DEBUG_REGS_NAMES, WHP_DEBUG_REGS_NAMES_LEN, WHP_FPU_NAMES, WHP_FPU_NAMES_LEN,
+    WHP_REGS_NAMES, WHP_REGS_NAMES_LEN, WHP_SREGS_NAMES, WHP_SREGS_NAMES_LEN,
 };
 use crate::hypervisor::surrogate_process::SurrogateProcess;
 use crate::hypervisor::surrogate_process_manager::get_surrogate_process_manager;
@@ -42,7 +41,7 @@ use crate::hypervisor::surrogate_process_manager::get_surrogate_process_manager;
 use crate::hypervisor::virtual_machine::x86_64::hw_interrupts::TimerThread;
 use crate::hypervisor::virtual_machine::{
     CreateVmError, HypervisorError, MapMemoryError, RegisterError, RunVcpuError, UnmapMemoryError,
-    VirtualMachine, VmExit, XSAVE_MIN_SIZE,
+    VirtualMachine, VmExit,
 };
 use crate::hypervisor::wrappers::HandleWrapper;
 use crate::mem::memory_region::{MemoryRegion, MemoryRegionFlags, MemoryRegionType};
@@ -607,6 +606,7 @@ impl VirtualMachine for WhpVm {
         })
     }
 
+    #[allow(dead_code)]
     fn set_debug_regs(&self, drs: &CommonDebugRegs) -> std::result::Result<(), RegisterError> {
         let whp_regs: [(WHV_REGISTER_NAME, Align16<WHV_REGISTER_VALUE>); WHP_DEBUG_REGS_NAMES_LEN] =
             drs.into();
@@ -666,85 +666,6 @@ impl VirtualMachine for WhpVm {
         Ok(xsave_buffer)
     }
 
-    fn reset_xsave(&self) -> std::result::Result<(), RegisterError> {
-        // WHP uses compacted XSAVE format (bit 63 of XCOMP_BV set).
-        // We cannot just zero out the xsave area, we need to preserve the XCOMP_BV.
-
-        // Get the required buffer size by calling with NULL buffer.
-        let mut buffer_size_needed: u32 = 0;
-
-        let result = unsafe {
-            WHvGetVirtualProcessorXsaveState(
-                self.partition,
-                0,
-                std::ptr::null_mut(),
-                0,
-                &mut buffer_size_needed,
-            )
-        };
-
-        // Expect insufficient buffer error; any other error is unexpected
-        if let Err(e) = result
-            && e.code() != windows::Win32::Foundation::WHV_E_INSUFFICIENT_BUFFER
-        {
-            return Err(RegisterError::GetXsaveSize(e.into()));
-        }
-
-        if buffer_size_needed < XSAVE_MIN_SIZE as u32 {
-            return Err(RegisterError::XsaveSizeMismatch {
-                expected: XSAVE_MIN_SIZE as u32,
-                actual: buffer_size_needed,
-            });
-        }
-
-        // Create a buffer to hold the current state (to get the correct XCOMP_BV)
-        let mut current_state = vec![0u8; buffer_size_needed as usize];
-        let mut written_bytes = 0;
-        unsafe {
-            WHvGetVirtualProcessorXsaveState(
-                self.partition,
-                0,
-                current_state.as_mut_ptr() as *mut std::ffi::c_void,
-                buffer_size_needed,
-                &mut written_bytes,
-            )
-            .map_err(|e| RegisterError::GetXsave(e.into()))?;
-        };
-
-        // Zero out most of the buffer, preserving only XCOMP_BV (520-528).
-        // Extended components with XSTATE_BV bit=0 will use their init values.
-        //
-        // - Legacy region (0-512): x87 FPU + SSE state
-        // - XSTATE_BV (512-520): Feature bitmap
-        // - XCOMP_BV (520-528): Compaction bitmap + format bit (KEEP)
-        // - Reserved (528-576): Header padding
-        // - Extended (576+): AVX, AVX-512, MPX, PKRU, AMX, etc.
-        current_state[0..520].fill(0);
-        current_state[528..].fill(0);
-
-        // XSAVE area layout from Intel SDM Vol. 1 Section 13.4.1:
-        // - Bytes 0-1: FCW (x87 FPU Control Word)
-        // - Bytes 24-27: MXCSR
-        // - Bytes 512-519: XSTATE_BV (bitmap of valid state components)
-        current_state[0..2].copy_from_slice(&FP_CONTROL_WORD_DEFAULT.to_le_bytes());
-        current_state[24..28].copy_from_slice(&MXCSR_DEFAULT.to_le_bytes());
-        // XSTATE_BV = 0x3: bits 0,1 = x87 + SSE valid. Explicitly tell hypervisor
-        // to apply the legacy region from this buffer for consistent behavior.
-        current_state[512..520].copy_from_slice(&0x3u64.to_le_bytes());
-
-        unsafe {
-            WHvSetVirtualProcessorXsaveState(
-                self.partition,
-                0,
-                current_state.as_ptr() as *const std::ffi::c_void,
-                buffer_size_needed,
-            )
-            .map_err(|e| RegisterError::SetXsave(e.into()))?;
-        }
-
-        Ok(())
-    }
-
     #[cfg(test)]
     #[cfg(not(feature = "nanvix-unstable"))]
     fn set_xsave(&self, xsave: &[u32]) -> std::result::Result<(), RegisterError> {
@@ -788,6 +709,36 @@ impl VirtualMachine for WhpVm {
             .map_err(|e| RegisterError::SetXsave(e.into()))?;
         }
 
+        Ok(())
+    }
+
+    fn reset_partition(&mut self) -> std::result::Result<(), RegisterError> {
+        unsafe {
+            WHvResetPartition(self.partition)
+                .map_err(|e| RegisterError::ResetPartition(e.into()))?;
+
+            // WHvResetPartition resets LAPIC to power-on defaults.
+            // Re-initialize it when LAPIC emulation is active.
+            //
+            // set_sregs filters out APIC_BASE (the snapshot sregs
+            // default it to 0, which would disable the LAPIC). This
+            // means APIC_BASE is never written after the VMCB rebuild,
+            // so the AVIC clean bit stays set and the CPU may use stale
+            // cached AVIC state. Re-writing the post-reset value forces
+            // the hypervisor to dirty SVM_CLEAN_FIELD_AVIC.
+            #[cfg(feature = "hw-interrupts")]
+            {
+                Self::init_lapic_bulk(self.partition)
+                    .map_err(|e| RegisterError::ResetPartition(e.into()))?;
+
+                let apic_base = self.sregs()?.apic_base;
+                self.set_registers(&[(
+                    WHvX64RegisterApicBase,
+                    Align16(WHV_REGISTER_VALUE { Reg64: apic_base }),
+                )])
+                .map_err(|e| RegisterError::ResetPartition(e.into()))?;
+            }
+        }
         Ok(())
     }
 

--- a/src/hyperlight_host/src/hypervisor/virtual_machine/whp.rs
+++ b/src/hyperlight_host/src/hypervisor/virtual_machine/whp.rs
@@ -86,6 +86,145 @@ fn release_file_mapping(view_base: *mut c_void, mapping_handle: HandleWrapper) {
     }
 }
 
+/// Workaround for a Hyper-V bug on AMD SVM where the `ObScrubPartition`
+/// path (invoked by `WHvResetPartition`) does not flush the Nested Page
+/// Table (NPT) TLB. After reset, stale GPA-to-HPA translations from
+/// the previous guest execution persist, causing the guest to read
+/// wrong physical memory. Intel is unaffected.
+///
+/// This bug most commonly surfaces as the `interrupt_same_thread_no_barrier`
+/// integration test failing on AMD Windows hosts. @ludfjig has verified
+/// the fix works on Windows Insider builds; this workaround can be
+/// removed once that fix ships in a released version of Windows.
+///
+/// The workaround unmaps and remaps a dummy page after each
+/// `WHvResetPartition`, which forces the hypervisor to invalidate
+/// NPT entries.
+mod npt_flush {
+    use std::os::raw::c_void;
+
+    use hyperlight_common::mem::PAGE_SIZE_USIZE;
+    use windows::Win32::Foundation::{CloseHandle, HANDLE, INVALID_HANDLE_VALUE};
+    use windows::Win32::System::Hypervisor::*;
+    use windows::Win32::System::Memory::{CreateFileMappingA, PAGE_READWRITE};
+    use windows::core::PCSTR;
+
+    use super::WHvMapGpaRange2Func;
+    use crate::hypervisor::surrogate_process::SurrogateProcess;
+    use crate::hypervisor::virtual_machine::{CreateVmError, RegisterError};
+    use crate::mem::layout::SandboxMemoryLayout;
+    use crate::mem::memory_region::SurrogateMapping;
+
+    /// GPA for the dummy page. Placed just past the maximum snapshot
+    /// region so it can never collide with guest memory.
+    const GPA: u64 =
+        (SandboxMemoryLayout::BASE_ADDRESS + SandboxMemoryLayout::MAX_MEMORY_SIZE) as u64;
+
+    #[derive(Debug)]
+    pub(super) struct NptInvalidator {
+        handle: HANDLE,
+        surrogate_addr: *mut c_void,
+        map_gpa_range2: WHvMapGpaRange2Func,
+    }
+
+    impl NptInvalidator {
+        const FLAGS: WHV_MAP_GPA_RANGE_FLAGS = WHvMapGpaRangeFlagRead;
+
+        /// Allocate a dummy page, map it into the surrogate process, and
+        /// create the initial GPA mapping.
+        pub(super) fn new(
+            partition: WHV_PARTITION_HANDLE,
+            surrogate_process: &mut SurrogateProcess,
+        ) -> Result<Self, CreateVmError> {
+            let handle = unsafe {
+                CreateFileMappingA(
+                    INVALID_HANDLE_VALUE,
+                    None,
+                    PAGE_READWRITE,
+                    0,
+                    PAGE_SIZE_USIZE as u32,
+                    PCSTR::null(),
+                )
+                .map_err(|e| CreateVmError::InitializeVm(e.into()))?
+            };
+
+            let surrogate_addr = surrogate_process
+                .map(
+                    handle.into(),
+                    0, // sentinel key; MapViewOfFile never returns 0
+                    PAGE_SIZE_USIZE,
+                    &SurrogateMapping::SandboxMemory,
+                )
+                .map_err(|e| CreateVmError::SurrogateProcess(e.to_string()))?;
+
+            let map_gpa_range2 = unsafe {
+                super::try_load_whv_map_gpa_range2()
+                    .map_err(|e| CreateVmError::InitializeVm(e.into()))?
+            };
+
+            let res = unsafe {
+                map_gpa_range2(
+                    partition,
+                    surrogate_process.process_handle.into(),
+                    surrogate_addr,
+                    GPA,
+                    PAGE_SIZE_USIZE as u64,
+                    Self::FLAGS,
+                )
+            };
+            if res.is_err() {
+                return Err(CreateVmError::InitializeVm(
+                    windows_result::Error::from_hresult(res).into(),
+                ));
+            }
+
+            Ok(Self {
+                handle,
+                surrogate_addr,
+                map_gpa_range2,
+            })
+        }
+
+        /// Force an NPT TLB flush by unmapping and remapping the dummy page.
+        pub(super) fn flush(
+            &mut self,
+            partition: WHV_PARTITION_HANDLE,
+            surrogate_process: &SurrogateProcess,
+        ) -> std::result::Result<(), RegisterError> {
+            unsafe {
+                WHvUnmapGpaRange(partition, GPA, PAGE_SIZE_USIZE as u64)
+                    .map_err(|e| RegisterError::ResetPartition(e.into()))?;
+            }
+            let res = unsafe {
+                (self.map_gpa_range2)(
+                    partition,
+                    surrogate_process.process_handle.into(),
+                    self.surrogate_addr,
+                    GPA,
+                    PAGE_SIZE_USIZE as u64,
+                    Self::FLAGS,
+                )
+            };
+            if res.is_err() {
+                return Err(RegisterError::ResetPartition(
+                    windows_result::Error::from_hresult(res).into(),
+                ));
+            }
+            Ok(())
+        }
+    }
+
+    impl Drop for NptInvalidator {
+        fn drop(&mut self) {
+            // The surrogate mapping is freed when SurrogateProcess drops;
+            // we only need to close the file-mapping handle.
+            if let Err(e) = unsafe { CloseHandle(self.handle) } {
+                tracing::error!("Failed to close NptInvalidator handle: {:?}", e);
+            }
+        }
+    }
+}
+
 /// A Windows Hypervisor Platform implementation of a single-vcpu VM
 #[derive(Debug)]
 pub(crate) struct WhpVm {
@@ -98,6 +237,10 @@ pub(crate) struct WhpVm {
     /// Handle to the background timer (if started).
     #[cfg(feature = "hw-interrupts")]
     timer: Option<TimerThread>,
+    /// Dummy page that is unmapped and remapped to force NPT TLB
+    /// flushes after `WHvResetPartition` on AMD SVM hosts.
+    /// See the [`npt_flush`] module for details.
+    npt_flush: npt_flush::NptInvalidator,
 }
 
 // Safety: `WhpVm` is !Send because it holds `SurrogateProcess` which contains a raw pointer
@@ -105,8 +248,8 @@ pub(crate) struct WhpVm {
 // in the surrogate process. It is never dereferenced, only used for address arithmetic and
 // resource management (unmapping). This is a system resource that is not bound to the creating
 // thread and can be safely transferred between threads.
-// `file_mappings` contains raw pointers that are also kernel resource handles,
-// safe to use from any thread.
+// `file_mappings` and `NptInvalidator` contain raw pointers that are also kernel
+// resource handles, safe to use from any thread.
 unsafe impl Send for WhpVm {}
 
 impl WhpVm {
@@ -144,9 +287,11 @@ impl WhpVm {
 
         let mgr = get_surrogate_process_manager()
             .map_err(|e| CreateVmError::SurrogateProcess(e.to_string()))?;
-        let surrogate_process = mgr
+        let mut surrogate_process = mgr
             .get_surrogate_process()
             .map_err(|e| CreateVmError::SurrogateProcess(e.to_string()))?;
+
+        let npt_flush = npt_flush::NptInvalidator::new(partition, &mut surrogate_process)?;
 
         Ok(WhpVm {
             partition,
@@ -154,6 +299,7 @@ impl WhpVm {
             file_mappings: Vec::new(),
             #[cfg(feature = "hw-interrupts")]
             timer: None,
+            npt_flush,
         })
     }
 
@@ -716,6 +862,10 @@ impl VirtualMachine for WhpVm {
         unsafe {
             WHvResetPartition(self.partition)
                 .map_err(|e| RegisterError::ResetPartition(e.into()))?;
+
+            // Flush NPT TLB (AMD SVM workaround, see npt_flush module).
+            self.npt_flush
+                .flush(self.partition, &self.surrogate_process)?;
 
             // WHvResetPartition resets LAPIC to power-on defaults.
             // Re-initialize it when LAPIC emulation is active.

--- a/src/hyperlight_host/src/hypervisor/virtual_machine/whp.rs
+++ b/src/hyperlight_host/src/hypervisor/virtual_machine/whp.rs
@@ -33,9 +33,8 @@ use windows_result::HRESULT;
 use crate::hypervisor::gdb::{DebugError, DebuggableVm};
 use crate::hypervisor::regs::{
     Align16, CommonDebugRegs, CommonFpu, CommonRegisters, CommonSpecialRegisters,
-    FP_CONTROL_WORD_DEFAULT, MXCSR_DEFAULT, WHP_DEBUG_REGS_NAMES, WHP_DEBUG_REGS_NAMES_LEN,
-    WHP_FPU_NAMES, WHP_FPU_NAMES_LEN, WHP_REGS_NAMES, WHP_REGS_NAMES_LEN, WHP_SREGS_NAMES,
-    WHP_SREGS_NAMES_LEN,
+    WHP_DEBUG_REGS_NAMES, WHP_DEBUG_REGS_NAMES_LEN, WHP_FPU_NAMES, WHP_FPU_NAMES_LEN,
+    WHP_REGS_NAMES, WHP_REGS_NAMES_LEN, WHP_SREGS_NAMES, WHP_SREGS_NAMES_LEN,
 };
 use crate::hypervisor::surrogate_process::SurrogateProcess;
 use crate::hypervisor::surrogate_process_manager::{
@@ -45,7 +44,7 @@ use crate::hypervisor::surrogate_process_manager::{
 use crate::hypervisor::virtual_machine::x86_64::hw_interrupts::TimerThread;
 use crate::hypervisor::virtual_machine::{
     CreateVmError, HypervisorError, MapMemoryError, RegisterError, RunVcpuError, UnmapMemoryError,
-    VirtualMachine, VmExit, XSAVE_MIN_SIZE,
+    VirtualMachine, VmExit,
 };
 use crate::hypervisor::wrappers::HandleWrapper;
 use crate::mem::memory_region::{MemoryRegion, MemoryRegionFlags, MemoryRegionType};
@@ -693,6 +692,7 @@ impl VirtualMachine for WhpVm {
         })
     }
 
+    #[allow(dead_code)]
     fn set_debug_regs(&self, drs: &CommonDebugRegs) -> std::result::Result<(), RegisterError> {
         let whp_regs: [(WHV_REGISTER_NAME, Align16<WHV_REGISTER_VALUE>); WHP_DEBUG_REGS_NAMES_LEN] =
             drs.into();
@@ -752,85 +752,6 @@ impl VirtualMachine for WhpVm {
         Ok(xsave_buffer)
     }
 
-    fn reset_xsave(&self) -> std::result::Result<(), RegisterError> {
-        // WHP uses compacted XSAVE format (bit 63 of XCOMP_BV set).
-        // We cannot just zero out the xsave area, we need to preserve the XCOMP_BV.
-
-        // Get the required buffer size by calling with NULL buffer.
-        let mut buffer_size_needed: u32 = 0;
-
-        let result = unsafe {
-            WHvGetVirtualProcessorXsaveState(
-                self.partition,
-                0,
-                std::ptr::null_mut(),
-                0,
-                &mut buffer_size_needed,
-            )
-        };
-
-        // Expect insufficient buffer error; any other error is unexpected
-        if let Err(e) = result
-            && e.code() != windows::Win32::Foundation::WHV_E_INSUFFICIENT_BUFFER
-        {
-            return Err(RegisterError::GetXsaveSize(e.into()));
-        }
-
-        if buffer_size_needed < XSAVE_MIN_SIZE as u32 {
-            return Err(RegisterError::XsaveSizeMismatch {
-                expected: XSAVE_MIN_SIZE as u32,
-                actual: buffer_size_needed,
-            });
-        }
-
-        // Create a buffer to hold the current state (to get the correct XCOMP_BV)
-        let mut current_state = vec![0u8; buffer_size_needed as usize];
-        let mut written_bytes = 0;
-        unsafe {
-            WHvGetVirtualProcessorXsaveState(
-                self.partition,
-                0,
-                current_state.as_mut_ptr() as *mut std::ffi::c_void,
-                buffer_size_needed,
-                &mut written_bytes,
-            )
-            .map_err(|e| RegisterError::GetXsave(e.into()))?;
-        };
-
-        // Zero out most of the buffer, preserving only XCOMP_BV (520-528).
-        // Extended components with XSTATE_BV bit=0 will use their init values.
-        //
-        // - Legacy region (0-512): x87 FPU + SSE state
-        // - XSTATE_BV (512-520): Feature bitmap
-        // - XCOMP_BV (520-528): Compaction bitmap + format bit (KEEP)
-        // - Reserved (528-576): Header padding
-        // - Extended (576+): AVX, AVX-512, MPX, PKRU, AMX, etc.
-        current_state[0..520].fill(0);
-        current_state[528..].fill(0);
-
-        // XSAVE area layout from Intel SDM Vol. 1 Section 13.4.1:
-        // - Bytes 0-1: FCW (x87 FPU Control Word)
-        // - Bytes 24-27: MXCSR
-        // - Bytes 512-519: XSTATE_BV (bitmap of valid state components)
-        current_state[0..2].copy_from_slice(&FP_CONTROL_WORD_DEFAULT.to_le_bytes());
-        current_state[24..28].copy_from_slice(&MXCSR_DEFAULT.to_le_bytes());
-        // XSTATE_BV = 0x3: bits 0,1 = x87 + SSE valid. Explicitly tell hypervisor
-        // to apply the legacy region from this buffer for consistent behavior.
-        current_state[512..520].copy_from_slice(&0x3u64.to_le_bytes());
-
-        unsafe {
-            WHvSetVirtualProcessorXsaveState(
-                self.partition,
-                0,
-                current_state.as_ptr() as *const std::ffi::c_void,
-                buffer_size_needed,
-            )
-            .map_err(|e| RegisterError::SetXsave(e.into()))?;
-        }
-
-        Ok(())
-    }
-
     #[cfg(test)]
     fn set_xsave(&self, xsave: &[u32]) -> std::result::Result<(), RegisterError> {
         // Get the required buffer size by calling with NULL buffer.
@@ -873,6 +794,36 @@ impl VirtualMachine for WhpVm {
             .map_err(|e| RegisterError::SetXsave(e.into()))?;
         }
 
+        Ok(())
+    }
+
+    fn reset_partition(&mut self) -> std::result::Result<(), RegisterError> {
+        unsafe {
+            WHvResetPartition(self.partition)
+                .map_err(|e| RegisterError::ResetPartition(e.into()))?;
+
+            // WHvResetPartition resets LAPIC to power-on defaults.
+            // Re-initialize it when LAPIC emulation is active.
+            //
+            // set_sregs filters out APIC_BASE (the snapshot sregs
+            // default it to 0, which would disable the LAPIC). This
+            // means APIC_BASE is never written after the VMCB rebuild,
+            // so the AVIC clean bit stays set and the CPU may use stale
+            // cached AVIC state. Re-writing the post-reset value forces
+            // the hypervisor to dirty SVM_CLEAN_FIELD_AVIC.
+            #[cfg(feature = "hw-interrupts")]
+            {
+                Self::init_lapic_bulk(self.partition)
+                    .map_err(|e| RegisterError::ResetPartition(e.into()))?;
+
+                let apic_base = self.sregs()?.apic_base;
+                self.set_registers(&[(
+                    WHvX64RegisterApicBase,
+                    Align16(WHV_REGISTER_VALUE { Reg64: apic_base }),
+                )])
+                .map_err(|e| RegisterError::ResetPartition(e.into()))?;
+            }
+        }
         Ok(())
     }
 

--- a/src/hyperlight_host/src/hypervisor/virtual_machine/whp.rs
+++ b/src/hyperlight_host/src/hypervisor/virtual_machine/whp.rs
@@ -119,6 +119,225 @@ impl Drop for NoSurrogateGuard {
     }
 }
 
+/// Workaround for a Hyper-V bug on AMD SVM where the `ObScrubPartition`
+/// path (invoked by `WHvResetPartition`) does not flush the Nested Page
+/// Table (NPT) TLB. After reset, stale GPA-to-HPA translations from
+/// the previous guest execution persist, causing the guest to read
+/// wrong physical memory. Intel is unaffected.
+///
+/// This bug most commonly surfaces as the `interrupt_same_thread_no_barrier`
+/// integration test failing on AMD Windows hosts. @ludfjig has verified
+/// the fix works on Windows Insider builds; this workaround can be
+/// removed once that fix ships in a released version of Windows.
+///
+/// The workaround unmaps and remaps a dummy page after each
+/// `WHvResetPartition`, which forces the hypervisor to invalidate
+/// NPT entries.
+mod npt_flush {
+    use std::os::raw::c_void;
+
+    use hyperlight_common::mem::PAGE_SIZE_USIZE;
+    use windows::Win32::Foundation::{CloseHandle, HANDLE, INVALID_HANDLE_VALUE};
+    use windows::Win32::System::Hypervisor::*;
+    use windows::Win32::System::Memory::{
+        CreateFileMappingA, MEM_COMMIT, MEM_RELEASE, MEM_RESERVE, PAGE_READWRITE, VirtualAlloc,
+        VirtualFree,
+    };
+    use windows::core::PCSTR;
+
+    use super::WHvMapGpaRange2Func;
+    use crate::hypervisor::surrogate_process::SurrogateProcess;
+    use crate::hypervisor::virtual_machine::{CreateVmError, RegisterError};
+    use crate::hypervisor::wrappers::HandleWrapper;
+    use crate::mem::layout::SandboxMemoryLayout;
+    use crate::mem::memory_region::SurrogateMapping;
+
+    /// GPA for the dummy page. Placed just past the maximum snapshot
+    /// region so it can never collide with guest memory.
+    const GPA: u64 =
+        (SandboxMemoryLayout::BASE_ADDRESS + SandboxMemoryLayout::MAX_MEMORY_SIZE) as u64;
+
+    #[derive(Debug)]
+    pub(super) enum NptInvalidator {
+        /// Surrogate mode: the dummy page lives in the surrogate process and
+        /// is (re)mapped via `WHvMapGpaRange2`.
+        Surrogate {
+            handle: HANDLE,
+            surrogate_addr: *mut c_void,
+            process_handle: HandleWrapper,
+            map_gpa_range2: WHvMapGpaRange2Func,
+        },
+        /// No-surrogate mode (`HYPERLIGHT_MAX_SURROGATES=0`): the dummy page is
+        /// a host-owned committed page (re)mapped via `WHvMapGpaRange`.
+        NoSurrogate { host_addr: *mut c_void },
+    }
+
+    impl NptInvalidator {
+        const FLAGS: WHV_MAP_GPA_RANGE_FLAGS = WHvMapGpaRangeFlagRead;
+
+        /// Allocate a dummy page in the surrogate process and create the
+        /// initial GPA mapping via `WHvMapGpaRange2`.
+        pub(super) fn new_surrogate(
+            partition: WHV_PARTITION_HANDLE,
+            surrogate_process: &mut SurrogateProcess,
+        ) -> Result<Self, CreateVmError> {
+            let handle = unsafe {
+                CreateFileMappingA(
+                    INVALID_HANDLE_VALUE,
+                    None,
+                    PAGE_READWRITE,
+                    0,
+                    PAGE_SIZE_USIZE as u32,
+                    PCSTR::null(),
+                )
+                .map_err(|e| CreateVmError::InitializeVm(e.into()))?
+            };
+
+            let surrogate_addr = surrogate_process
+                .map(
+                    handle.into(),
+                    0, // sentinel key; MapViewOfFile never returns 0
+                    PAGE_SIZE_USIZE,
+                    &SurrogateMapping::SandboxMemory,
+                )
+                .map_err(|e| CreateVmError::SurrogateProcess(e.to_string()))?;
+
+            let map_gpa_range2 = unsafe {
+                super::try_load_whv_map_gpa_range2()
+                    .map_err(|e| CreateVmError::InitializeVm(e.into()))?
+            };
+
+            let process_handle = surrogate_process.process_handle;
+
+            let res = unsafe {
+                map_gpa_range2(
+                    partition,
+                    process_handle.into(),
+                    surrogate_addr,
+                    GPA,
+                    PAGE_SIZE_USIZE as u64,
+                    Self::FLAGS,
+                )
+            };
+            if res.is_err() {
+                return Err(CreateVmError::InitializeVm(
+                    windows_result::Error::from_hresult(res).into(),
+                ));
+            }
+
+            Ok(Self::Surrogate {
+                handle,
+                surrogate_addr,
+                process_handle,
+                map_gpa_range2,
+            })
+        }
+
+        /// Allocate a host-owned dummy page and create the initial GPA mapping
+        /// via `WHvMapGpaRange`. Used when surrogates are disabled.
+        pub(super) fn new_no_surrogate(
+            partition: WHV_PARTITION_HANDLE,
+        ) -> Result<Self, CreateVmError> {
+            let host_addr = unsafe {
+                VirtualAlloc(
+                    None,
+                    PAGE_SIZE_USIZE,
+                    MEM_COMMIT | MEM_RESERVE,
+                    PAGE_READWRITE,
+                )
+            };
+            if host_addr.is_null() {
+                return Err(CreateVmError::InitializeVm(
+                    windows_result::Error::from_thread().into(),
+                ));
+            }
+
+            let res = unsafe {
+                WHvMapGpaRange(
+                    partition,
+                    host_addr as *const c_void,
+                    GPA,
+                    PAGE_SIZE_USIZE as u64,
+                    Self::FLAGS,
+                )
+            };
+            if let Err(e) = res {
+                unsafe {
+                    let _ = VirtualFree(host_addr, 0, MEM_RELEASE);
+                }
+                return Err(CreateVmError::InitializeVm(e.into()));
+            }
+
+            Ok(Self::NoSurrogate { host_addr })
+        }
+
+        /// Force an NPT TLB flush by unmapping and remapping the dummy page.
+        pub(super) fn flush(
+            &mut self,
+            partition: WHV_PARTITION_HANDLE,
+        ) -> std::result::Result<(), RegisterError> {
+            unsafe {
+                WHvUnmapGpaRange(partition, GPA, PAGE_SIZE_USIZE as u64)
+                    .map_err(|e| RegisterError::ResetPartition(e.into()))?;
+            }
+            match self {
+                Self::Surrogate {
+                    surrogate_addr,
+                    process_handle,
+                    map_gpa_range2,
+                    ..
+                } => {
+                    let res = unsafe {
+                        (*map_gpa_range2)(
+                            partition,
+                            (*process_handle).into(),
+                            *surrogate_addr,
+                            GPA,
+                            PAGE_SIZE_USIZE as u64,
+                            Self::FLAGS,
+                        )
+                    };
+                    if res.is_err() {
+                        return Err(RegisterError::ResetPartition(
+                            windows_result::Error::from_hresult(res).into(),
+                        ));
+                    }
+                }
+                Self::NoSurrogate { host_addr } => unsafe {
+                    WHvMapGpaRange(
+                        partition,
+                        *host_addr as *const c_void,
+                        GPA,
+                        PAGE_SIZE_USIZE as u64,
+                        Self::FLAGS,
+                    )
+                    .map_err(|e| RegisterError::ResetPartition(e.into()))?;
+                },
+            }
+            Ok(())
+        }
+    }
+
+    impl Drop for NptInvalidator {
+        fn drop(&mut self) {
+            match self {
+                // The surrogate mapping is freed when SurrogateProcess drops;
+                // we only need to close the file-mapping handle.
+                Self::Surrogate { handle, .. } => {
+                    if let Err(e) = unsafe { CloseHandle(*handle) } {
+                        tracing::error!("Failed to close NptInvalidator handle: {:?}", e);
+                    }
+                }
+                Self::NoSurrogate { host_addr } => {
+                    if let Err(e) = unsafe { VirtualFree(*host_addr, 0, MEM_RELEASE) } {
+                        tracing::error!("Failed to free NptInvalidator page: {:?}", e);
+                    }
+                }
+            }
+        }
+    }
+}
+
 /// A Windows Hypervisor Platform implementation of a single-vcpu VM
 #[derive(Debug)]
 pub(crate) struct WhpVm {
@@ -136,6 +355,10 @@ pub(crate) struct WhpVm {
     /// Handle to the background timer (if started).
     #[cfg(feature = "hw-interrupts")]
     timer: Option<TimerThread>,
+    /// Dummy page that is unmapped and remapped to force NPT TLB
+    /// flushes after `WHvResetPartition` on AMD SVM hosts.
+    /// See the [`npt_flush`] module for details.
+    npt_flush: npt_flush::NptInvalidator,
 }
 
 // Safety: `WhpVm` is !Send because it holds `Option<SurrogateProcess>` which
@@ -145,8 +368,8 @@ pub(crate) struct WhpVm {
 // (unmapping). This is a system resource that is not bound to the creating
 // thread and can be safely transferred between threads. When the `Option` is
 // `None` (surrogates disabled), no such pointer exists.
-// `file_mappings` contains raw pointers that are also kernel resource handles,
-// safe to use from any thread.
+// `file_mappings` and `NptInvalidator` contain raw pointers that are also
+// kernel resource handles, safe to use from any thread.
 unsafe impl Send for WhpVm {}
 
 impl WhpVm {
@@ -186,7 +409,7 @@ impl WhpVm {
             p
         };
 
-        let surrogate_process = if no_surrogate {
+        let mut surrogate_process = if no_surrogate {
             None
         } else {
             let mgr = get_surrogate_process_manager()
@@ -197,6 +420,11 @@ impl WhpVm {
             )
         };
 
+        let npt_flush = match &mut surrogate_process {
+            Some(surrogate) => npt_flush::NptInvalidator::new_surrogate(partition, surrogate)?,
+            None => npt_flush::NptInvalidator::new_no_surrogate(partition)?,
+        };
+
         Ok(WhpVm {
             partition,
             surrogate_process,
@@ -204,6 +432,7 @@ impl WhpVm {
             _no_surrogate_guard: no_surrogate_guard,
             #[cfg(feature = "hw-interrupts")]
             timer: None,
+            npt_flush,
         })
     }
 
@@ -801,6 +1030,9 @@ impl VirtualMachine for WhpVm {
         unsafe {
             WHvResetPartition(self.partition)
                 .map_err(|e| RegisterError::ResetPartition(e.into()))?;
+
+            // Flush NPT TLB (AMD SVM workaround, see npt_flush module).
+            self.npt_flush.flush(self.partition)?;
 
             // WHvResetPartition resets LAPIC to power-on defaults.
             // Re-initialize it when LAPIC emulation is active.

--- a/src/hyperlight_host/src/mem/layout.rs
+++ b/src/hyperlight_host/src/mem/layout.rs
@@ -313,7 +313,7 @@ impl SandboxMemoryLayout {
     /// Both the scratch region and the snapshot region are bounded by
     /// this size. The value is arbitrary but chosen to be large enough
     /// for most workloads while preventing accidental resource exhaustion.
-    const MAX_MEMORY_SIZE: usize = (16 * 1024 * 1024 * 1024) - Self::BASE_ADDRESS; // 16 GiB - BASE_ADDRESS
+    pub(crate) const MAX_MEMORY_SIZE: usize = (16 * 1024 * 1024 * 1024) - Self::BASE_ADDRESS; // 16 GiB - BASE_ADDRESS
 
     /// The base address of the sandbox's memory.
     #[cfg(not(feature = "nanvix-unstable"))]

--- a/src/hyperlight_host/src/sandbox/initialized_multi_use.rs
+++ b/src/hyperlight_host/src/sandbox/initialized_multi_use.rs
@@ -287,6 +287,12 @@ impl MultiUseSandbox {
             return Err(SnapshotSandboxMismatch);
         }
 
+        // Reset VM/vCPU state before memory restore.
+        self.vm.reset_vm_state().map_err(|e| {
+            self.poisoned = true;
+            HyperlightVmError::Restore(e)
+        })?;
+
         let (gsnapshot, gscratch) = self.mem_mgr.restore_snapshot(&snapshot)?;
         if let Some(gsnapshot) = gsnapshot {
             self.vm
@@ -305,7 +311,7 @@ impl MultiUseSandbox {
         // TODO (ludfjig): Go through the rest of possible errors in this `MultiUseSandbox::restore` function
         // and determine if they should also poison the sandbox.
         self.vm
-            .reset_vcpu(snapshot.root_pt_gpa(), sregs)
+            .restore_sregs(snapshot.root_pt_gpa(), sregs)
             .map_err(|e| {
                 self.poisoned = true;
                 HyperlightVmError::Restore(e)
@@ -1436,7 +1442,7 @@ mod tests {
     }
 
     /// Test that snapshot restore properly resets vCPU debug registers. This test verifies
-    /// that restore() calls reset_vcpu().
+    /// that restore() calls reset_vm_state().
     #[test]
     fn snapshot_restore_resets_debug_registers() {
         let mut sandbox: MultiUseSandbox = {
@@ -1466,7 +1472,7 @@ mod tests {
         let dr0_after_restore: u64 = sandbox.call("GetDr0", ()).unwrap();
         assert_eq!(
             dr0_after_restore, 0,
-            "DR0 should be 0 after restore (reset_vcpu should have been called)"
+            "DR0 should be 0 after restore (reset_vm_state should have been called)"
         );
     }
 

--- a/src/hyperlight_host/src/sandbox/initialized_multi_use.rs
+++ b/src/hyperlight_host/src/sandbox/initialized_multi_use.rs
@@ -519,6 +519,12 @@ impl MultiUseSandbox {
             snapshot.validate_compatibility(&self.mem_mgr.layout, &host_funcs)?;
         }
 
+        // Reset VM/vCPU state before memory restore.
+        self.vm.reset_vm_state().map_err(|e| {
+            self.poisoned = true;
+            HyperlightVmError::Restore(e)
+        })?;
+
         let (gsnapshot, gscratch) = self.mem_mgr.restore_snapshot(&snapshot)?;
         if let Some(gsnapshot) = gsnapshot {
             self.vm
@@ -537,7 +543,7 @@ impl MultiUseSandbox {
         // TODO (ludfjig): Go through the rest of possible errors in this `MultiUseSandbox::restore` function
         // and determine if they should also poison the sandbox.
         self.vm
-            .reset_vcpu(snapshot.root_pt_gpa(), sregs)
+            .restore_sregs(snapshot.root_pt_gpa(), sregs)
             .map_err(|e| {
                 self.poisoned = true;
                 HyperlightVmError::Restore(e)
@@ -1870,7 +1876,7 @@ mod tests {
     }
 
     /// Test that snapshot restore properly resets vCPU debug registers. This test verifies
-    /// that restore() calls reset_vcpu().
+    /// that restore() calls reset_vm_state().
     #[test]
     fn snapshot_restore_resets_debug_registers() {
         let mut sandbox: MultiUseSandbox = {
@@ -1901,7 +1907,7 @@ mod tests {
         let dr0_after_restore: u64 = sandbox.call("GetDr0", ()).unwrap();
         assert_eq!(
             dr0_after_restore, 0,
-            "DR0 should be 0 after restore (reset_vcpu should have been called)"
+            "DR0 should be 0 after restore (reset_vm_state should have been called)"
         );
     }
 

--- a/src/hyperlight_host/tests/integration_test.rs
+++ b/src/hyperlight_host/tests/integration_test.rs
@@ -195,7 +195,7 @@ fn interrupt_same_thread() {
             // Only allow successful calls or interrupted.
             // The call can be successful in case the call is finished before kill() is called.
             Ok(_) | Err(HyperlightError::ExecutionCanceledByHost()) => {}
-            _ => panic!("Unexpected return"),
+            other => panic!("Unexpected return: {:?}", other),
         };
         if sbox2.poisoned() {
             sbox2.restore(snapshot2.clone()).unwrap();

--- a/src/hyperlight_host/tests/integration_test.rs
+++ b/src/hyperlight_host/tests/integration_test.rs
@@ -194,7 +194,7 @@ fn interrupt_same_thread() {
             // Only allow successful calls or interrupted.
             // The call can be successful in case the call is finished before kill() is called.
             Ok(_) | Err(HyperlightError::ExecutionCanceledByHost()) => {}
-            _ => panic!("Unexpected return"),
+            other => panic!("Unexpected return: {:?}", other),
         };
         if sbox2.poisoned() {
             sbox2.restore(snapshot2.clone()).unwrap();


### PR DESCRIPTION
Addresses #791 for windows (WHP), by resetting all guest visible state on the partition. Resets more vm state on `restore()` at the expense of some performance (roughly ~100micros). MSHV is planned to use the same hv call, but doesn't exist in mshv crate yet, although dom0 kernel should have support already. KVM doesn't have a nice api like this, so will still manual work for KVM.

Note: the second commit is a workaround for a hyper-v bug