### PR TITLE
Re-export guest types and error utilities from `hyperlight_guest_bin`

### DIFF
--- a/src/hyperlight_guest/src/error.rs
+++ b/src/hyperlight_guest/src/error.rs
@@ -17,7 +17,7 @@ limitations under the License.
 use alloc::format;
 use alloc::string::{String, ToString as _};
 
-use hyperlight_common::flatbuffer_wrappers::guest_error::ErrorCode;
+pub use hyperlight_common::flatbuffer_wrappers::guest_error::ErrorCode;
 use hyperlight_common::func::Error as FuncError;
 use {anyhow, serde_json};
 

--- a/src/hyperlight_guest/src/types.rs
+++ b/src/hyperlight_guest/src/types.rs
@@ -1,5 +1,5 @@
 /*
-Copyright 2025  The Hyperlight Authors.
+Copyright 2026  The Hyperlight Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -12,23 +12,9 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-*/
+ */
 
-#![no_std]
-#[cfg(all(feature = "trace_guest", not(target_arch = "x86_64")))]
-compile_error!("trace_guest feature is only supported on x86_64 architecture");
-
-extern crate alloc;
-
-// Modules
-pub mod error;
-pub mod exit;
-pub mod layout;
-pub mod prim_alloc;
-pub mod types;
-
-pub mod guest_handle {
-    pub mod handle;
-    pub mod host_comm;
-    pub mod io;
-}
+pub use hyperlight_common::flatbuffer_wrappers::function_call::FunctionCall;
+pub use hyperlight_common::flatbuffer_wrappers::function_types::{
+    ParameterType, ParameterValue, ReturnType, ReturnValue,
+};

--- a/src/hyperlight_guest_bin/src/error.rs
+++ b/src/hyperlight_guest_bin/src/error.rs
@@ -1,5 +1,5 @@
 /*
-Copyright 2025  The Hyperlight Authors.
+Copyright 2026  The Hyperlight Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,21 +14,5 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#![no_std]
-#[cfg(all(feature = "trace_guest", not(target_arch = "x86_64")))]
-compile_error!("trace_guest feature is only supported on x86_64 architecture");
-
-extern crate alloc;
-
-// Modules
-pub mod error;
-pub mod exit;
-pub mod layout;
-pub mod prim_alloc;
-pub mod types;
-
-pub mod guest_handle {
-    pub mod handle;
-    pub mod host_comm;
-    pub mod io;
-}
+pub use hyperlight_guest::error::*;
+pub use hyperlight_guest::{bail, ensure};

--- a/src/hyperlight_guest_bin/src/lib.rs
+++ b/src/hyperlight_guest_bin/src/lib.rs
@@ -47,6 +47,7 @@ pub mod guest_function {
     pub mod register;
 }
 
+pub mod error;
 pub mod guest_logger;
 pub mod host_comm;
 pub mod memory;


### PR DESCRIPTION
## Summary

This PR re-exports common types and error utilities from `hyperlight_guest_bin`, allowing users to build guest binaries with a single dependency on `hyperlight_guest_bin` instead of requiring an explicit dependency on both `hyperlight_guest` and `hyperlight_guest_bin`.

## Changes

- Re-export `ErrorCode` from `hyperlight_guest::error`
- Add new `types` module to `hyperlight_guest` that re-exports `FunctionCall`, `ParameterType`, `ParameterValue`, `ReturnType`, and `ReturnValue`
- Add new `error` module to `hyperlight_guest_bin` that re-exports error types and the `bail`/`ensure` macros

## Motivation

Simplifies the dependency graph for guest binary authors by allowing them to depend only on `hyperlight_guest_bin`.