### PR TITLE
feat(clippy): add disallowed macros for asserts in clippy.toml 

### DIFF
--- a/src/hyperlight_common/clippy.toml
+++ b/src/hyperlight_common/clippy.toml
@@ -1,0 +1,5 @@
+disallowed-macros = [
+    { path = "std::assert", reason = "no asserts in release builds" },
+    { path = "std::assert_eq", reason = "no asserts in release builds" },
+    { path = "std::assert_ne", reason = "no asserts in release builds" },
+]

--- a/src/hyperlight_common/src/lib.rs
+++ b/src/hyperlight_common/src/lib.rs
@@ -17,6 +17,16 @@ limitations under the License.
 #![cfg_attr(not(any(test, debug_assertions)), warn(clippy::panic))]
 #![cfg_attr(not(any(test, debug_assertions)), warn(clippy::expect_used))]
 #![cfg_attr(not(any(test, debug_assertions)), warn(clippy::unwrap_used))]
+// clippy.toml disallows assert!/assert_eq!/assert_ne! via disallowed-macros.
+// That lint is active by default, so we suppress it globally here, then
+// selectively re-enable it for release host builds (feature = "std").
+// Guest targets (no std) are allowed asserts — panics are contained in the
+// micro-VM and cannot crash the host. Tests and debug builds are also allowed.
+#![allow(clippy::disallowed_macros)]
+#![cfg_attr(
+    not(any(test, debug_assertions, not(feature = "std"))),
+    warn(clippy::disallowed_macros)
+)]
 // We use Arbitrary during fuzzing, which requires std
 #![cfg_attr(not(feature = "fuzzing"), no_std)]
 

--- a/src/hyperlight_common/src/version_note.rs
+++ b/src/hyperlight_common/src/version_note.rs
@@ -90,6 +90,7 @@ impl<const NAME_SZ: usize, const DESC_SZ: usize> ElfNote<NAME_SZ, DESC_SZ> {
     ///
     /// Panics at compile time if `NAME_SZ` or `DESC_SZ` don't match
     /// `padded_name_size(name.len() + 1)` or `padded_desc_size(desc.len() + 1)`.
+    #[allow(clippy::disallowed_macros)] // These asserts are evaluated at compile time only (const fn).
     pub const fn new(name: &str, desc: &str, n_type: u32) -> Self {
         // NAME_SZ and DESC_SZ must match the padded sizes.
         assert!(


### PR DESCRIPTION
This pull request introduces stricter linting for assertion macros in release builds.

**Linting and Build Configuration Changes:**

* Added a `clippy.toml` configuration disallowing the use of `assert!`, `assert_eq!`, and `assert_ne!` macros in release builds, with explanations for each.
* Updated crate-level attributes in `lib.rs` to globally suppress the `clippy::disallowed_macros` lint, then selectively re-enable it for release host builds (with `std` feature), while allowing asserts for guest targets and in test/debug builds. This is thoroughly documented in comments.
