### PR TITLE
feat: i686 page tables, snapshot compaction, and CoW (standalone)

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -268,7 +268,7 @@ test-rust-tracing target=default-target features="":
 check-i686 target=default-target:
     cargo check -p hyperlight-common --target i686-unknown-linux-gnu --profile={{ if target == "debug" { "dev" } else { target } }}
     cargo check -p hyperlight-guest --target i686-unknown-linux-gnu --profile={{ if target == "debug" { "dev" } else { target } }}
-    cargo check -p hyperlight-common --target i686-unknown-linux-gnu --features nanvix-unstable --profile={{ if target == "debug" { "dev" } else { target } }}
+    cargo check -p hyperlight-common --target i686-unknown-linux-gnu --features i686-guest --profile={{ if target == "debug" { "dev" } else { target } }}
     # Verify that trace_guest correctly fails on i686 (compile_error should trigger)
     ! cargo check -p hyperlight-guest --target i686-unknown-linux-gnu --features trace_guest --profile={{ if target == "debug" { "dev" } else { target } }} 2>/dev/null
 
@@ -291,8 +291,8 @@ check:
     {{ cargo-cmd }} check -p hyperlight-host --features print_debug  {{ target-triple-flag }}
     {{ cargo-cmd }} check -p hyperlight-host --features gdb  {{ target-triple-flag }}
     {{ cargo-cmd }} check -p hyperlight-host --features trace_guest,mem_profile  {{ target-triple-flag }}
-    {{ cargo-cmd }} check -p hyperlight-host --features nanvix-unstable  {{ target-triple-flag }}
-    {{ cargo-cmd }} check -p hyperlight-host --features nanvix-unstable,executable_heap  {{ target-triple-flag }}
+    {{ cargo-cmd }} check -p hyperlight-host --features i686-guest  {{ target-triple-flag }}
+    {{ cargo-cmd }} check -p hyperlight-host --features i686-guest,executable_heap  {{ target-triple-flag }}
     {{ cargo-cmd }} check -p hyperlight-host --features hw-interrupts  {{ target-triple-flag }}
 
 fmt-check: (ensure-nightly-fmt)

--- a/src/hyperlight_common/Cargo.toml
+++ b/src/hyperlight_common/Cargo.toml
@@ -31,7 +31,8 @@ fuzzing = ["dep:arbitrary"]
 trace_guest = []
 mem_profile = []
 std = ["thiserror/std", "log/std", "tracing/std"]
-nanvix-unstable = []
+i686-guest = []
+guest-counter = []
 
 [lib]
 bench = false # see https://bheisler.github.io/criterion.rs/book/faq.html#cargo-bench-gives-unrecognized-option-errors-for-valid-command-line-options

--- a/src/hyperlight_common/Cargo.toml
+++ b/src/hyperlight_common/Cargo.toml
@@ -32,6 +32,7 @@ trace_guest = []
 mem_profile = []
 std = ["thiserror/std", "log/std", "tracing/std"]
 i686-guest = []
+nanvix-unstable = ["i686-guest"]
 guest-counter = []
 
 [lib]

--- a/src/hyperlight_common/src/arch/aarch64/vmem.rs
+++ b/src/hyperlight_common/src/arch/aarch64/vmem.rs
@@ -44,9 +44,17 @@ pub unsafe fn virt_to_phys<'a, Op: TableReadOps + 'a>(
     core::iter::empty()
 }
 
-pub trait TableMovability<Op: TableReadOps + ?Sized, TableMoveInfo> {}
-impl<Op: TableOps<TableMovability = crate::vmem::MayMoveTable>> TableMovability<Op, Op::TableAddr>
+impl<Op: TableOps<TableMovability = crate::vmem::MayMoveTable>> crate::vmem::TableMovability<Op>
     for crate::vmem::MayMoveTable
 {
+    type RootUpdateParent = crate::vmem::UpdateParentRoot;
+    fn root_update_parent() -> Self::RootUpdateParent {
+        crate::vmem::UpdateParentRoot {}
+    }
 }
-impl<Op: TableReadOps> TableMovability<Op, Void> for crate::vmem::MayNotMoveTable {}
+impl<Op: TableReadOps> crate::vmem::TableMovability<Op> for crate::vmem::MayNotMoveTable {
+    type RootUpdateParent = crate::vmem::UpdateParentNone;
+    fn root_update_parent() -> Self::RootUpdateParent {
+        crate::vmem::UpdateParentNone {}
+    }
+}

--- a/src/hyperlight_common/src/arch/aarch64/vmem.rs
+++ b/src/hyperlight_common/src/arch/aarch64/vmem.rs
@@ -46,6 +46,29 @@ pub unsafe fn virt_to_phys<'a, Op: TableReadOps + 'a>(
     core::iter::empty()
 }
 
+/// Stub — see [`crate::vmem::walk_va_spaces`].
+#[allow(clippy::missing_safety_doc)]
+pub unsafe fn walk_va_spaces<Op: TableReadOps>(
+    _op: &Op,
+    _roots: &[Op::TableAddr],
+    _address: u64,
+    _len: u64,
+) -> ::alloc::vec::Vec<(
+    crate::vmem::SpaceId,
+    ::alloc::vec::Vec<crate::vmem::SpaceAwareMapping>,
+)> {
+    ::alloc::vec::Vec::new()
+}
+
+/// Stub — see [`crate::vmem::space_aware_map`].
+#[allow(clippy::missing_safety_doc)]
+pub unsafe fn space_aware_map<Op: TableOps>(
+    _op: &Op,
+    _ref_map: crate::vmem::SpaceReferenceMapping,
+    _built_roots: &::alloc::collections::BTreeMap<crate::vmem::SpaceId, Op::TableAddr>,
+) {
+}
+
 pub trait TableMovability<Op: TableReadOps + ?Sized, TableMoveInfo> {}
 impl<Op: TableOps<TableMovability = crate::vmem::MayMoveTable>> TableMovability<Op, Op::TableAddr>
     for crate::vmem::MayMoveTable

--- a/src/hyperlight_common/src/arch/aarch64/vmem.rs
+++ b/src/hyperlight_common/src/arch/aarch64/vmem.rs
@@ -20,6 +20,7 @@ use crate::vmem::{Mapping, TableOps, TableReadOps, Void};
 
 pub const PAGE_SIZE: usize = 4096;
 pub const PAGE_TABLE_SIZE: usize = 4096;
+pub const PAGE_PRESENT: u64 = 1; // AArch64: bit 0 is the "valid" bit
 pub type PageTableEntry = u64;
 pub type VirtAddr = u64;
 pub type PhysAddr = u64;

--- a/src/hyperlight_common/src/arch/aarch64/vmem.rs
+++ b/src/hyperlight_common/src/arch/aarch64/vmem.rs
@@ -21,6 +21,7 @@ use crate::vmem::{Mapping, TableOps, TableReadOps, Void};
 pub const PAGE_SIZE: usize = 4096;
 pub const PAGE_TABLE_SIZE: usize = 4096;
 pub const PAGE_PRESENT: u64 = 1; // AArch64: bit 0 is the "valid" bit
+pub const PTE_ADDR_MASK: u64 = 0x0000_FFFF_FFFF_F000; // bits [47:12]
 pub type PageTableEntry = u64;
 pub type VirtAddr = u64;
 pub type PhysAddr = u64;
@@ -45,17 +46,9 @@ pub unsafe fn virt_to_phys<'a, Op: TableReadOps + 'a>(
     core::iter::empty()
 }
 
-impl<Op: TableOps<TableMovability = crate::vmem::MayMoveTable>> crate::vmem::TableMovability<Op>
+pub trait TableMovability<Op: TableReadOps + ?Sized, TableMoveInfo> {}
+impl<Op: TableOps<TableMovability = crate::vmem::MayMoveTable>> TableMovability<Op, Op::TableAddr>
     for crate::vmem::MayMoveTable
 {
-    type RootUpdateParent = crate::vmem::UpdateParentRoot;
-    fn root_update_parent() -> Self::RootUpdateParent {
-        crate::vmem::UpdateParentRoot {}
-    }
 }
-impl<Op: TableReadOps> crate::vmem::TableMovability<Op> for crate::vmem::MayNotMoveTable {
-    type RootUpdateParent = crate::vmem::UpdateParentNone;
-    fn root_update_parent() -> Self::RootUpdateParent {
-        crate::vmem::UpdateParentNone {}
-    }
-}
+impl<Op: TableReadOps> TableMovability<Op, Void> for crate::vmem::MayNotMoveTable {}

--- a/src/hyperlight_common/src/arch/amd64/vmem.rs
+++ b/src/hyperlight_common/src/arch/amd64/vmem.rs
@@ -28,7 +28,7 @@ limitations under the License.
 use crate::vmem::{
     BasicMapping, CowMapping, MapRequest, MapResponse, Mapping, MappingKind, TableMovabilityBase,
     TableOps, TableReadOps, UpdateParent, UpdateParentNone, UpdateParentRoot, UpdateParentTable,
-    modify_ptes, read_pte_if_present, require_pte_exist, write_entry_updating,
+    Void, modify_ptes, read_pte_if_present, require_pte_exist, write_entry_updating,
 };
 
 // Paging Flags
@@ -111,7 +111,7 @@ impl<Op: TableOps<TableMovability = crate::vmem::MayMoveTable>> TableMovability<
         UpdateParentRoot {}
     }
 }
-impl<Op: TableReadOps> TableMovability<Op, crate::vmem::Void> for crate::vmem::MayNotMoveTable {
+impl<Op: TableReadOps> TableMovability<Op, Void> for crate::vmem::MayNotMoveTable {
     type RootUpdateParent = UpdateParentNone;
     fn root_update_parent() -> Self::RootUpdateParent {
         UpdateParentNone {}
@@ -120,8 +120,8 @@ impl<Op: TableReadOps> TableMovability<Op, crate::vmem::Void> for crate::vmem::M
 
 impl<
     Op: TableOps<TableMovability = crate::vmem::MayMoveTable>,
-    P: crate::vmem::UpdateParent<Op, TableMoveInfo = Op::TableAddr>,
-> crate::vmem::UpdateParent<Op> for UpdateParentTable<Op, P>
+    P: UpdateParent<Op, TableMoveInfo = Op::TableAddr>,
+> UpdateParent<Op> for UpdateParentTable<Op, P>
 {
     type TableMoveInfo = Op::TableAddr;
     type ChildType = UpdateParentTable<Op, Self>;
@@ -136,7 +136,7 @@ impl<
     }
 }
 
-impl<Op: TableOps<TableMovability = crate::vmem::MayMoveTable>> crate::vmem::UpdateParent<Op>
+impl<Op: TableOps<TableMovability = crate::vmem::MayMoveTable>> UpdateParent<Op>
     for UpdateParentRoot
 {
     type TableMoveInfo = Op::TableAddr;

--- a/src/hyperlight_common/src/arch/amd64/vmem.rs
+++ b/src/hyperlight_common/src/arch/amd64/vmem.rs
@@ -265,6 +265,99 @@ unsafe fn map_page<
 /// 2. PDPT (38:30) - allocate PD if needed
 /// 3. PD (29:21) - allocate PT if needed
 /// 4. PT (20:12) - write final PTE with physical address and flags
+/// Multi-space page-table walking on amd64: walks each root
+/// independently and emits all leaves as `ThisSpace`. Aliased
+/// intermediate-table detection is not implemented — no current
+/// embedder exercises that pattern on amd64 (it is an i686/Nanvix-
+/// specific concern).
+#[allow(clippy::missing_safety_doc)]
+pub unsafe fn walk_va_spaces<Op: TableReadOps>(
+    op: &Op,
+    roots: &[Op::TableAddr],
+    address: u64,
+    len: u64,
+) -> ::alloc::vec::Vec<(
+    crate::vmem::SpaceId,
+    ::alloc::vec::Vec<crate::vmem::SpaceAwareMapping>,
+)> {
+    use ::alloc::vec::Vec;
+
+    let mut out: Vec<(
+        crate::vmem::SpaceId,
+        Vec<crate::vmem::SpaceAwareMapping>,
+    )> = Vec::with_capacity(roots.len());
+
+    let addr = address & ((1u64 << VA_BITS) - 1);
+    let vmin = addr & !(PAGE_SIZE as u64 - 1);
+    let vmax = core::cmp::min(addr + len, 1u64 << VA_BITS);
+
+    for &root in roots {
+        #[allow(clippy::unnecessary_cast)]
+        let root_id: crate::vmem::SpaceId = Op::to_phys(root) as u64;
+        let mut mappings: Vec<crate::vmem::SpaceAwareMapping> = Vec::new();
+
+        let iter = modify_ptes::<47, 39, Op, _>(MapRequest {
+            table_base: root,
+            vmin,
+            len: vmax.saturating_sub(vmin),
+            update_parent: UpdateParentNone {},
+        })
+        .filter_map(|r| unsafe { require_pte_exist(op, r) })
+        .flat_map(modify_ptes::<38, 30, Op, _>)
+        .filter_map(|r| unsafe { require_pte_exist(op, r) })
+        .flat_map(modify_ptes::<29, 21, Op, _>)
+        .filter_map(|r| unsafe { require_pte_exist(op, r) })
+        .flat_map(modify_ptes::<20, 12, Op, _>);
+
+        for r in iter {
+            let Some(pte) = (unsafe { read_pte_if_present(op, r.entry_ptr) }) else {
+                continue;
+            };
+            let phys_addr = pte & PTE_ADDR_MASK;
+            let sgn_bit = r.vmin >> (VA_BITS - 1);
+            let sgn_bits = 0u64.wrapping_sub(sgn_bit) << VA_BITS;
+            let virt_addr = sgn_bits | r.vmin;
+
+            let executable = (pte & PAGE_NX) == 0;
+            let avl = pte & PTE_AVL_MASK;
+            let kind = if avl == PAGE_AVL_COW {
+                MappingKind::Cow(CowMapping {
+                    readable: true,
+                    executable,
+                })
+            } else {
+                MappingKind::Basic(BasicMapping {
+                    readable: true,
+                    writable: (pte & PAGE_RW) != 0,
+                    executable,
+                })
+            };
+            mappings.push(crate::vmem::SpaceAwareMapping::ThisSpace(Mapping {
+                phys_base: phys_addr,
+                virt_base: virt_addr,
+                len: PAGE_SIZE as u64,
+                kind,
+                user_accessible: false,
+            }));
+        }
+
+        out.push((root_id, mappings));
+    }
+
+    out
+}
+
+/// See [`walk_va_spaces`]: amd64 never emits `AnotherSpace`, so this
+/// is unreachable in practice. It silently no-ops (rather than
+/// panicking) to keep the architecture-independent re-export usable.
+#[allow(clippy::missing_safety_doc)]
+pub unsafe fn space_aware_map<Op: TableOps>(
+    _op: &Op,
+    _ref_map: crate::vmem::SpaceReferenceMapping,
+    _built_roots: &::alloc::collections::BTreeMap<crate::vmem::SpaceId, Op::TableAddr>,
+) {
+}
+
 #[allow(clippy::missing_safety_doc)]
 pub unsafe fn map<Op: TableOps>(op: &Op, mapping: Mapping) {
     modify_ptes::<47, 39, Op, _>(MapRequest {

--- a/src/hyperlight_common/src/arch/amd64/vmem.rs
+++ b/src/hyperlight_common/src/arch/amd64/vmem.rs
@@ -27,7 +27,8 @@ limitations under the License.
 
 use crate::vmem::{
     BasicMapping, CowMapping, MapRequest, MapResponse, Mapping, MappingKind, TableMovabilityBase,
-    TableOps, TableReadOps, UpdateParent, UpdateParentNone, Void, modify_ptes, write_entry_updating,
+    TableOps, TableReadOps, UpdateParent, UpdateParentNone, Void, modify_ptes,
+    write_entry_updating,
 };
 
 /// Parent is another page table whose ancestors may also need

--- a/src/hyperlight_common/src/arch/amd64/vmem.rs
+++ b/src/hyperlight_common/src/arch/amd64/vmem.rs
@@ -28,8 +28,49 @@ limitations under the License.
 use crate::vmem::{
     BasicMapping, CowMapping, MapRequest, MapResponse, Mapping, MappingKind, TableMovabilityBase,
     TableOps, TableReadOps, UpdateParent, UpdateParentNone, UpdateParentRoot, UpdateParentTable,
-    Void, modify_ptes, read_pte_if_present, require_pte_exist, write_entry_updating,
+    Void, modify_ptes, write_entry_updating,
 };
+
+/// Read a PTE and return it (widened to u64) if the present bit is
+/// set. The amd64 "present" encoding is a single bit (bit 0); other
+/// architectures may need richer semantics, which is why this lives
+/// per-arch rather than in the common module.
+///
+/// # Safety
+/// `entry_ptr` must point to a valid page table entry.
+#[inline(always)]
+#[allow(clippy::useless_conversion)]
+pub(super) unsafe fn read_pte_if_present<Op: TableReadOps>(
+    op: &Op,
+    entry_ptr: Op::TableAddr,
+) -> Option<u64> {
+    let pte: u64 = unsafe { op.read_entry(entry_ptr) }.into();
+    if (pte & PAGE_PRESENT) != 0 {
+        Some(pte)
+    } else {
+        None
+    }
+}
+
+/// Require that a PTE is present and descend to the next-level table.
+///
+/// # Safety
+/// `op` must provide valid page table memory.
+pub(super) unsafe fn require_pte_exist<Op: TableReadOps, P: UpdateParent<Op>>(
+    op: &Op,
+    x: MapResponse<Op, P>,
+) -> Option<MapRequest<Op, P::ChildType>>
+where
+    P::ChildType: UpdateParent<Op>,
+{
+    unsafe { read_pte_if_present(op, x.entry_ptr) }.map(|pte| MapRequest {
+        #[allow(clippy::unnecessary_cast)]
+        table_base: Op::from_phys((pte & PTE_ADDR_MASK) as PhysAddr),
+        vmin: x.vmin,
+        len: x.len,
+        update_parent: x.update_parent.for_child_at_entry(x.entry_ptr),
+    })
+}
 
 // Paging Flags
 //

--- a/src/hyperlight_common/src/arch/amd64/vmem.rs
+++ b/src/hyperlight_common/src/arch/amd64/vmem.rs
@@ -282,10 +282,8 @@ pub unsafe fn walk_va_spaces<Op: TableReadOps>(
 )> {
     use ::alloc::vec::Vec;
 
-    let mut out: Vec<(
-        crate::vmem::SpaceId,
-        Vec<crate::vmem::SpaceAwareMapping>,
-    )> = Vec::with_capacity(roots.len());
+    let mut out: Vec<(crate::vmem::SpaceId, Vec<crate::vmem::SpaceAwareMapping>)> =
+        Vec::with_capacity(roots.len());
 
     let addr = address & ((1u64 << VA_BITS) - 1);
     let vmin = addr & !(PAGE_SIZE as u64 - 1);

--- a/src/hyperlight_common/src/arch/amd64/vmem.rs
+++ b/src/hyperlight_common/src/arch/amd64/vmem.rs
@@ -26,8 +26,9 @@ limitations under the License.
 //! allocating intermediate tables as needed and setting appropriate flags on leaf PTEs
 
 use crate::vmem::{
-    BasicMapping, CowMapping, Mapping, MappingKind, TableMovabilityBase, TableOps, TableReadOps,
-    Void,
+    BasicMapping, CowMapping, MapRequest, MapResponse, Mapping, MappingKind, TableMovability as _,
+    TableMovabilityBase, TableOps, TableReadOps, UpdateParent, UpdateParentNone, UpdateParentRoot,
+    UpdateParentTable, modify_ptes, read_pte_if_present, require_pte_exist, write_entry_updating,
 };
 
 // Paging Flags
@@ -82,26 +83,6 @@ const fn page_nx_flag(executable: bool) -> u64 {
     if executable { 0 } else { PAGE_NX }
 }
 
-/// Read a page table entry and return it if the present bit is set
-/// # Safety
-/// The caller must ensure that `entry_ptr` points to a valid page table entry.
-#[inline(always)]
-unsafe fn read_pte_if_present<Op: TableReadOps>(op: &Op, entry_ptr: Op::TableAddr) -> Option<u64> {
-    let pte = unsafe { op.read_entry(entry_ptr) };
-    if (pte & PAGE_PRESENT) != 0 {
-        Some(pte)
-    } else {
-        None
-    }
-}
-
-/// Utility function to extract an (inclusive on both ends) bit range
-/// from a quadword.
-#[inline(always)]
-fn bits<const HIGH_BIT: u8, const LOW_BIT: u8>(x: u64) -> u64 {
-    (x & ((1 << (HIGH_BIT + 1)) - 1)) >> LOW_BIT
-}
-
 /// Helper function to generate a page table entry that points to another table
 #[allow(clippy::identity_op)]
 #[allow(clippy::precedence)]
@@ -115,14 +96,9 @@ fn pte_for_table<Op: TableOps>(table_addr: Op::TableAddr) -> u64 {
         PAGE_PRESENT // P   - this entry is present
 }
 
-/// This trait is used to select appropriate implementations of
-/// [`UpdateParent`] to be used, depending on whether a particular
-/// implementation needs the ability to move tables.
-pub trait TableMovability<Op: TableReadOps + ?Sized, TableMoveInfo> {
-    type RootUpdateParent: UpdateParent<Op, TableMoveInfo = TableMoveInfo>;
-    fn root_update_parent() -> Self::RootUpdateParent;
-}
-impl<Op: TableOps<TableMovability = crate::vmem::MayMoveTable>> TableMovability<Op, Op::TableAddr>
+// ---- TableMovability + UpdateParent impls ----
+
+impl<Op: TableOps<TableMovability = crate::vmem::MayMoveTable>> crate::vmem::TableMovability<Op>
     for crate::vmem::MayMoveTable
 {
     type RootUpdateParent = UpdateParentRoot;
@@ -130,78 +106,17 @@ impl<Op: TableOps<TableMovability = crate::vmem::MayMoveTable>> TableMovability<
         UpdateParentRoot {}
     }
 }
-impl<Op: TableReadOps> TableMovability<Op, Void> for crate::vmem::MayNotMoveTable {
+impl<Op: TableReadOps> crate::vmem::TableMovability<Op> for crate::vmem::MayNotMoveTable {
     type RootUpdateParent = UpdateParentNone;
     fn root_update_parent() -> Self::RootUpdateParent {
         UpdateParentNone {}
     }
 }
 
-/// Helper function to write a page table entry, updating the whole
-/// chain of tables back to the root if necessary
-unsafe fn write_entry_updating<
-    Op: TableOps,
-    P: UpdateParent<
-            Op,
-            TableMoveInfo = <Op::TableMovability as TableMovabilityBase<Op>>::TableMoveInfo,
-        >,
->(
-    op: &Op,
-    parent: P,
-    addr: Op::TableAddr,
-    entry: u64,
-) {
-    if let Some(again) = unsafe { op.write_entry(addr, entry) } {
-        parent.update_parent(op, again);
-    }
-}
-
-/// A helper trait that allows us to move a page table (e.g. from the
-/// snapshot to the scratch region), keeping track of the context that
-/// needs to be updated when that is moved (and potentially
-/// recursively updating, if necessary)
-///
-/// This is done via a trait so that the selected impl knows the exact
-/// nesting depth of tables, in order to assist
-/// inlining/specialisation in generating efficient code.
-///
-/// The trait definition only bounds its parameter by
-/// [`TableReadOps`], since [`UpdateParentNone`] does not need to be
-/// able to actually write to the tables.
-pub trait UpdateParent<Op: TableReadOps + ?Sized>: Copy {
-    /// The type of the information about a moved table which is
-    /// needed in order to update its parent.
-    type TableMoveInfo;
-    /// The [`UpdateParent`] type that should be used when going down
-    /// another level in the table, in order to add the current level
-    /// to the chain of ancestors to be updated.
-    type ChildType: UpdateParent<Op, TableMoveInfo = Self::TableMoveInfo>;
-    fn update_parent(self, op: &Op, new_ptr: Self::TableMoveInfo);
-    fn for_child_at_entry(self, entry_ptr: Op::TableAddr) -> Self::ChildType;
-}
-
-/// A struct implementing [`UpdateParent`] that keeps track of the
-/// fact that the parent table is itself another table, whose own
-/// ancestors may need to be recursively updated
-pub struct UpdateParentTable<Op: TableOps, P: UpdateParent<Op>> {
-    parent: P,
-    entry_ptr: Op::TableAddr,
-}
-impl<Op: TableOps, P: UpdateParent<Op>> Clone for UpdateParentTable<Op, P> {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl<Op: TableOps, P: UpdateParent<Op>> Copy for UpdateParentTable<Op, P> {}
-impl<Op: TableOps, P: UpdateParent<Op>> UpdateParentTable<Op, P> {
-    fn new(parent: P, entry_ptr: Op::TableAddr) -> Self {
-        UpdateParentTable { parent, entry_ptr }
-    }
-}
 impl<
     Op: TableOps<TableMovability = crate::vmem::MayMoveTable>,
-    P: UpdateParent<Op, TableMoveInfo = Op::TableAddr>,
-> UpdateParent<Op> for UpdateParentTable<Op, P>
+    P: crate::vmem::UpdateParent<Op, TableMoveInfo = Op::TableAddr>,
+> crate::vmem::UpdateParent<Op> for UpdateParentTable<Op, P>
 {
     type TableMoveInfo = Op::TableAddr;
     type ChildType = UpdateParentTable<Op, Self>;
@@ -216,12 +131,7 @@ impl<
     }
 }
 
-/// A struct implementing [`UpdateParent`] that keeps track of the
-/// fact that the parent "table" is actually the root (e.g. the value
-/// of CR3 in the guest)
-#[derive(Copy, Clone)]
-pub struct UpdateParentRoot {}
-impl<Op: TableOps<TableMovability = crate::vmem::MayMoveTable>> UpdateParent<Op>
+impl<Op: TableOps<TableMovability = crate::vmem::MayMoveTable>> crate::vmem::UpdateParent<Op>
     for UpdateParentRoot
 {
     type TableMoveInfo = Op::TableAddr;
@@ -236,133 +146,8 @@ impl<Op: TableOps<TableMovability = crate::vmem::MayMoveTable>> UpdateParent<Op>
     }
 }
 
-/// A struct implementing [`UpdateParent`] that is impossible to use
-/// (since its [`update_parent`] method takes `Void`), used when it is
-/// statically known that a table operation cannot result in a need to
-/// update ancestors.
-#[derive(Copy, Clone)]
-pub struct UpdateParentNone {}
-impl<Op: TableReadOps> UpdateParent<Op> for UpdateParentNone {
-    type TableMoveInfo = Void;
-    type ChildType = Self;
-    fn update_parent(self, _op: &Op, impossible: Void) {
-        match impossible {}
-    }
-    fn for_child_at_entry(self, _entry_ptr: Op::TableAddr) -> Self {
-        self
-    }
-}
-
-/// A helper structure indicating a mapping operation that needs to be
-/// performed
-struct MapRequest<Op: TableReadOps, P: UpdateParent<Op>> {
-    table_base: Op::TableAddr,
-    vmin: VirtAddr,
-    len: u64,
-    update_parent: P,
-}
-
-/// A helper structure indicating that a particular PTE needs to be
-/// modified
-struct MapResponse<Op: TableReadOps, P: UpdateParent<Op>> {
-    entry_ptr: Op::TableAddr,
-    vmin: VirtAddr,
-    len: u64,
-    update_parent: P,
-}
-
-/// Iterator that walks through page table entries at a specific level.
-///
-/// Given a virtual address range and a table base, this iterator yields
-/// `MapResponse` items for each page table entry that needs to be modified.
-/// The const generics `HIGH_BIT` and `LOW_BIT` specify which bits of the
-/// virtual address are used to index into this level's table.
-///
-/// For example:
-/// - PML4: HIGH_BIT=47, LOW_BIT=39 (9 bits = 512 entries, each covering 512GB)
-/// - PDPT: HIGH_BIT=38, LOW_BIT=30 (9 bits = 512 entries, each covering 1GB)
-/// - PD:   HIGH_BIT=29, LOW_BIT=21 (9 bits = 512 entries, each covering 2MB)
-/// - PT:   HIGH_BIT=20, LOW_BIT=12 (9 bits = 512 entries, each covering 4KB)
-struct ModifyPteIterator<
-    const HIGH_BIT: u8,
-    const LOW_BIT: u8,
-    Op: TableReadOps,
-    P: UpdateParent<Op>,
-> {
-    request: MapRequest<Op, P>,
-    n: u64,
-}
-impl<const HIGH_BIT: u8, const LOW_BIT: u8, Op: TableReadOps, P: UpdateParent<Op>> Iterator
-    for ModifyPteIterator<HIGH_BIT, LOW_BIT, Op, P>
-{
-    type Item = MapResponse<Op, P>;
-    fn next(&mut self) -> Option<Self::Item> {
-        // Each page table entry at this level covers a region of size (1 << LOW_BIT) bytes.
-        // For example, at the PT level (LOW_BIT=12), each entry covers 4KB (0x1000 bytes).
-        // At the PD level (LOW_BIT=21), each entry covers 2MB (0x200000 bytes).
-        //
-        // This mask isolates the bits below this level's index bits, used for alignment.
-        let lower_bits_mask = (1 << LOW_BIT) - 1;
-
-        // Calculate the virtual address for this iteration.
-        // On the first iteration (n=0), start at the requested vmin.
-        // On subsequent iterations, advance to the next aligned boundary.
-        // This handles the case where vmin isn't aligned to this level's entry size.
-        let next_vmin = if self.n == 0 {
-            self.request.vmin
-        } else {
-            // Align to the next boundary by adding one entry's worth
-            // and masking off lower bits. Masking off before adding
-            // is safe, since n << LOW_BIT must always have zeros in
-            // these positions.
-            let aligned_min = self.request.vmin & !lower_bits_mask;
-            // Use checked_add here because going past the end of the
-            // address space counts as "the next one would be out of
-            // range"
-            aligned_min.checked_add(self.n << LOW_BIT)?
-        };
-
-        // Check if we've processed the entire requested range
-        if next_vmin >= self.request.vmin + self.request.len {
-            return None;
-        }
-
-        // Calculate the pointer to this level's page table entry.
-        // bits::<HIGH_BIT, LOW_BIT> extracts the relevant index bits from the virtual address.
-        // Shift left by 3 (multiply by 8) because each entry is 8 bytes (u64).
-        let entry_ptr = Op::entry_addr(
-            self.request.table_base,
-            bits::<HIGH_BIT, LOW_BIT>(next_vmin) << 3,
-        );
-
-        // Calculate how many bytes remain to be mapped from this point
-        let len_from_here = self.request.len - (next_vmin - self.request.vmin);
-
-        // Calculate the maximum bytes this single entry can cover.
-        // If next_vmin is aligned, this is the full entry size (1 << LOW_BIT).
-        // If not aligned (only possible on first iteration), it's the remaining
-        // space until the next boundary.
-        let max_len = (1 << LOW_BIT) - (next_vmin & lower_bits_mask);
-
-        // The actual length for this entry is the smaller of what's needed vs what fits
-        let next_len = core::cmp::min(len_from_here, max_len);
-
-        // Advance iteration counter for next call
-        self.n += 1;
-
-        Some(MapResponse {
-            entry_ptr,
-            vmin: next_vmin,
-            len: next_len,
-            update_parent: self.request.update_parent,
-        })
-    }
-}
-fn modify_ptes<const HIGH_BIT: u8, const LOW_BIT: u8, Op: TableReadOps, P: UpdateParent<Op>>(
-    r: MapRequest<Op, P>,
-) -> ModifyPteIterator<HIGH_BIT, LOW_BIT, Op, P> {
-    ModifyPteIterator { request: r, n: 0 }
-}
+/// amd64 PTE shift: log2(8) = 3 for 8-byte entries
+const PTE_SHIFT: u8 = 3;
 
 /// Page-mapping callback to allocate a next-level page table if necessary.
 /// # Safety
@@ -480,39 +265,20 @@ unsafe fn map_page<
 /// 4. PT (20:12) - write final PTE with physical address and flags
 #[allow(clippy::missing_safety_doc)]
 pub unsafe fn map<Op: TableOps>(op: &Op, mapping: Mapping) {
-    modify_ptes::<47, 39, Op, _>(MapRequest {
+    modify_ptes::<47, 39, PTE_SHIFT, Op, _>(MapRequest {
         table_base: op.root_table(),
         vmin: mapping.virt_base,
         len: mapping.len,
         update_parent: Op::TableMovability::root_update_parent(),
     })
     .map(|r| unsafe { alloc_pte_if_needed(op, r) })
-    .flat_map(modify_ptes::<38, 30, Op, _>)
+    .flat_map(modify_ptes::<38, 30, PTE_SHIFT, Op, _>)
     .map(|r| unsafe { alloc_pte_if_needed(op, r) })
-    .flat_map(modify_ptes::<29, 21, Op, _>)
+    .flat_map(modify_ptes::<29, 21, PTE_SHIFT, Op, _>)
     .map(|r| unsafe { alloc_pte_if_needed(op, r) })
-    .flat_map(modify_ptes::<20, 12, Op, _>)
+    .flat_map(modify_ptes::<20, 12, PTE_SHIFT, Op, _>)
     .map(|r| unsafe { map_page(op, &mapping, r) })
     .for_each(drop);
-}
-
-/// # Safety
-/// This function traverses page table data structures, and should not
-/// be called concurrently with any other operations that modify the
-/// page table.
-unsafe fn require_pte_exist<Op: TableReadOps, P: UpdateParent<Op>>(
-    op: &Op,
-    x: MapResponse<Op, P>,
-) -> Option<MapRequest<Op, P::ChildType>>
-where
-    P::ChildType: UpdateParent<Op>,
-{
-    unsafe { read_pte_if_present(op, x.entry_ptr) }.map(|pte| MapRequest {
-        table_base: Op::from_phys(pte & PTE_ADDR_MASK),
-        vmin: x.vmin,
-        len: x.len,
-        update_parent: x.update_parent.for_child_at_entry(x.entry_ptr),
-    })
 }
 
 // There are no notable architecture-specific safety considerations
@@ -545,18 +311,18 @@ pub unsafe fn virt_to_phys<'a, Op: TableReadOps + 'a>(
     // Calculate the maximum virtual address we need to look at based on the starting
     // address and length ensuring we don't go past the end of the address space
     let vmax = core::cmp::min(addr + len, 1u64 << VA_BITS);
-    modify_ptes::<47, 39, Op, _>(MapRequest {
+    modify_ptes::<47, 39, PTE_SHIFT, Op, _>(MapRequest {
         table_base: op.as_ref().root_table(),
         vmin,
         len: vmax - vmin,
         update_parent: UpdateParentNone {},
     })
-    .filter_map(move |r| unsafe { require_pte_exist(op.as_ref(), r) })
-    .flat_map(modify_ptes::<38, 30, Op, _>)
-    .filter_map(move |r| unsafe { require_pte_exist(op.as_ref(), r) })
-    .flat_map(modify_ptes::<29, 21, Op, _>)
-    .filter_map(move |r| unsafe { require_pte_exist(op.as_ref(), r) })
-    .flat_map(modify_ptes::<20, 12, Op, _>)
+    .filter_map(move |r| unsafe { require_pte_exist::<PTE_ADDR_MASK, _, _>(op.as_ref(), r) })
+    .flat_map(modify_ptes::<38, 30, PTE_SHIFT, Op, _>)
+    .filter_map(move |r| unsafe { require_pte_exist::<PTE_ADDR_MASK, _, _>(op.as_ref(), r) })
+    .flat_map(modify_ptes::<29, 21, PTE_SHIFT, Op, _>)
+    .filter_map(move |r| unsafe { require_pte_exist::<PTE_ADDR_MASK, _, _>(op.as_ref(), r) })
+    .flat_map(modify_ptes::<20, 12, PTE_SHIFT, Op, _>)
     .filter_map(move |r| {
         let pte = unsafe { read_pte_if_present(op.as_ref(), r.entry_ptr) }?;
         let phys_addr = pte & PTE_ADDR_MASK;
@@ -596,72 +362,6 @@ pub type PageTableEntry = u64;
 pub type VirtAddr = u64;
 pub type PhysAddr = u64;
 
-/// i686 guest page-table walker and PTE constants for the x86_64 host.
-///
-/// When the host builds with `i686-guest`, it needs to walk 2-level i686
-/// page tables in guest memory. The `arch/i686/vmem.rs` module only compiles
-/// for `target_arch = "x86"` (the guest side), so the host-side walker lives
-/// here, gated behind the feature flag.
-#[cfg(feature = "i686-guest")]
-pub mod i686_guest {
-    use alloc::vec::Vec;
-
-    use crate::vmem::{BasicMapping, CowMapping, Mapping, MappingKind, TableReadOps};
-
-    pub const PAGE_PRESENT: u64 = 1;
-    pub const PAGE_RW: u64 = 1 << 1;
-    pub const PAGE_USER: u64 = 1 << 2;
-    pub const PAGE_ACCESSED: u64 = 1 << 5;
-    pub const PAGE_AVL_COW: u64 = 1 << 9;
-    pub const PTE_ADDR_MASK: u64 = 0xFFFFF000;
-
-    /// Walk an i686 2-level page table and return all present mappings.
-    ///
-    /// # Safety
-    /// The caller must ensure that `op` provides valid page table memory.
-    pub unsafe fn virt_to_phys_all<Op: TableReadOps>(op: &Op) -> Vec<Mapping> {
-        let root = op.root_table();
-        let mut mappings = Vec::new();
-        for pdi in 0..1024u64 {
-            let pde_ptr = Op::entry_addr(root, pdi * 4);
-            let pde: u64 = unsafe { op.read_entry(pde_ptr) };
-            if (pde & PAGE_PRESENT) == 0 {
-                continue;
-            }
-            let pt_phys = pde & PTE_ADDR_MASK;
-            let pt_base = Op::from_phys(pt_phys as crate::vmem::PhysAddr);
-            for pti in 0..1024u64 {
-                let pte_ptr = Op::entry_addr(pt_base, pti * 4);
-                let pte: u64 = unsafe { op.read_entry(pte_ptr) };
-                if (pte & PAGE_PRESENT) == 0 {
-                    continue;
-                }
-                let phys_base = pte & PTE_ADDR_MASK;
-                let virt_base = (pdi << 22) | (pti << 12);
-                let kind = if (pte & PAGE_AVL_COW) != 0 {
-                    MappingKind::Cow(CowMapping {
-                        readable: true,
-                        executable: true,
-                    })
-                } else {
-                    MappingKind::Basic(BasicMapping {
-                        readable: true,
-                        writable: (pte & PAGE_RW) != 0,
-                        executable: true,
-                    })
-                };
-                mappings.push(Mapping {
-                    phys_base,
-                    virt_base,
-                    len: super::PAGE_SIZE as u64,
-                    kind,
-                });
-            }
-        }
-        mappings
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use alloc::vec;
@@ -671,7 +371,7 @@ mod tests {
     use super::*;
     use crate::vmem::{
         BasicMapping, Mapping, MappingKind, MayNotMoveTable, PAGE_TABLE_ENTRIES_PER_TABLE,
-        TableOps, TableReadOps, Void,
+        TableOps, TableReadOps, Void, bits,
     };
 
     /// A mock TableOps implementation for testing that stores page tables in memory
@@ -1127,7 +827,8 @@ mod tests {
             update_parent: UpdateParentNone {},
         };
 
-        let responses: Vec<_> = modify_ptes::<20, 12, MockTableOps, _>(request).collect();
+        let responses: Vec<_> =
+            modify_ptes::<20, 12, PTE_SHIFT, MockTableOps, _>(request).collect();
         assert_eq!(responses.len(), 1, "Single page should yield one response");
         assert_eq!(responses[0].vmin, 0x1000);
         assert_eq!(responses[0].len, PAGE_SIZE as u64);
@@ -1143,7 +844,8 @@ mod tests {
             update_parent: UpdateParentNone {},
         };
 
-        let responses: Vec<_> = modify_ptes::<20, 12, MockTableOps, _>(request).collect();
+        let responses: Vec<_> =
+            modify_ptes::<20, 12, PTE_SHIFT, MockTableOps, _>(request).collect();
         assert_eq!(responses.len(), 3, "3 pages should yield 3 responses");
     }
 
@@ -1157,7 +859,8 @@ mod tests {
             update_parent: UpdateParentNone {},
         };
 
-        let responses: Vec<_> = modify_ptes::<20, 12, MockTableOps, _>(request).collect();
+        let responses: Vec<_> =
+            modify_ptes::<20, 12, PTE_SHIFT, MockTableOps, _>(request).collect();
         assert_eq!(responses.len(), 0, "Zero length should yield no responses");
     }
 
@@ -1173,7 +876,8 @@ mod tests {
             update_parent: UpdateParentNone {},
         };
 
-        let responses: Vec<_> = modify_ptes::<20, 12, MockTableOps, _>(request).collect();
+        let responses: Vec<_> =
+            modify_ptes::<20, 12, PTE_SHIFT, MockTableOps, _>(request).collect();
         assert_eq!(
             responses.len(),
             2,

--- a/src/hyperlight_common/src/arch/amd64/vmem.rs
+++ b/src/hyperlight_common/src/arch/amd64/vmem.rs
@@ -268,9 +268,12 @@ unsafe fn map_page<
 ///
 /// Multi-space page-table walking on amd64: walks each root
 /// independently and emits all leaves as `ThisSpace`. Aliased
-/// intermediate-table detection is not implemented — no current
-/// embedder exercises that pattern on amd64 (it is an i686/Nanvix-
-/// specific concern).
+/// intermediate-table detection is not implemented here because no
+/// current embedder exercises that pattern on amd64.
+///
+/// TODO: align with the i686 implementation and detect aliased
+/// intermediate tables to avoid semantic divergence across arches.
+/// Tracking: follow-up issue.
 #[allow(clippy::missing_safety_doc)]
 pub unsafe fn walk_va_spaces<Op: TableReadOps>(
     op: &Op,

--- a/src/hyperlight_common/src/arch/amd64/vmem.rs
+++ b/src/hyperlight_common/src/arch/amd64/vmem.rs
@@ -265,6 +265,7 @@ unsafe fn map_page<
 /// 2. PDPT (38:30) - allocate PD if needed
 /// 3. PD (29:21) - allocate PT if needed
 /// 4. PT (20:12) - write final PTE with physical address and flags
+///
 /// Multi-space page-table walking on amd64: walks each root
 /// independently and emits all leaves as `ThisSpace`. Aliased
 /// intermediate-table detection is not implemented — no current

--- a/src/hyperlight_common/src/arch/amd64/vmem.rs
+++ b/src/hyperlight_common/src/arch/amd64/vmem.rs
@@ -596,6 +596,72 @@ pub type PageTableEntry = u64;
 pub type VirtAddr = u64;
 pub type PhysAddr = u64;
 
+/// i686 guest page-table walker and PTE constants for the x86_64 host.
+///
+/// When the host builds with `i686-guest`, it needs to walk 2-level i686
+/// page tables in guest memory. The `arch/i686/vmem.rs` module only compiles
+/// for `target_arch = "x86"` (the guest side), so the host-side walker lives
+/// here, gated behind the feature flag.
+#[cfg(feature = "i686-guest")]
+pub mod i686_guest {
+    use alloc::vec::Vec;
+
+    use crate::vmem::{BasicMapping, CowMapping, Mapping, MappingKind, TableReadOps};
+
+    pub const PAGE_PRESENT: u64 = 1;
+    pub const PAGE_RW: u64 = 1 << 1;
+    pub const PAGE_USER: u64 = 1 << 2;
+    pub const PAGE_ACCESSED: u64 = 1 << 5;
+    pub const PAGE_AVL_COW: u64 = 1 << 9;
+    pub const PTE_ADDR_MASK: u64 = 0xFFFFF000;
+
+    /// Walk an i686 2-level page table and return all present mappings.
+    ///
+    /// # Safety
+    /// The caller must ensure that `op` provides valid page table memory.
+    pub unsafe fn virt_to_phys_all<Op: TableReadOps>(op: &Op) -> Vec<Mapping> {
+        let root = op.root_table();
+        let mut mappings = Vec::new();
+        for pdi in 0..1024u64 {
+            let pde_ptr = Op::entry_addr(root, pdi * 4);
+            let pde: u64 = unsafe { op.read_entry(pde_ptr) };
+            if (pde & PAGE_PRESENT) == 0 {
+                continue;
+            }
+            let pt_phys = pde & PTE_ADDR_MASK;
+            let pt_base = Op::from_phys(pt_phys as crate::vmem::PhysAddr);
+            for pti in 0..1024u64 {
+                let pte_ptr = Op::entry_addr(pt_base, pti * 4);
+                let pte: u64 = unsafe { op.read_entry(pte_ptr) };
+                if (pte & PAGE_PRESENT) == 0 {
+                    continue;
+                }
+                let phys_base = pte & PTE_ADDR_MASK;
+                let virt_base = (pdi << 22) | (pti << 12);
+                let kind = if (pte & PAGE_AVL_COW) != 0 {
+                    MappingKind::Cow(CowMapping {
+                        readable: true,
+                        executable: true,
+                    })
+                } else {
+                    MappingKind::Basic(BasicMapping {
+                        readable: true,
+                        writable: (pte & PAGE_RW) != 0,
+                        executable: true,
+                    })
+                };
+                mappings.push(Mapping {
+                    phys_base,
+                    virt_base,
+                    len: super::PAGE_SIZE as u64,
+                    kind,
+                });
+            }
+        }
+        mappings
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use alloc::vec;

--- a/src/hyperlight_common/src/arch/amd64/vmem.rs
+++ b/src/hyperlight_common/src/arch/amd64/vmem.rs
@@ -27,9 +27,30 @@ limitations under the License.
 
 use crate::vmem::{
     BasicMapping, CowMapping, MapRequest, MapResponse, Mapping, MappingKind, TableMovabilityBase,
-    TableOps, TableReadOps, UpdateParent, UpdateParentNone, UpdateParentRoot, UpdateParentTable,
-    Void, modify_ptes, write_entry_updating,
+    TableOps, TableReadOps, UpdateParent, UpdateParentNone, Void, modify_ptes, write_entry_updating,
 };
+
+/// Parent is another page table whose ancestors may also need
+/// updating when it relocates.
+pub struct UpdateParentTable<Op: TableOps, P: UpdateParent<Op>> {
+    pub(crate) parent: P,
+    pub(crate) entry_ptr: Op::TableAddr,
+}
+impl<Op: TableOps, P: UpdateParent<Op>> Clone for UpdateParentTable<Op, P> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl<Op: TableOps, P: UpdateParent<Op>> Copy for UpdateParentTable<Op, P> {}
+impl<Op: TableOps, P: UpdateParent<Op>> UpdateParentTable<Op, P> {
+    pub(crate) fn new(parent: P, entry_ptr: Op::TableAddr) -> Self {
+        UpdateParentTable { parent, entry_ptr }
+    }
+}
+
+/// Parent is the root (e.g. CR3).
+#[derive(Copy, Clone)]
+pub struct UpdateParentRoot {}
 
 /// Read a PTE and return it (widened to u64) if the present bit is
 /// set. The amd64 "present" encoding is a single bit (bit 0); other

--- a/src/hyperlight_common/src/arch/amd64/vmem.rs
+++ b/src/hyperlight_common/src/arch/amd64/vmem.rs
@@ -51,7 +51,7 @@ use crate::vmem::{
 //
 
 /// Page is Present
-const PAGE_PRESENT: u64 = 1;
+pub const PAGE_PRESENT: u64 = 1;
 /// Page is Read/Write (if not set page is read only so long as the WP bit in CR0 is set to 1 - which it is in Hyperlight)
 const PAGE_RW: u64 = 1 << 1;
 /// Execute Disable (if this bit is set then data in the page cannot be executed)`
@@ -350,6 +350,7 @@ pub unsafe fn virt_to_phys<'a, Op: TableReadOps + 'a>(
             virt_base: virt_addr,
             len: PAGE_SIZE as u64,
             kind,
+            user_accessible: false,
         })
     })
 }
@@ -531,6 +532,7 @@ mod tests {
                 writable: true,
                 executable: false,
             }),
+            user_accessible: false,
         };
 
         unsafe { map(&ops, mapping) };
@@ -564,6 +566,7 @@ mod tests {
                 writable: false,
                 executable: true,
             }),
+            user_accessible: false,
         };
 
         unsafe { map(&ops, mapping) };
@@ -587,6 +590,7 @@ mod tests {
                 writable: true,
                 executable: false,
             }),
+            user_accessible: false,
         };
 
         unsafe { map(&ops, mapping) };
@@ -620,6 +624,7 @@ mod tests {
                 writable: true,
                 executable: false,
             }),
+            user_accessible: false,
         };
         unsafe { map(&ops, mapping1) };
         let tables_after_first = ops.table_count();
@@ -634,6 +639,7 @@ mod tests {
                 writable: true,
                 executable: false,
             }),
+            user_accessible: false,
         };
         unsafe { map(&ops, mapping2) };
 
@@ -659,6 +665,7 @@ mod tests {
                 writable: true,
                 executable: false,
             }),
+            user_accessible: false,
         };
 
         unsafe { map(&ops, mapping) };
@@ -681,6 +688,7 @@ mod tests {
                 writable: true,
                 executable: false,
             }),
+            user_accessible: false,
         };
 
         unsafe { map(&ops, mapping) };
@@ -703,6 +711,7 @@ mod tests {
                 writable: true,
                 executable: false,
             }),
+            user_accessible: false,
         };
 
         unsafe { map(&ops, mapping) };
@@ -725,6 +734,7 @@ mod tests {
                 writable: true,
                 executable: false,
             }),
+            user_accessible: false,
         };
 
         unsafe { map(&ops, mapping) };
@@ -746,6 +756,7 @@ mod tests {
                 virt_base: 0x1000,
                 len: PAGE_SIZE as u64,
                 kind,
+                user_accessible: false,
             };
             unsafe { map(&ops, mapping) };
             let result = unsafe { virt_to_phys(&ops, 0x1000, 1).next() };
@@ -803,6 +814,7 @@ mod tests {
                 writable: true,
                 executable: false,
             }),
+            user_accessible: false,
         };
 
         unsafe { map(&ops, mapping) };

--- a/src/hyperlight_common/src/arch/amd64/vmem.rs
+++ b/src/hyperlight_common/src/arch/amd64/vmem.rs
@@ -26,9 +26,9 @@ limitations under the License.
 //! allocating intermediate tables as needed and setting appropriate flags on leaf PTEs
 
 use crate::vmem::{
-    BasicMapping, CowMapping, MapRequest, MapResponse, Mapping, MappingKind, TableMovability as _,
-    TableMovabilityBase, TableOps, TableReadOps, UpdateParent, UpdateParentNone, UpdateParentRoot,
-    UpdateParentTable, modify_ptes, read_pte_if_present, require_pte_exist, write_entry_updating,
+    BasicMapping, CowMapping, MapRequest, MapResponse, Mapping, MappingKind, TableMovabilityBase,
+    TableOps, TableReadOps, UpdateParent, UpdateParentNone, UpdateParentRoot, UpdateParentTable,
+    modify_ptes, read_pte_if_present, require_pte_exist, write_entry_updating,
 };
 
 // Paging Flags
@@ -58,7 +58,7 @@ const PAGE_RW: u64 = 1 << 1;
 const PAGE_NX: u64 = 1 << 63;
 /// Mask to extract the physical address from a PTE (bits 51:12)
 /// This masks out the lower 12 flag bits AND the upper bits including NX (bit 63)
-const PTE_ADDR_MASK: u64 = 0x000F_FFFF_FFFF_F000;
+pub const PTE_ADDR_MASK: u64 = 0x000F_FFFF_FFFF_F000;
 const PAGE_USER_ACCESS_DISABLED: u64 = 0 << 2; // U/S bit not set - supervisor mode only (no code runs in user mode for now)
 const PAGE_DIRTY_SET: u64 = 1 << 6; // D - dirty bit
 const PAGE_ACCESSED_SET: u64 = 1 << 5; // A - accessed bit
@@ -96,9 +96,14 @@ fn pte_for_table<Op: TableOps>(table_addr: Op::TableAddr) -> u64 {
         PAGE_PRESENT // P   - this entry is present
 }
 
-// ---- TableMovability + UpdateParent impls ----
-
-impl<Op: TableOps<TableMovability = crate::vmem::MayMoveTable>> crate::vmem::TableMovability<Op>
+/// This trait is used to select appropriate implementations of
+/// [`UpdateParent`] to be used, depending on whether a particular
+/// implementation needs the ability to move tables.
+pub trait TableMovability<Op: TableReadOps + ?Sized, TableMoveInfo> {
+    type RootUpdateParent: UpdateParent<Op, TableMoveInfo = TableMoveInfo>;
+    fn root_update_parent() -> Self::RootUpdateParent;
+}
+impl<Op: TableOps<TableMovability = crate::vmem::MayMoveTable>> TableMovability<Op, Op::TableAddr>
     for crate::vmem::MayMoveTable
 {
     type RootUpdateParent = UpdateParentRoot;
@@ -106,7 +111,7 @@ impl<Op: TableOps<TableMovability = crate::vmem::MayMoveTable>> crate::vmem::Tab
         UpdateParentRoot {}
     }
 }
-impl<Op: TableReadOps> crate::vmem::TableMovability<Op> for crate::vmem::MayNotMoveTable {
+impl<Op: TableReadOps> TableMovability<Op, crate::vmem::Void> for crate::vmem::MayNotMoveTable {
     type RootUpdateParent = UpdateParentNone;
     fn root_update_parent() -> Self::RootUpdateParent {
         UpdateParentNone {}
@@ -145,9 +150,6 @@ impl<Op: TableOps<TableMovability = crate::vmem::MayMoveTable>> crate::vmem::Upd
         Self::ChildType::new(self, entry_ptr)
     }
 }
-
-/// amd64 PTE shift: log2(8) = 3 for 8-byte entries
-const PTE_SHIFT: u8 = 3;
 
 /// Page-mapping callback to allocate a next-level page table if necessary.
 /// # Safety
@@ -265,18 +267,18 @@ unsafe fn map_page<
 /// 4. PT (20:12) - write final PTE with physical address and flags
 #[allow(clippy::missing_safety_doc)]
 pub unsafe fn map<Op: TableOps>(op: &Op, mapping: Mapping) {
-    modify_ptes::<47, 39, PTE_SHIFT, Op, _>(MapRequest {
+    modify_ptes::<47, 39, Op, _>(MapRequest {
         table_base: op.root_table(),
         vmin: mapping.virt_base,
         len: mapping.len,
         update_parent: Op::TableMovability::root_update_parent(),
     })
     .map(|r| unsafe { alloc_pte_if_needed(op, r) })
-    .flat_map(modify_ptes::<38, 30, PTE_SHIFT, Op, _>)
+    .flat_map(modify_ptes::<38, 30, Op, _>)
     .map(|r| unsafe { alloc_pte_if_needed(op, r) })
-    .flat_map(modify_ptes::<29, 21, PTE_SHIFT, Op, _>)
+    .flat_map(modify_ptes::<29, 21, Op, _>)
     .map(|r| unsafe { alloc_pte_if_needed(op, r) })
-    .flat_map(modify_ptes::<20, 12, PTE_SHIFT, Op, _>)
+    .flat_map(modify_ptes::<20, 12, Op, _>)
     .map(|r| unsafe { map_page(op, &mapping, r) })
     .for_each(drop);
 }
@@ -311,18 +313,18 @@ pub unsafe fn virt_to_phys<'a, Op: TableReadOps + 'a>(
     // Calculate the maximum virtual address we need to look at based on the starting
     // address and length ensuring we don't go past the end of the address space
     let vmax = core::cmp::min(addr + len, 1u64 << VA_BITS);
-    modify_ptes::<47, 39, PTE_SHIFT, Op, _>(MapRequest {
+    modify_ptes::<47, 39, Op, _>(MapRequest {
         table_base: op.as_ref().root_table(),
         vmin,
         len: vmax - vmin,
         update_parent: UpdateParentNone {},
     })
-    .filter_map(move |r| unsafe { require_pte_exist::<PTE_ADDR_MASK, _, _>(op.as_ref(), r) })
-    .flat_map(modify_ptes::<38, 30, PTE_SHIFT, Op, _>)
-    .filter_map(move |r| unsafe { require_pte_exist::<PTE_ADDR_MASK, _, _>(op.as_ref(), r) })
-    .flat_map(modify_ptes::<29, 21, PTE_SHIFT, Op, _>)
-    .filter_map(move |r| unsafe { require_pte_exist::<PTE_ADDR_MASK, _, _>(op.as_ref(), r) })
-    .flat_map(modify_ptes::<20, 12, PTE_SHIFT, Op, _>)
+    .filter_map(move |r| unsafe { require_pte_exist(op.as_ref(), r) })
+    .flat_map(modify_ptes::<38, 30, Op, _>)
+    .filter_map(move |r| unsafe { require_pte_exist(op.as_ref(), r) })
+    .flat_map(modify_ptes::<29, 21, Op, _>)
+    .filter_map(move |r| unsafe { require_pte_exist(op.as_ref(), r) })
+    .flat_map(modify_ptes::<20, 12, Op, _>)
     .filter_map(move |r| {
         let pte = unsafe { read_pte_if_present(op.as_ref(), r.entry_ptr) }?;
         let phys_addr = pte & PTE_ADDR_MASK;
@@ -839,8 +841,7 @@ mod tests {
             update_parent: UpdateParentNone {},
         };
 
-        let responses: Vec<_> =
-            modify_ptes::<20, 12, PTE_SHIFT, MockTableOps, _>(request).collect();
+        let responses: Vec<_> = modify_ptes::<20, 12, MockTableOps, _>(request).collect();
         assert_eq!(responses.len(), 1, "Single page should yield one response");
         assert_eq!(responses[0].vmin, 0x1000);
         assert_eq!(responses[0].len, PAGE_SIZE as u64);
@@ -856,8 +857,7 @@ mod tests {
             update_parent: UpdateParentNone {},
         };
 
-        let responses: Vec<_> =
-            modify_ptes::<20, 12, PTE_SHIFT, MockTableOps, _>(request).collect();
+        let responses: Vec<_> = modify_ptes::<20, 12, MockTableOps, _>(request).collect();
         assert_eq!(responses.len(), 3, "3 pages should yield 3 responses");
     }
 
@@ -871,8 +871,7 @@ mod tests {
             update_parent: UpdateParentNone {},
         };
 
-        let responses: Vec<_> =
-            modify_ptes::<20, 12, PTE_SHIFT, MockTableOps, _>(request).collect();
+        let responses: Vec<_> = modify_ptes::<20, 12, MockTableOps, _>(request).collect();
         assert_eq!(responses.len(), 0, "Zero length should yield no responses");
     }
 
@@ -888,8 +887,7 @@ mod tests {
             update_parent: UpdateParentNone {},
         };
 
-        let responses: Vec<_> =
-            modify_ptes::<20, 12, PTE_SHIFT, MockTableOps, _>(request).collect();
+        let responses: Vec<_> = modify_ptes::<20, 12, MockTableOps, _>(request).collect();
         assert_eq!(
             responses.len(),
             2,

--- a/src/hyperlight_common/src/arch/i686/layout.rs
+++ b/src/hyperlight_common/src/arch/i686/layout.rs
@@ -14,14 +14,17 @@ See the License for the specific language governing permissions and
 limitations under the License.
  */
 
-// This file is just dummy definitions at the moment, in order to
-// allow compiling the guest for real mode boot scenarios.
+// i686 layout constants for 32-bit protected mode with paging.
 
 pub const MAX_GVA: usize = 0xffff_ffff;
 /// Set below the KVM APIC access page at 0xFEE00000 to avoid EEXIST when scratch
 /// regions are large enough to reach that address.
 pub const MAX_GPA: usize = 0xFEDF_FFFF;
 
-pub fn min_scratch_size(_input_data_size: usize, _output_data_size: usize) -> usize {
-    crate::vmem::PAGE_SIZE
+/// Minimum scratch region size: IO buffers (page-aligned) plus 12 pages
+/// for bookkeeping and the exception stack. Page table space is validated
+/// separately by `set_pt_size()`.
+pub fn min_scratch_size(input_data_size: usize, output_data_size: usize) -> usize {
+    (input_data_size + output_data_size).next_multiple_of(crate::vmem::PAGE_SIZE)
+        + 12 * crate::vmem::PAGE_SIZE
 }

--- a/src/hyperlight_common/src/arch/i686/vmem.rs
+++ b/src/hyperlight_common/src/arch/i686/vmem.rs
@@ -22,9 +22,9 @@ limitations under the License.
 //! Entries are 4 bytes wide. There is no NX bit; all pages are executable.
 
 use crate::vmem::{
-    BasicMapping, CowMapping, MapRequest, MapResponse, Mapping, MappingKind, TableMovabilityBase,
-    TableOps, TableReadOps, UpdateParent, UpdateParentNone, modify_ptes, read_pte_if_present,
-    require_pte_exist, write_entry_updating,
+    BasicMapping, CowMapping, MapRequest, MapResponse, Mapping, MappingKind, SpaceAwareMapping,
+    SpaceId, SpaceReferenceMapping, TableMovabilityBase, TableOps, TableReadOps, UpdateParent,
+    UpdateParentNone, modify_ptes, read_pte_if_present, require_pte_exist, write_entry_updating,
 };
 
 pub const PAGE_SIZE: usize = 4096;
@@ -167,6 +167,187 @@ pub unsafe fn map<Op: TableOps>(op: &Op, mapping: Mapping) {
     .flat_map(modify_ptes::<21, 12, Op, _>)
     .map(|r| unsafe { map_page(op, &mapping, r) })
     .for_each(drop);
+}
+
+//==================================================================================================
+// Multi-space walk / link (shared intermediate tables)
+//==================================================================================================
+
+/// i686 has two levels (PD -> PT). The only sharable thing is a PT,
+/// at depth 1 (one level below the root PD).
+const SHARED_TABLE_DEPTH: usize = 1;
+
+/// Walk multiple root PDs together, detecting PDEs that point at the
+/// same PT PA across roots (i.e. aliased PTs — the standard
+/// "kernel-half shared" trick on x86 without KPTI). The first root to
+/// visit a given PT PA becomes the "owner"; later roots that alias it
+/// receive `AnotherSpace(SpaceReferenceMapping { depth: 1, .. })`
+/// entries.
+///
+/// Generic over `TableAddr` so it works with both the in-guest
+/// implementation (`TableAddr = u32`, backed by raw pointers) and the
+/// host-side snapshot buffer (`TableAddr = u64`, byte offsets).
+///
+/// # Safety
+/// Same invariants as [`virt_to_phys`]. Callers must not mutate the
+/// page tables concurrently.
+#[allow(clippy::missing_safety_doc)]
+pub unsafe fn walk_va_spaces<Op: TableReadOps>(
+    op: &Op,
+    roots: &[Op::TableAddr],
+    address: u64,
+    len: u64,
+) -> ::alloc::vec::Vec<(SpaceId, ::alloc::vec::Vec<SpaceAwareMapping>)> {
+    use ::alloc::vec::Vec;
+
+    // Map: PT PA -> (owner SpaceId, the VA at which the owner used
+    // this PT). Subsequent visits to the same PT PA emit AnotherSpace.
+    let mut seen_pts: ::alloc::collections::BTreeMap<u64, (SpaceId, u64)> =
+        ::alloc::collections::BTreeMap::new();
+    let mut results: Vec<(SpaceId, Vec<SpaceAwareMapping>)> = Vec::with_capacity(roots.len());
+
+    let vmin = address & !(PAGE_SIZE as u64 - 1);
+    let vmax = core::cmp::min(address + len, 1u64 << VA_BITS);
+
+    for &root in roots {
+        #[allow(clippy::unnecessary_cast)]
+        let root_id: SpaceId = Op::to_phys(root) as u64;
+        let mut mappings: Vec<SpaceAwareMapping> = Vec::new();
+
+        // Iterate PDEs covering [vmin, vmax) at the PD level (bits 31:22).
+        let pde_iter = modify_ptes::<31, 22, Op, _>(MapRequest {
+            table_base: root,
+            vmin,
+            len: vmax.saturating_sub(vmin),
+            update_parent: UpdateParentNone {},
+        });
+        for r in pde_iter {
+            let Some(pde) = (unsafe { read_pte_if_present(op, r.entry_ptr) }) else {
+                continue;
+            };
+            let pt_pa: u64 = pde & PTE_ADDR_MASK;
+
+            // Seen this PT via an earlier root? Emit AnotherSpace and
+            // don't descend — the sub-tree is fully described by the
+            // owner's entries.
+            if let Some(&(owner, their_va)) = seen_pts.get(&pt_pa) {
+                if owner != root_id {
+                    mappings.push(SpaceAwareMapping::AnotherSpace(SpaceReferenceMapping {
+                        depth: SHARED_TABLE_DEPTH,
+                        space: owner,
+                        our_va: r.vmin,
+                        their_va,
+                    }));
+                    continue;
+                }
+                // Same space saw this PT before (shouldn't happen with
+                // the virt_to_phys-style per-PDE iteration, but skip
+                // defensively).
+                continue;
+            }
+            seen_pts.insert(pt_pa, (root_id, r.vmin));
+
+            // Descend the PT and emit ThisSpace entries for each live
+            // 4KB leaf, mirroring virt_to_phys's leaf-emission logic.
+            let pt_request = MapRequest {
+                #[allow(clippy::unnecessary_cast)]
+                table_base: Op::from_phys(pt_pa as PhysAddr),
+                vmin: r.vmin,
+                len: r.len,
+                update_parent: UpdateParentNone {},
+            };
+            for leaf in modify_ptes::<21, 12, Op, _>(pt_request) {
+                let Some(pte) = (unsafe { read_pte_if_present(op, leaf.entry_ptr) }) else {
+                    continue;
+                };
+                let phys_addr = pte & PTE_ADDR_MASK;
+                let avl = pte & PTE_AVL_MASK;
+                let kind = if avl == PAGE_AVL_COW {
+                    MappingKind::Cow(CowMapping {
+                        readable: true,
+                        executable: true,
+                    })
+                } else {
+                    MappingKind::Basic(BasicMapping {
+                        readable: true,
+                        writable: (pte & PAGE_RW) != 0,
+                        executable: true,
+                    })
+                };
+                mappings.push(SpaceAwareMapping::ThisSpace(Mapping {
+                    phys_base: phys_addr,
+                    virt_base: leaf.vmin,
+                    len: PAGE_SIZE as u64,
+                    kind,
+                    user_accessible: (pte & PAGE_USER) != 0,
+                }));
+            }
+        }
+
+        results.push((root_id, mappings));
+    }
+
+    results
+}
+
+/// Install the link described by `ref_map` in `op`'s root PT tree:
+/// look up what the owner space's rebuilt root put at `their_va`'s
+/// PDE slot, and write that PA into our root's PDE slot for
+/// `our_va`. The owner's rebuilt root is found via `built_roots`.
+///
+/// On i686 `ref_map.depth` must be 1 (PT-level sharing). Other depths
+/// are rejected defensively.
+///
+/// # Safety
+/// Same invariants as [`map`]: caller owns the concurrency story and
+/// must invalidate the TLB if the page tables are live.
+#[allow(clippy::missing_safety_doc)]
+pub unsafe fn space_aware_map<Op: TableOps>(
+    op: &Op,
+    ref_map: SpaceReferenceMapping,
+    built_roots: &::alloc::collections::BTreeMap<SpaceId, Op::TableAddr>,
+) {
+    assert!(
+        ref_map.depth == SHARED_TABLE_DEPTH,
+        "i686 only supports depth={} sharing; got depth={}",
+        SHARED_TABLE_DEPTH,
+        ref_map.depth
+    );
+
+    // Their rebuilt root — must have been populated earlier in the
+    // rebuild loop (walk_va_spaces guarantees topological order).
+    let Some(&their_root) = built_roots.get(&ref_map.space) else {
+        // Defensive: we have no linkage target. Skip rather than
+        // panic. A trace print would live here in a debug build.
+        return;
+    };
+
+    // Read their PDE at their_va's index to get the rebuilt PT PA.
+    let their_pdi = (ref_map.their_va >> 22) & 0x3FF;
+    let their_pde_ptr = Op::entry_addr(
+        their_root,
+        their_pdi * core::mem::size_of::<PageTableEntry>() as u64,
+    );
+    let Some(their_pde) = (unsafe { read_pte_if_present(op, their_pde_ptr) }) else {
+        // Owner didn't end up with a PDE here — nothing to link.
+        return;
+    };
+    let their_pt_pa: u64 = their_pde & PTE_ADDR_MASK;
+
+    // Compose our PDE: point at their PT, preserve their PDE's low
+    // bits (PAGE_USER for kernel-accessible, PAGE_RW, etc.) so the
+    // hardware still honours sharing semantics uniformly.
+    let our_pdi = (ref_map.our_va >> 22) & 0x3FF;
+    let our_root = op.root_table();
+    let our_pde_ptr = Op::entry_addr(
+        our_root,
+        our_pdi * core::mem::size_of::<PageTableEntry>() as u64,
+    );
+
+    let new_pde: u64 = their_pt_pa | (their_pde & !PTE_ADDR_MASK) | PAGE_PRESENT;
+    unsafe {
+        write_entry_updating(op, Op::TableMovability::root_update_parent(), our_pde_ptr, new_pde);
+    }
 }
 
 /// Translate a virtual address range to its backing physical pages.

--- a/src/hyperlight_common/src/arch/i686/vmem.rs
+++ b/src/hyperlight_common/src/arch/i686/vmem.rs
@@ -24,7 +24,7 @@ limitations under the License.
 use crate::vmem::{
     BasicMapping, CowMapping, MapRequest, MapResponse, Mapping, MappingKind, SpaceAwareMapping,
     SpaceId, SpaceReferenceMapping, TableMovabilityBase, TableOps, TableReadOps, UpdateParent,
-    UpdateParentNone, modify_ptes, read_pte_if_present, require_pte_exist, write_entry_updating,
+    UpdateParentNone, modify_ptes, write_entry_updating,
 };
 
 pub const PAGE_SIZE: usize = 4096;
@@ -59,6 +59,46 @@ impl<Op: TableReadOps> TableMovability<Op, crate::vmem::Void> for crate::vmem::M
 #[inline(always)]
 const fn page_rw_flag(writable: bool) -> u64 {
     if writable { PAGE_RW } else { 0 }
+}
+
+/// Read a PTE and return it (widened to u64) if the present bit is
+/// set. On i686 "present" is a single bit; archs that need richer
+/// checks define their own variant.
+///
+/// # Safety
+/// `entry_ptr` must point to a valid page table entry.
+#[inline(always)]
+#[allow(clippy::useless_conversion)]
+pub(super) unsafe fn read_pte_if_present<Op: TableReadOps>(
+    op: &Op,
+    entry_ptr: Op::TableAddr,
+) -> Option<u64> {
+    let pte: u64 = unsafe { op.read_entry(entry_ptr) }.into();
+    if (pte & PAGE_PRESENT) != 0 {
+        Some(pte)
+    } else {
+        None
+    }
+}
+
+/// Require that a PTE is present and descend to the next-level table.
+///
+/// # Safety
+/// `op` must provide valid page table memory.
+pub(super) unsafe fn require_pte_exist<Op: TableReadOps, P: UpdateParent<Op>>(
+    op: &Op,
+    x: MapResponse<Op, P>,
+) -> Option<MapRequest<Op, P::ChildType>>
+where
+    P::ChildType: UpdateParent<Op>,
+{
+    unsafe { read_pte_if_present(op, x.entry_ptr) }.map(|pte| MapRequest {
+        #[allow(clippy::unnecessary_cast)]
+        table_base: Op::from_phys((pte & PTE_ADDR_MASK) as PhysAddr),
+        vmin: x.vmin,
+        len: x.len,
+        update_parent: x.update_parent.for_child_at_entry(x.entry_ptr),
+    })
 }
 
 /// Generate a PDE pointing to a page table.

--- a/src/hyperlight_common/src/arch/i686/vmem.rs
+++ b/src/hyperlight_common/src/arch/i686/vmem.rs
@@ -70,8 +70,6 @@ fn pte_for_table<Op: TableOps>(table_addr: Op::TableAddr) -> u64 {
     phys | PAGE_USER | PAGE_RW | PAGE_ACCESSED | PAGE_PRESENT
 }
 
-// ---- Page table manipulation ----
-
 /// # Safety
 /// Must not be called concurrently with other page table modifications.
 unsafe fn alloc_pte_if_needed<

--- a/src/hyperlight_common/src/arch/i686/vmem.rs
+++ b/src/hyperlight_common/src/arch/i686/vmem.rs
@@ -346,7 +346,12 @@ pub unsafe fn space_aware_map<Op: TableOps>(
 
     let new_pde: u64 = their_pt_pa | (their_pde & !PTE_ADDR_MASK) | PAGE_PRESENT;
     unsafe {
-        write_entry_updating(op, Op::TableMovability::root_update_parent(), our_pde_ptr, new_pde);
+        write_entry_updating(
+            op,
+            Op::TableMovability::root_update_parent(),
+            our_pde_ptr,
+            new_pde,
+        );
     }
 }
 

--- a/src/hyperlight_common/src/arch/i686/vmem.rs
+++ b/src/hyperlight_common/src/arch/i686/vmem.rs
@@ -14,10 +14,18 @@ See the License for the specific language governing permissions and
 limitations under the License.
  */
 
-// This file is just dummy definitions at the moment, in order to
-// allow compiling the guest for real mode boot scenarios.
+//! i686 2-level page table manipulation code.
+//!
+//! - PD (Page Directory) - bits 31:22 - 1024 entries, each covering 4MB
+//! - PT (Page Table) - bits 20:12 - 1024 entries, each covering 4KB pages
+//!
+//! Entries are 4 bytes wide. There is no NX bit; all pages are executable.
 
-use crate::vmem::{Mapping, TableOps, TableReadOps, Void};
+use crate::vmem::{
+    BasicMapping, CowMapping, MapRequest, MapResponse, Mapping, MappingKind, TableMovability as _,
+    TableMovabilityBase, TableOps, TableReadOps, UpdateParent, UpdateParentNone, modify_ptes,
+    read_pte_if_present, require_pte_exist, write_entry_updating,
+};
 
 pub const PAGE_SIZE: usize = 4096;
 pub const PAGE_TABLE_SIZE: usize = 4096;
@@ -25,25 +33,171 @@ pub type PageTableEntry = u32;
 pub type VirtAddr = u32;
 pub type PhysAddr = u32;
 
-#[allow(clippy::missing_safety_doc)]
-pub unsafe fn map<Op: TableOps>(_op: &Op, _mapping: Mapping) {
-    panic!("vmem::map: i686 guests do not support booting the full hyperlight guest kernel");
+// i686 PTE flags
+const PAGE_PRESENT: u64 = 1;
+const PAGE_RW: u64 = 1 << 1;
+pub const PAGE_USER: u64 = 1 << 2;
+const PAGE_ACCESSED: u64 = 1 << 5;
+const PTE_ADDR_MASK: u64 = 0xFFFFF000;
+const PTE_AVL_MASK: u64 = 0x0E00;
+const PAGE_AVL_COW: u64 = 1 << 9;
+
+const VA_BITS: usize = 32;
+/// log2(4) for 4-byte entries
+const PTE_SHIFT: u8 = 2;
+
+#[inline(always)]
+const fn page_rw_flag(writable: bool) -> u64 {
+    if writable { PAGE_RW } else { 0 }
 }
 
-#[allow(clippy::missing_safety_doc)]
-pub unsafe fn virt_to_phys<Op: TableOps>(_op: &Op, _address: u64) -> impl Iterator<Item = Mapping> {
-    panic!(
-        "vmem::virt_to_phys: i686 guests do not support booting the full hyperlight guest kernel"
-    );
-    // necessary to provide a concrete type that impls Iterator as the
-    // return type, even though this will never be executed
-    #[allow(unreachable_code)]
-    core::iter::empty()
+/// Generate a PDE pointing to a page table.
+/// Does not set PAGE_USER; the caller controls user-accessibility
+/// per VA region (kernel PDEs stay supervisor-only, user PDEs get
+/// PAGE_USER added after mapping).
+fn pte_for_table<Op: TableOps>(table_addr: Op::TableAddr) -> u64 {
+    #[allow(clippy::unnecessary_cast)]
+    let phys = Op::to_phys(table_addr) as u64;
+    phys | PAGE_RW | PAGE_ACCESSED | PAGE_PRESENT
 }
 
-pub trait TableMovability<Op: TableReadOps + ?Sized, TableMoveInfo> {}
-impl<Op: TableOps<TableMovability = crate::vmem::MayMoveTable>> TableMovability<Op, Op::TableAddr>
-    for crate::vmem::MayMoveTable
+// ---- Page table manipulation ----
+
+/// # Safety
+/// Must not be called concurrently with other page table modifications.
+unsafe fn alloc_pte_if_needed<
+    Op: TableOps,
+    P: UpdateParent<
+            Op,
+            TableMoveInfo = <Op::TableMovability as TableMovabilityBase<Op>>::TableMoveInfo,
+        >,
+>(
+    op: &Op,
+    x: MapResponse<Op, P>,
+) -> MapRequest<Op, P::ChildType>
+where
+    P::ChildType: UpdateParent<Op>,
 {
+    let new_update_parent = x.update_parent.for_child_at_entry(x.entry_ptr);
+    if let Some(pte) = unsafe { read_pte_if_present(op, x.entry_ptr) } {
+        #[allow(clippy::unnecessary_cast)]
+        return MapRequest {
+            table_base: Op::from_phys((pte & PTE_ADDR_MASK) as super::PhysAddr),
+            vmin: x.vmin,
+            len: x.len,
+            update_parent: new_update_parent,
+        };
+    }
+
+    let page_addr = unsafe { op.alloc_table() };
+    let pte = pte_for_table::<Op>(page_addr);
+    unsafe {
+        write_entry_updating(op, x.update_parent, x.entry_ptr, pte);
+    };
+    MapRequest {
+        table_base: page_addr,
+        vmin: x.vmin,
+        len: x.len,
+        update_parent: new_update_parent,
+    }
 }
-impl<Op: TableReadOps> TableMovability<Op, Void> for crate::vmem::MayNotMoveTable {}
+
+/// Write a leaf PTE. i686 has no NX bit so all pages are executable.
+///
+/// # Safety
+/// Must not be called concurrently with other page table modifications.
+unsafe fn map_page<
+    Op: TableOps,
+    P: UpdateParent<
+            Op,
+            TableMoveInfo = <Op::TableMovability as TableMovabilityBase<Op>>::TableMoveInfo,
+        >,
+>(
+    op: &Op,
+    mapping: &Mapping,
+    r: MapResponse<Op, P>,
+) {
+    let pte = match &mapping.kind {
+        MappingKind::Basic(bm) => {
+            (mapping.phys_base + (r.vmin - mapping.virt_base))
+                | PAGE_USER
+                | PAGE_ACCESSED
+                | page_rw_flag(bm.writable)
+                | PAGE_PRESENT
+        }
+        MappingKind::Cow(_cm) => {
+            (mapping.phys_base + (r.vmin - mapping.virt_base))
+                | PAGE_USER
+                | PAGE_AVL_COW
+                | PAGE_ACCESSED
+                | PAGE_PRESENT
+        }
+        MappingKind::Unmapped => 0,
+    };
+    unsafe {
+        write_entry_updating(op, r.update_parent, r.entry_ptr, pte);
+    }
+}
+
+/// Map a contiguous virtual address range using 2-level paging (PD -> PT).
+///
+/// # Safety
+/// See [`crate::vmem::map`].
+#[allow(clippy::missing_safety_doc)]
+pub unsafe fn map<Op: TableOps>(op: &Op, mapping: Mapping) {
+    modify_ptes::<31, 22, PTE_SHIFT, Op, _>(MapRequest {
+        table_base: op.root_table(),
+        vmin: mapping.virt_base,
+        len: mapping.len,
+        update_parent: Op::TableMovability::root_update_parent(),
+    })
+    .map(|r| unsafe { alloc_pte_if_needed(op, r) })
+    .flat_map(modify_ptes::<21, 12, PTE_SHIFT, Op, _>)
+    .map(|r| unsafe { map_page(op, &mapping, r) })
+    .for_each(drop);
+}
+
+/// Translate a virtual address range to its backing physical pages.
+///
+/// # Safety
+/// See [`crate::vmem::virt_to_phys`].
+#[allow(clippy::missing_safety_doc)]
+pub unsafe fn virt_to_phys<'a, Op: TableReadOps + 'a>(
+    op: impl core::convert::AsRef<Op> + Copy + 'a,
+    address: u64,
+    len: u64,
+) -> impl Iterator<Item = Mapping> + 'a {
+    let vmin = address & !(PAGE_SIZE as u64 - 1);
+    let vmax = core::cmp::min(address + len, 1u64 << VA_BITS);
+    modify_ptes::<31, 22, PTE_SHIFT, Op, _>(MapRequest {
+        table_base: op.as_ref().root_table(),
+        vmin,
+        len: vmax.saturating_sub(vmin),
+        update_parent: UpdateParentNone {},
+    })
+    .filter_map(move |r| unsafe { require_pte_exist::<PTE_ADDR_MASK, _, _>(op.as_ref(), r) })
+    .flat_map(modify_ptes::<21, 12, PTE_SHIFT, Op, _>)
+    .filter_map(move |r| {
+        let pte = unsafe { read_pte_if_present(op.as_ref(), r.entry_ptr) }?;
+        let phys_addr = pte & PTE_ADDR_MASK;
+        let avl = pte & PTE_AVL_MASK;
+        let kind = if avl == PAGE_AVL_COW {
+            MappingKind::Cow(CowMapping {
+                readable: true,
+                executable: true,
+            })
+        } else {
+            MappingKind::Basic(BasicMapping {
+                readable: true,
+                writable: (pte & PAGE_RW) != 0,
+                executable: true,
+            })
+        };
+        Some(Mapping {
+            phys_base: phys_addr,
+            virt_base: r.vmin,
+            len: PAGE_SIZE as u64,
+            kind,
+        })
+    })
+}

--- a/src/hyperlight_common/src/arch/i686/vmem.rs
+++ b/src/hyperlight_common/src/arch/i686/vmem.rs
@@ -22,9 +22,9 @@ limitations under the License.
 //! Entries are 4 bytes wide. There is no NX bit; all pages are executable.
 
 use crate::vmem::{
-    BasicMapping, CowMapping, MapRequest, MapResponse, Mapping, MappingKind, TableMovability as _,
-    TableMovabilityBase, TableOps, TableReadOps, UpdateParent, UpdateParentNone, modify_ptes,
-    read_pte_if_present, require_pte_exist, write_entry_updating,
+    BasicMapping, CowMapping, MapRequest, MapResponse, Mapping, MappingKind, TableMovabilityBase,
+    TableOps, TableReadOps, UpdateParent, UpdateParentNone, modify_ptes, read_pte_if_present,
+    require_pte_exist, write_entry_updating,
 };
 
 pub const PAGE_SIZE: usize = 4096;
@@ -38,15 +38,18 @@ pub const PAGE_PRESENT: u64 = 1;
 const PAGE_RW: u64 = 1 << 1;
 pub const PAGE_USER: u64 = 1 << 2;
 const PAGE_ACCESSED: u64 = 1 << 5;
-const PTE_ADDR_MASK: u64 = 0xFFFFF000;
+pub const PTE_ADDR_MASK: u64 = 0xFFFFF000;
 const PTE_AVL_MASK: u64 = 0x0E00;
 const PAGE_AVL_COW: u64 = 1 << 9;
 
 const VA_BITS: usize = 32;
-/// log2(4) for 4-byte entries
-const PTE_SHIFT: u8 = 2;
 
-impl<Op: TableReadOps> crate::vmem::TableMovability<Op> for crate::vmem::MayNotMoveTable {
+pub trait TableMovability<Op: TableReadOps + ?Sized, TableMoveInfo> {
+    type RootUpdateParent: UpdateParent<Op, TableMoveInfo = TableMoveInfo>;
+    fn root_update_parent() -> Self::RootUpdateParent;
+}
+
+impl<Op: TableReadOps> TableMovability<Op, crate::vmem::Void> for crate::vmem::MayNotMoveTable {
     type RootUpdateParent = UpdateParentNone;
     fn root_update_parent() -> Self::RootUpdateParent {
         UpdateParentNone {}
@@ -156,14 +159,14 @@ unsafe fn map_page<
 /// See [`crate::vmem::map`].
 #[allow(clippy::missing_safety_doc)]
 pub unsafe fn map<Op: TableOps>(op: &Op, mapping: Mapping) {
-    modify_ptes::<31, 22, PTE_SHIFT, Op, _>(MapRequest {
+    modify_ptes::<31, 22, Op, _>(MapRequest {
         table_base: op.root_table(),
         vmin: mapping.virt_base,
         len: mapping.len,
         update_parent: Op::TableMovability::root_update_parent(),
     })
     .map(|r| unsafe { alloc_pte_if_needed(op, r) })
-    .flat_map(modify_ptes::<21, 12, PTE_SHIFT, Op, _>)
+    .flat_map(modify_ptes::<21, 12, Op, _>)
     .map(|r| unsafe { map_page(op, &mapping, r) })
     .for_each(drop);
 }
@@ -180,14 +183,14 @@ pub unsafe fn virt_to_phys<'a, Op: TableReadOps + 'a>(
 ) -> impl Iterator<Item = Mapping> + 'a {
     let vmin = address & !(PAGE_SIZE as u64 - 1);
     let vmax = core::cmp::min(address + len, 1u64 << VA_BITS);
-    modify_ptes::<31, 22, PTE_SHIFT, Op, _>(MapRequest {
+    modify_ptes::<31, 22, Op, _>(MapRequest {
         table_base: op.as_ref().root_table(),
         vmin,
         len: vmax.saturating_sub(vmin),
         update_parent: UpdateParentNone {},
     })
-    .filter_map(move |r| unsafe { require_pte_exist::<PTE_ADDR_MASK, _, _>(op.as_ref(), r) })
-    .flat_map(modify_ptes::<21, 12, PTE_SHIFT, Op, _>)
+    .filter_map(move |r| unsafe { require_pte_exist(op.as_ref(), r) })
+    .flat_map(modify_ptes::<21, 12, Op, _>)
     .filter_map(move |r| {
         let pte = unsafe { read_pte_if_present(op.as_ref(), r.entry_ptr) }?;
         let phys_addr = pte & PTE_ADDR_MASK;

--- a/src/hyperlight_common/src/arch/i686/vmem.rs
+++ b/src/hyperlight_common/src/arch/i686/vmem.rs
@@ -34,7 +34,7 @@ pub type VirtAddr = u32;
 pub type PhysAddr = u32;
 
 // i686 PTE flags
-const PAGE_PRESENT: u64 = 1;
+pub const PAGE_PRESENT: u64 = 1;
 const PAGE_RW: u64 = 1 << 1;
 pub const PAGE_USER: u64 = 1 << 2;
 const PAGE_ACCESSED: u64 = 1 << 5;
@@ -46,19 +46,25 @@ const VA_BITS: usize = 32;
 /// log2(4) for 4-byte entries
 const PTE_SHIFT: u8 = 2;
 
+impl<Op: TableReadOps> crate::vmem::TableMovability<Op> for crate::vmem::MayNotMoveTable {
+    type RootUpdateParent = UpdateParentNone;
+    fn root_update_parent() -> Self::RootUpdateParent {
+        UpdateParentNone {}
+    }
+}
+
 #[inline(always)]
 const fn page_rw_flag(writable: bool) -> u64 {
     if writable { PAGE_RW } else { 0 }
 }
 
 /// Generate a PDE pointing to a page table.
-/// Does not set PAGE_USER; the caller controls user-accessibility
-/// per VA region (kernel PDEs stay supervisor-only, user PDEs get
-/// PAGE_USER added after mapping).
+/// Sets PAGE_USER unconditionally so that user-mode leaf PTEs
+/// beneath it can function. The leaf PTE controls actual access.
 fn pte_for_table<Op: TableOps>(table_addr: Op::TableAddr) -> u64 {
     #[allow(clippy::unnecessary_cast)]
     let phys = Op::to_phys(table_addr) as u64;
-    phys | PAGE_RW | PAGE_ACCESSED | PAGE_PRESENT
+    phys | PAGE_USER | PAGE_RW | PAGE_ACCESSED | PAGE_PRESENT
 }
 
 // ---- Page table manipulation ----
@@ -117,17 +123,22 @@ unsafe fn map_page<
     mapping: &Mapping,
     r: MapResponse<Op, P>,
 ) {
+    let user_flag = if mapping.user_accessible {
+        PAGE_USER
+    } else {
+        0
+    };
     let pte = match &mapping.kind {
         MappingKind::Basic(bm) => {
             (mapping.phys_base + (r.vmin - mapping.virt_base))
-                | PAGE_USER
+                | user_flag
                 | PAGE_ACCESSED
                 | page_rw_flag(bm.writable)
                 | PAGE_PRESENT
         }
         MappingKind::Cow(_cm) => {
             (mapping.phys_base + (r.vmin - mapping.virt_base))
-                | PAGE_USER
+                | user_flag
                 | PAGE_AVL_COW
                 | PAGE_ACCESSED
                 | PAGE_PRESENT
@@ -198,6 +209,7 @@ pub unsafe fn virt_to_phys<'a, Op: TableReadOps + 'a>(
             virt_base: r.vmin,
             len: PAGE_SIZE as u64,
             kind,
+            user_accessible: (pte & PAGE_USER) != 0,
         })
     })
 }

--- a/src/hyperlight_common/src/layout.rs
+++ b/src/hyperlight_common/src/layout.rs
@@ -16,11 +16,11 @@ limitations under the License.
 
 #[cfg_attr(target_arch = "x86", path = "arch/i686/layout.rs")]
 #[cfg_attr(
-    all(target_arch = "x86_64", not(feature = "nanvix-unstable")),
+    all(target_arch = "x86_64", not(feature = "i686-guest")),
     path = "arch/amd64/layout.rs"
 )]
 #[cfg_attr(
-    all(target_arch = "x86_64", feature = "nanvix-unstable"),
+    all(target_arch = "x86_64", feature = "i686-guest"),
     path = "arch/i686/layout.rs"
 )]
 #[cfg_attr(target_arch = "aarch64", path = "arch/aarch64/layout.rs")]
@@ -28,7 +28,7 @@ mod arch;
 
 pub use arch::{MAX_GPA, MAX_GVA};
 #[cfg(any(
-    all(target_arch = "x86_64", not(feature = "nanvix-unstable")),
+    all(target_arch = "x86_64", not(feature = "i686-guest")),
     target_arch = "aarch64"
 ))]
 pub use arch::{SNAPSHOT_PT_GVA_MAX, SNAPSHOT_PT_GVA_MIN};
@@ -45,7 +45,7 @@ pub const SCRATCH_TOP_EXN_STACK_OFFSET: u64 = 0x20;
 /// counter falls in scratch page 0xffffe000 instead of the very last page
 /// 0xfffff000, which on i686 guests would require frame 0xfffff — exceeding the
 /// maximum representable frame number.
-#[cfg(feature = "nanvix-unstable")]
+#[cfg(feature = "guest-counter")]
 pub const SCRATCH_TOP_GUEST_COUNTER_OFFSET: u64 = 0x1008;
 
 pub fn scratch_base_gpa(size: usize) -> u64 {

--- a/src/hyperlight_common/src/layout.rs
+++ b/src/hyperlight_common/src/layout.rs
@@ -39,18 +39,6 @@ pub const SCRATCH_TOP_ALLOCATOR_OFFSET: u64 = 0x10;
 pub const SCRATCH_TOP_SNAPSHOT_PT_GPA_BASE_OFFSET: u64 = 0x18;
 pub const SCRATCH_TOP_EXN_STACK_OFFSET: u64 = 0x20;
 
-/// Offset from the top of scratch for the number of active page directory roots.
-/// The guest writes this before signaling boot-complete so the host can walk
-/// all active PDs during snapshot creation (not just CR3).
-#[cfg(feature = "i686-guest")]
-pub const SCRATCH_TOP_PD_ROOTS_COUNT_OFFSET: u64 = 0x28;
-/// Offset from the top of scratch for the PD roots array (u32 GPAs on i686).
-#[cfg(feature = "i686-guest")]
-pub const SCRATCH_TOP_PD_ROOTS_ARRAY_OFFSET: u64 = 0x30;
-/// Maximum number of PD roots the guest can expose to the host.
-#[cfg(feature = "i686-guest")]
-pub const MAX_PD_ROOTS: usize = 32;
-
 /// Offset from the top of scratch memory for a shared host-guest u64 counter.
 ///
 /// This is placed at 0x1008 (rather than the next sequential 0x28) so that the

--- a/src/hyperlight_common/src/layout.rs
+++ b/src/hyperlight_common/src/layout.rs
@@ -37,7 +37,8 @@ pub use arch::{SNAPSHOT_PT_GVA_MAX, SNAPSHOT_PT_GVA_MIN};
 pub const SCRATCH_TOP_SIZE_OFFSET: u64 = 0x08;
 pub const SCRATCH_TOP_ALLOCATOR_OFFSET: u64 = 0x10;
 pub const SCRATCH_TOP_SNAPSHOT_PT_GPA_BASE_OFFSET: u64 = 0x18;
-pub const SCRATCH_TOP_EXN_STACK_OFFSET: u64 = 0x20;
+pub const SCRATCH_TOP_SNAPSHOT_GENERATION_OFFSET: u64 = 0x20;
+pub const SCRATCH_TOP_EXN_STACK_OFFSET: u64 = 0x30;
 
 /// Offset from the top of scratch memory for a shared host-guest u64 counter.
 ///

--- a/src/hyperlight_common/src/layout.rs
+++ b/src/hyperlight_common/src/layout.rs
@@ -39,6 +39,18 @@ pub const SCRATCH_TOP_ALLOCATOR_OFFSET: u64 = 0x10;
 pub const SCRATCH_TOP_SNAPSHOT_PT_GPA_BASE_OFFSET: u64 = 0x18;
 pub const SCRATCH_TOP_EXN_STACK_OFFSET: u64 = 0x20;
 
+/// Offset from the top of scratch for the number of active page directory roots.
+/// The guest writes this before signaling boot-complete so the host can walk
+/// all active PDs during snapshot creation (not just CR3).
+#[cfg(feature = "i686-guest")]
+pub const SCRATCH_TOP_PD_ROOTS_COUNT_OFFSET: u64 = 0x28;
+/// Offset from the top of scratch for the PD roots array (u32 GPAs on i686).
+#[cfg(feature = "i686-guest")]
+pub const SCRATCH_TOP_PD_ROOTS_ARRAY_OFFSET: u64 = 0x30;
+/// Maximum number of PD roots the guest can expose to the host.
+#[cfg(feature = "i686-guest")]
+pub const MAX_PD_ROOTS: usize = 32;
+
 /// Offset from the top of scratch memory for a shared host-guest u64 counter.
 ///
 /// This is placed at 0x1008 (rather than the next sequential 0x28) so that the

--- a/src/hyperlight_common/src/vmem.rs
+++ b/src/hyperlight_common/src/vmem.rs
@@ -19,6 +19,21 @@ limitations under the License.
 #[cfg_attr(target_arch = "aarch64", path = "arch/aarch64/vmem.rs")]
 mod arch;
 
+// The `i686-guest` feature is consumed two ways: the guest itself
+// compiles for `target_arch = "x86"`, and the x86_64 host compiles
+// it to pick up the PT walker under `vmem::i686_guest`. Enabling
+// the feature on any other host (e.g. aarch64) would leave the
+// re-export missing and produce confusing errors in downstream
+// crates — surface it up front.
+#[cfg(all(
+    feature = "i686-guest",
+    not(any(target_arch = "x86", target_arch = "x86_64"))
+))]
+compile_error!(
+    "the `i686-guest` feature is only supported on `target_arch = \"x86\"` (guest) or \
+     `target_arch = \"x86_64\"` (host) targets"
+);
+
 /// This is always the page size that the /guest/ is being compiled
 /// for, which may or may not be the same as the host page size.
 pub use arch::PAGE_SIZE;

--- a/src/hyperlight_common/src/vmem.rs
+++ b/src/hyperlight_common/src/vmem.rs
@@ -38,22 +38,23 @@ compile_error!(
 /// This is always the page size that the /guest/ is being compiled
 /// for, which may or may not be the same as the host page size.
 pub use arch::PAGE_SIZE;
-pub use arch::{PAGE_PRESENT, PAGE_TABLE_SIZE, PageTableEntry, PhysAddr, VirtAddr};
+pub use arch::{PAGE_PRESENT, PAGE_TABLE_SIZE, PTE_ADDR_MASK, PageTableEntry, PhysAddr, VirtAddr};
 pub const PAGE_TABLE_ENTRIES_PER_TABLE: usize =
     PAGE_TABLE_SIZE / core::mem::size_of::<PageTableEntry>();
 
 // Shared page table iterator infrastructure used by each arch module.
 
-/// Extract bits `[HIGH_BIT:LOW_BIT]` (inclusive) from a u64.
+/// Utility function to extract an (inclusive on both ends) bit range
+/// from a quadword.
 #[inline(always)]
 pub(crate) fn bits<const HIGH_BIT: u8, const LOW_BIT: u8>(x: u64) -> u64 {
     (x & ((1 << (HIGH_BIT + 1)) - 1)) >> LOW_BIT
 }
 
-/// Read a PTE and return it (widened to u64) if the present bit is set.
+/// Read a page table entry and return it if the present bit is set.
 ///
 /// # Safety
-/// `entry_ptr` must point to a valid page table entry.
+/// The caller must ensure that `entry_ptr` points to a valid page table entry.
 #[inline(always)]
 #[allow(clippy::useless_conversion)]
 pub(crate) unsafe fn read_pte_if_present<Op: TableReadOps>(
@@ -68,7 +69,8 @@ pub(crate) unsafe fn read_pte_if_present<Op: TableReadOps>(
     }
 }
 
-/// Write a PTE, recursively updating parent entries if the table was moved.
+/// Helper function to write a page table entry, updating the whole
+/// chain of tables back to the root if necessary.
 ///
 /// # Safety
 /// Same requirements as [`TableOps::write_entry`].
@@ -90,9 +92,18 @@ pub(crate) unsafe fn write_entry_updating<
     }
 }
 
-/// Tracks the chain of ancestor page table entries that need updating
-/// when a table is relocated. Implemented as a trait so that the
-/// compiler can specialise per nesting depth for inlining.
+/// A helper trait that allows us to move a page table (e.g. from the
+/// snapshot to the scratch region), keeping track of the context that
+/// needs to be updated when that is moved (and potentially
+/// recursively updating, if necessary).
+///
+/// This is done via a trait so that the selected impl knows the exact
+/// nesting depth of tables, in order to assist
+/// inlining/specialisation in generating efficient code.
+///
+/// The trait definition only bounds its parameter by
+/// [`TableReadOps`], since [`UpdateParentNone`] does not need to be
+/// able to actually write to the tables.
 pub trait UpdateParent<Op: TableReadOps + ?Sized>: Copy {
     /// The type of the information about a moved table which is
     /// needed in order to update its parent.
@@ -105,7 +116,9 @@ pub trait UpdateParent<Op: TableReadOps + ?Sized>: Copy {
     fn for_child_at_entry(self, entry_ptr: Op::TableAddr) -> Self::ChildType;
 }
 
-/// Parent is another page table whose ancestors may also need updating.
+/// A struct implementing [`UpdateParent`] that keeps track of the
+/// fact that the parent table is itself another table, whose own
+/// ancestors may need to be recursively updated.
 /// The `MayMoveTable` impl lives in each arch module (needs `pte_for_table`).
 #[allow(dead_code)] // used only by archs that support MayMoveTable
 pub struct UpdateParentTable<Op: TableOps, P: UpdateParent<Op>> {
@@ -125,11 +138,17 @@ impl<Op: TableOps, P: UpdateParent<Op>> UpdateParentTable<Op, P> {
     }
 }
 
-/// Parent is the root (e.g. CR3). `MayMoveTable` impl lives in each arch module.
+/// A struct implementing [`UpdateParent`] that keeps track of the
+/// fact that the parent "table" is actually the root (e.g. the value
+/// of CR3 in the guest).
+/// `MayMoveTable` impl lives in each arch module.
 #[derive(Copy, Clone)]
 pub struct UpdateParentRoot {}
 
-/// No-op parent tracker (tables are never relocated).
+/// A struct implementing [`UpdateParent`] that is impossible to use
+/// (since its [`UpdateParent::update_parent`] method takes [`Void`]),
+/// used when it is statically known that a table operation cannot
+/// result in a need to update ancestors.
 #[derive(Copy, Clone)]
 pub struct UpdateParentNone {}
 impl<Op: TableReadOps> UpdateParent<Op> for UpdateParentNone {
@@ -143,7 +162,8 @@ impl<Op: TableReadOps> UpdateParent<Op> for UpdateParentNone {
     }
 }
 
-/// A request to map/walk a VA range within a specific page table.
+/// A helper structure indicating a mapping operation that needs to be
+/// performed.
 pub(crate) struct MapRequest<Op: TableReadOps, P: UpdateParent<Op>> {
     pub table_base: Op::TableAddr,
     pub vmin: u64,
@@ -151,7 +171,8 @@ pub(crate) struct MapRequest<Op: TableReadOps, P: UpdateParent<Op>> {
     pub update_parent: P,
 }
 
-/// A single PTE that needs to be examined or modified.
+/// A helper structure indicating that a particular PTE needs to be
+/// modified.
 pub(crate) struct MapResponse<Op: TableReadOps, P: UpdateParent<Op>> {
     pub entry_ptr: Op::TableAddr,
     pub vmin: u64,
@@ -159,58 +180,92 @@ pub(crate) struct MapResponse<Op: TableReadOps, P: UpdateParent<Op>> {
     pub update_parent: P,
 }
 
-/// Iterates over PTEs at one level of the page table hierarchy.
+/// Iterator that walks through page table entries at a specific level.
 ///
-/// `HIGH_BIT`/`LOW_BIT` select which VA bits index this level.
-/// `PTE_SHIFT` is log2(PTE byte size) (3 for 8-byte, 2 for 4-byte).
+/// Given a virtual address range and a table base, this iterator yields
+/// `MapResponse` items for each page table entry that needs to be modified.
+/// The const generics `HIGH_BIT` and `LOW_BIT` specify which bits of the
+/// virtual address are used to index into this level's table.
+///
+/// For example on amd64:
+/// - PML4: HIGH_BIT=47, LOW_BIT=39 (9 bits = 512 entries, each covering 512GB)
+/// - PDPT: HIGH_BIT=38, LOW_BIT=30 (9 bits = 512 entries, each covering 1GB)
+/// - PD:   HIGH_BIT=29, LOW_BIT=21 (9 bits = 512 entries, each covering 2MB)
+/// - PT:   HIGH_BIT=20, LOW_BIT=12 (9 bits = 512 entries, each covering 4KB)
+///
+/// On i686:
+/// - PD:   HIGH_BIT=31, LOW_BIT=22 (10 bits = 1024 entries, each covering 4MB)
+/// - PT:   HIGH_BIT=21, LOW_BIT=12 (10 bits = 1024 entries, each covering 4KB)
 pub(crate) struct ModifyPteIterator<
     const HIGH_BIT: u8,
     const LOW_BIT: u8,
-    const PTE_SHIFT: u8,
     Op: TableReadOps,
     P: UpdateParent<Op>,
 > {
     request: MapRequest<Op, P>,
     n: u64,
 }
-impl<
-    const HIGH_BIT: u8,
-    const LOW_BIT: u8,
-    const PTE_SHIFT: u8,
-    Op: TableReadOps,
-    P: UpdateParent<Op>,
-> Iterator for ModifyPteIterator<HIGH_BIT, LOW_BIT, PTE_SHIFT, Op, P>
+impl<const HIGH_BIT: u8, const LOW_BIT: u8, Op: TableReadOps, P: UpdateParent<Op>> Iterator
+    for ModifyPteIterator<HIGH_BIT, LOW_BIT, Op, P>
 {
     type Item = MapResponse<Op, P>;
     fn next(&mut self) -> Option<Self::Item> {
+        // Each page table entry at this level covers a region of size
+        // (1 << LOW_BIT) bytes. For example, at the PT level
+        // (LOW_BIT=12), each entry covers 4KB (0x1000 bytes). At the
+        // PD level (LOW_BIT=21), each entry covers 2MB (0x200000
+        // bytes).
+        //
+        // This mask isolates the bits below this level's index bits,
+        // used for alignment.
         let lower_bits_mask = (1u64 << LOW_BIT) - 1;
 
-        // First iteration starts at vmin; subsequent ones advance to
-        // the next aligned boundary. checked_add handles overflow at
-        // the end of the address space.
+        // Calculate the virtual address for this iteration.
+        // On the first iteration (n=0), start at the requested vmin.
+        // On subsequent iterations, advance to the next aligned boundary.
+        // This handles the case where vmin isn't aligned to this level's
+        // entry size.
         let next_vmin = if self.n == 0 {
             self.request.vmin
         } else {
+            // Align to the next boundary by adding one entry's worth
+            // and masking off lower bits. Masking off before adding
+            // is safe, since n << LOW_BIT must always have zeros in
+            // these positions.
             let aligned_min = self.request.vmin & !lower_bits_mask;
+            // Use checked_add because going past the end of the
+            // address space counts as "the next one would be out of
+            // range"
             aligned_min.checked_add(self.n << LOW_BIT)?
         };
 
+        // Check if we've processed the entire requested range
         if next_vmin >= self.request.vmin + self.request.len {
             return None;
         }
 
-        // Compute the byte offset of the PTE within the table.
+        // Calculate the pointer to this level's page table entry.
+        // bits::<HIGH_BIT, LOW_BIT> extracts the relevant index bits
+        // from the virtual address. Multiply by the PTE size to get
+        // the byte offset.
+        let pte_index = bits::<HIGH_BIT, LOW_BIT>(next_vmin);
         let entry_ptr = Op::entry_addr(
             self.request.table_base,
-            bits::<HIGH_BIT, LOW_BIT>(next_vmin) << PTE_SHIFT,
+            pte_index * core::mem::size_of::<PageTableEntry>() as u64,
         );
 
-        // Length this single entry covers (may be less than a full
-        // entry if vmin is unaligned on the first iteration).
+        // Calculate how many bytes remain to be mapped from this point.
         let len_from_here = self.request.len - (next_vmin - self.request.vmin);
+        // Calculate the maximum bytes this single entry can cover.
+        // If next_vmin is aligned, this is the full entry size (1 << LOW_BIT).
+        // If not aligned (only possible on first iteration), it's the
+        // remaining space until the next boundary.
         let max_len = (1u64 << LOW_BIT) - (next_vmin & lower_bits_mask);
+        // The actual length for this entry is the smaller of what's
+        // needed vs what fits.
         let next_len = core::cmp::min(len_from_here, max_len);
 
+        // Advance iteration counter for next call
         self.n += 1;
 
         Some(MapResponse {
@@ -225,25 +280,19 @@ impl<
 pub(crate) fn modify_ptes<
     const HIGH_BIT: u8,
     const LOW_BIT: u8,
-    const PTE_SHIFT: u8,
     Op: TableReadOps,
     P: UpdateParent<Op>,
 >(
     r: MapRequest<Op, P>,
-) -> ModifyPteIterator<HIGH_BIT, LOW_BIT, PTE_SHIFT, Op, P> {
+) -> ModifyPteIterator<HIGH_BIT, LOW_BIT, Op, P> {
     ModifyPteIterator { request: r, n: 0 }
 }
 
 /// Require that a PTE is present and descend to the next-level table.
-/// `PTE_ADDR_MASK` is arch-specific (must mask out flag bits including NX).
 ///
 /// # Safety
 /// `op` must provide valid page table memory.
-pub(crate) unsafe fn require_pte_exist<
-    const PTE_ADDR_MASK: u64,
-    Op: TableReadOps,
-    P: UpdateParent<Op>,
->(
+pub(crate) unsafe fn require_pte_exist<Op: TableReadOps, P: UpdateParent<Op>>(
     op: &Op,
     x: MapResponse<Op, P>,
 ) -> Option<MapRequest<Op, P::ChildType>>
@@ -336,12 +385,20 @@ mod sealed {
 }
 use sealed::*;
 
-/// Collects information about [`MayMoveTable`] / [`MayNotMoveTable`],
-/// including which [`UpdateParent`] type to use at the root level.
+/// A sealed trait used to collect some information about the marker
+/// structures [`MayMoveTable`] and [`MayNotMoveTable`].
 /// Implemented in each arch module.
-pub trait TableMovability<Op: TableReadOps + ?Sized>: TableMovabilityBase<Op> {
-    type RootUpdateParent: UpdateParent<Op, TableMoveInfo = <Self as TableMovabilityBase<Op>>::TableMoveInfo>;
-    fn root_update_parent() -> Self::RootUpdateParent;
+pub trait TableMovability<Op: TableReadOps + ?Sized>:
+    TableMovabilityBase<Op>
+    + arch::TableMovability<Op, <Self as TableMovabilityBase<Op>>::TableMoveInfo>
+{
+}
+impl<
+    Op: TableReadOps,
+    T: TableMovabilityBase<Op>
+        + arch::TableMovability<Op, <Self as TableMovabilityBase<Op>>::TableMoveInfo>,
+> TableMovability<Op> for T
+{
 }
 
 /// The operations used to actually access the page table structures

--- a/src/hyperlight_common/src/vmem.rs
+++ b/src/hyperlight_common/src/vmem.rs
@@ -518,3 +518,99 @@ pub use arch::map;
 /// be called concurrently with any other operations that modify the
 /// page table.
 pub use arch::virt_to_phys;
+
+//==================================================================================================
+// Multi-space (aliased page-table) walking
+//==================================================================================================
+
+/// Identifier for a virtual address space, used by the multi-space
+/// walker to describe which space "owns" a shared intermediate table.
+/// Implementations typically use the physical address of the root
+/// page table (which is unique per space).
+pub type SpaceId = u64;
+
+/// A reference from one address space to an intermediate page table
+/// that lives in a different space. Produced by [`walk_va_spaces`] when
+/// the walker encounters an intermediate table (at some `depth` below
+/// the root) whose physical address was already seen via an earlier
+/// root — i.e. the two spaces alias that sub-tree.
+///
+/// Semantics: the level-`depth` block in **our** space that contains
+/// VAs starting at `our_va` is aliased to the level-`depth` block in
+/// `space` that contains VAs starting at `their_va`. Everything below
+/// that sub-tree — PDEs, PTEs, leaf mappings — is shared wholesale.
+///
+/// `depth` is counted from the root:
+/// - `depth = 1` on i686: the shared thing is a leaf PT (the thing a
+///   PDE points to).
+/// - `depth = 1, 2, 3` on amd64: PDPT, PD, or PT respectively.
+#[derive(Debug, Clone, Copy)]
+pub struct SpaceReferenceMapping {
+    /// Depth from the root at which the alias starts (1-based).
+    pub depth: usize,
+    /// The "owning" space — the first root that visited this
+    /// intermediate PA during [`walk_va_spaces`].
+    pub space: SpaceId,
+    /// Start VA of the aliased sub-tree in OUR space.
+    pub our_va: u64,
+    /// Start VA of the aliased sub-tree in the owning space. Usually
+    /// equal to `our_va` (kernel mappings at the same VA across
+    /// processes) but the design permits different VAs.
+    pub their_va: u64,
+}
+
+/// Either a normal leaf mapping in the current space, or a reference
+/// to an intermediate table in another space. The compaction loop in
+/// the host snapshotting code treats these two cases differently:
+///
+/// - `ThisSpace(m)` is rebuilt like any other leaf mapping: the
+///   backing page is compacted into the new snapshot blob, the PTE is
+///   written, and intermediate tables are allocated on demand.
+/// - `AnotherSpace(r)` is rebuilt by *linking*: the entry in our
+///   rebuilt root at depth `r.depth - 1` for `r.our_va` is made to
+///   point at whatever table the owning space ended up with at
+///   `r.their_va`. See [`space_aware_map`].
+#[derive(Debug)]
+pub enum SpaceAwareMapping {
+    ThisSpace(Mapping),
+    AnotherSpace(SpaceReferenceMapping),
+}
+
+/// Walk multiple page-table roots together, emitting either a normal
+/// leaf mapping (`ThisSpace`) or a reference to an alias that was
+/// already seen via an earlier root (`AnotherSpace`).
+///
+/// The caller passes `roots` in their preferred order of primacy. The
+/// first root to visit a particular intermediate PA becomes the
+/// "owner" of that sub-table — subsequent roots that alias it receive
+/// `AnotherSpace` entries pointing back at the owner. Concretely for
+/// Nanvix: pass the kernel PD first so user PDs inherit kernel PTs by
+/// reference.
+///
+/// The returned `Vec` is ordered the same way `roots` was passed — so
+/// by construction the result is topologically sorted: every
+/// `AnotherSpace` reference points to a space that appears earlier in
+/// the list. This lets a rebuilder process roots in iteration order
+/// without a separate sort pass.
+///
+/// # Safety
+/// Same invariants as [`virt_to_phys`]. Callers must ensure the page
+/// tables are not being mutated concurrently.
+pub use arch::walk_va_spaces;
+
+/// Counterpart of [`walk_va_spaces`]'s `AnotherSpace` entries on the
+/// write side: installs a link in `op`'s root PT tree at `ref_map.our_va`
+/// that points at whatever intermediate table the owning space ended
+/// up with at `ref_map.their_va` (in `built_roots[ref_map.space]`).
+///
+/// Callers must process [`SpaceAwareMapping`]s in the order returned
+/// by `walk_va_spaces`, populating `built_roots` with each space's
+/// rebuilt root PA before moving on to the next space — that way, by
+/// the time we see an `AnotherSpace` entry, the owning space's
+/// rebuilt root is guaranteed to be in `built_roots`.
+///
+/// # Safety
+/// Same invariants as [`map`]: the caller owns the concurrency story
+/// around the page tables being written, and must invalidate TLBs
+/// afterwards if they were live.
+pub use arch::space_aware_map;

--- a/src/hyperlight_common/src/vmem.rs
+++ b/src/hyperlight_common/src/vmem.rs
@@ -22,6 +22,8 @@ mod arch;
 /// This is always the page size that the /guest/ is being compiled
 /// for, which may or may not be the same as the host page size.
 pub use arch::PAGE_SIZE;
+#[cfg(all(feature = "i686-guest", target_arch = "x86_64"))]
+pub use arch::i686_guest;
 pub use arch::{PAGE_TABLE_SIZE, PageTableEntry, PhysAddr, VirtAddr};
 pub const PAGE_TABLE_ENTRIES_PER_TABLE: usize =
     PAGE_TABLE_SIZE / core::mem::size_of::<PageTableEntry>();

--- a/src/hyperlight_common/src/vmem.rs
+++ b/src/hyperlight_common/src/vmem.rs
@@ -385,9 +385,7 @@ mod sealed {
 }
 use sealed::*;
 
-/// A sealed trait used to collect some information about the marker
-/// structures [`MayMoveTable`] and [`MayNotMoveTable`].
-/// Implemented in each arch module.
+/// A sealed trait used to collect some information about the marker structures [`MayMoveTable`] and [`MayNotMoveTable`]
 pub trait TableMovability<Op: TableReadOps + ?Sized>:
     TableMovabilityBase<Op>
     + arch::TableMovability<Op, <Self as TableMovabilityBase<Op>>::TableMoveInfo>

--- a/src/hyperlight_common/src/vmem.rs
+++ b/src/hyperlight_common/src/vmem.rs
@@ -51,24 +51,6 @@ pub(crate) fn bits<const HIGH_BIT: u8, const LOW_BIT: u8>(x: u64) -> u64 {
     (x & ((1 << (HIGH_BIT + 1)) - 1)) >> LOW_BIT
 }
 
-/// Read a page table entry and return it if the present bit is set.
-///
-/// # Safety
-/// The caller must ensure that `entry_ptr` points to a valid page table entry.
-#[inline(always)]
-#[allow(clippy::useless_conversion)]
-pub(crate) unsafe fn read_pte_if_present<Op: TableReadOps>(
-    op: &Op,
-    entry_ptr: Op::TableAddr,
-) -> Option<u64> {
-    let pte: u64 = unsafe { op.read_entry(entry_ptr) }.into();
-    if (pte & PAGE_PRESENT) != 0 {
-        Some(pte)
-    } else {
-        None
-    }
-}
-
 /// Helper function to write a page table entry, updating the whole
 /// chain of tables back to the root if necessary.
 ///
@@ -286,26 +268,6 @@ pub(crate) fn modify_ptes<
     r: MapRequest<Op, P>,
 ) -> ModifyPteIterator<HIGH_BIT, LOW_BIT, Op, P> {
     ModifyPteIterator { request: r, n: 0 }
-}
-
-/// Require that a PTE is present and descend to the next-level table.
-///
-/// # Safety
-/// `op` must provide valid page table memory.
-pub(crate) unsafe fn require_pte_exist<Op: TableReadOps, P: UpdateParent<Op>>(
-    op: &Op,
-    x: MapResponse<Op, P>,
-) -> Option<MapRequest<Op, P::ChildType>>
-where
-    P::ChildType: UpdateParent<Op>,
-{
-    unsafe { read_pte_if_present(op, x.entry_ptr) }.map(|pte| MapRequest {
-        #[allow(clippy::unnecessary_cast)]
-        table_base: Op::from_phys((pte & PTE_ADDR_MASK) as PhysAddr),
-        vmin: x.vmin,
-        len: x.len,
-        update_parent: x.update_parent.for_child_at_entry(x.entry_ptr),
-    })
 }
 
 /// The read-only operations used to actually access the page table

--- a/src/hyperlight_common/src/vmem.rs
+++ b/src/hyperlight_common/src/vmem.rs
@@ -38,10 +38,222 @@ compile_error!(
 /// for, which may or may not be the same as the host page size.
 pub use arch::PAGE_SIZE;
 #[cfg(all(feature = "i686-guest", target_arch = "x86_64"))]
-pub use arch::i686_guest;
+#[path = "arch/i686/vmem.rs"]
+pub mod i686_guest;
 pub use arch::{PAGE_TABLE_SIZE, PageTableEntry, PhysAddr, VirtAddr};
 pub const PAGE_TABLE_ENTRIES_PER_TABLE: usize =
     PAGE_TABLE_SIZE / core::mem::size_of::<PageTableEntry>();
+
+// Shared page table iterator infrastructure used by each arch module.
+
+/// Extract bits `[HIGH_BIT:LOW_BIT]` (inclusive) from a u64.
+#[inline(always)]
+pub(crate) fn bits<const HIGH_BIT: u8, const LOW_BIT: u8>(x: u64) -> u64 {
+    (x & ((1 << (HIGH_BIT + 1)) - 1)) >> LOW_BIT
+}
+
+/// Read a PTE and return it (widened to u64) if the present bit is set.
+///
+/// # Safety
+/// `entry_ptr` must point to a valid page table entry.
+#[inline(always)]
+#[allow(clippy::useless_conversion)]
+pub(crate) unsafe fn read_pte_if_present<Op: TableReadOps>(
+    op: &Op,
+    entry_ptr: Op::TableAddr,
+) -> Option<u64> {
+    let pte: u64 = unsafe { op.read_entry(entry_ptr) }.into();
+    if (pte & 1) != 0 { Some(pte) } else { None }
+}
+
+/// Write a PTE, recursively updating parent entries if the table was moved.
+///
+/// # Safety
+/// Same requirements as [`TableOps::write_entry`].
+pub(crate) unsafe fn write_entry_updating<
+    Op: TableOps,
+    P: UpdateParent<
+            Op,
+            TableMoveInfo = <Op::TableMovability as TableMovabilityBase<Op>>::TableMoveInfo,
+        >,
+>(
+    op: &Op,
+    parent: P,
+    addr: Op::TableAddr,
+    entry: u64,
+) {
+    #[allow(clippy::useless_conversion)]
+    if let Some(again) = unsafe { op.write_entry(addr, entry as PageTableEntry) } {
+        parent.update_parent(op, again);
+    }
+}
+
+/// Tracks the chain of ancestor page table entries that need updating
+/// when a table is relocated. Implemented as a trait so that the
+/// compiler can specialise per nesting depth for inlining.
+pub trait UpdateParent<Op: TableReadOps + ?Sized>: Copy {
+    /// The type of the information about a moved table which is
+    /// needed in order to update its parent.
+    type TableMoveInfo;
+    /// The [`UpdateParent`] type that should be used when going down
+    /// another level in the table, in order to add the current level
+    /// to the chain of ancestors to be updated.
+    type ChildType: UpdateParent<Op, TableMoveInfo = Self::TableMoveInfo>;
+    fn update_parent(self, op: &Op, new_ptr: Self::TableMoveInfo);
+    fn for_child_at_entry(self, entry_ptr: Op::TableAddr) -> Self::ChildType;
+}
+
+/// Parent is another page table whose ancestors may also need updating.
+/// The `MayMoveTable` impl lives in each arch module (needs `pte_for_table`).
+pub struct UpdateParentTable<Op: TableOps, P: UpdateParent<Op>> {
+    pub(crate) parent: P,
+    pub(crate) entry_ptr: Op::TableAddr,
+}
+impl<Op: TableOps, P: UpdateParent<Op>> Clone for UpdateParentTable<Op, P> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl<Op: TableOps, P: UpdateParent<Op>> Copy for UpdateParentTable<Op, P> {}
+impl<Op: TableOps, P: UpdateParent<Op>> UpdateParentTable<Op, P> {
+    pub(crate) fn new(parent: P, entry_ptr: Op::TableAddr) -> Self {
+        UpdateParentTable { parent, entry_ptr }
+    }
+}
+
+/// Parent is the root (e.g. CR3). `MayMoveTable` impl lives in each arch module.
+#[derive(Copy, Clone)]
+pub struct UpdateParentRoot {}
+
+/// No-op parent tracker (tables are never relocated).
+#[derive(Copy, Clone)]
+pub struct UpdateParentNone {}
+impl<Op: TableReadOps> UpdateParent<Op> for UpdateParentNone {
+    type TableMoveInfo = Void;
+    type ChildType = Self;
+    fn update_parent(self, _op: &Op, impossible: Void) {
+        match impossible {}
+    }
+    fn for_child_at_entry(self, _entry_ptr: Op::TableAddr) -> Self {
+        self
+    }
+}
+
+/// A request to map/walk a VA range within a specific page table.
+pub(crate) struct MapRequest<Op: TableReadOps, P: UpdateParent<Op>> {
+    pub table_base: Op::TableAddr,
+    pub vmin: u64,
+    pub len: u64,
+    pub update_parent: P,
+}
+
+/// A single PTE that needs to be examined or modified.
+pub(crate) struct MapResponse<Op: TableReadOps, P: UpdateParent<Op>> {
+    pub entry_ptr: Op::TableAddr,
+    pub vmin: u64,
+    pub len: u64,
+    pub update_parent: P,
+}
+
+/// Iterates over PTEs at one level of the page table hierarchy.
+///
+/// `HIGH_BIT`/`LOW_BIT` select which VA bits index this level.
+/// `PTE_SHIFT` is log2(PTE byte size) (3 for 8-byte, 2 for 4-byte).
+pub(crate) struct ModifyPteIterator<
+    const HIGH_BIT: u8,
+    const LOW_BIT: u8,
+    const PTE_SHIFT: u8,
+    Op: TableReadOps,
+    P: UpdateParent<Op>,
+> {
+    request: MapRequest<Op, P>,
+    n: u64,
+}
+impl<
+    const HIGH_BIT: u8,
+    const LOW_BIT: u8,
+    const PTE_SHIFT: u8,
+    Op: TableReadOps,
+    P: UpdateParent<Op>,
+> Iterator for ModifyPteIterator<HIGH_BIT, LOW_BIT, PTE_SHIFT, Op, P>
+{
+    type Item = MapResponse<Op, P>;
+    fn next(&mut self) -> Option<Self::Item> {
+        let lower_bits_mask = (1u64 << LOW_BIT) - 1;
+
+        // First iteration starts at vmin; subsequent ones advance to
+        // the next aligned boundary. checked_add handles overflow at
+        // the end of the address space.
+        let next_vmin = if self.n == 0 {
+            self.request.vmin
+        } else {
+            let aligned_min = self.request.vmin & !lower_bits_mask;
+            aligned_min.checked_add(self.n << LOW_BIT)?
+        };
+
+        if next_vmin >= self.request.vmin + self.request.len {
+            return None;
+        }
+
+        // Compute the byte offset of the PTE within the table.
+        let entry_ptr = Op::entry_addr(
+            self.request.table_base,
+            bits::<HIGH_BIT, LOW_BIT>(next_vmin) << PTE_SHIFT,
+        );
+
+        // Length this single entry covers (may be less than a full
+        // entry if vmin is unaligned on the first iteration).
+        let len_from_here = self.request.len - (next_vmin - self.request.vmin);
+        let max_len = (1u64 << LOW_BIT) - (next_vmin & lower_bits_mask);
+        let next_len = core::cmp::min(len_from_here, max_len);
+
+        self.n += 1;
+
+        Some(MapResponse {
+            entry_ptr,
+            vmin: next_vmin,
+            len: next_len,
+            update_parent: self.request.update_parent,
+        })
+    }
+}
+
+pub(crate) fn modify_ptes<
+    const HIGH_BIT: u8,
+    const LOW_BIT: u8,
+    const PTE_SHIFT: u8,
+    Op: TableReadOps,
+    P: UpdateParent<Op>,
+>(
+    r: MapRequest<Op, P>,
+) -> ModifyPteIterator<HIGH_BIT, LOW_BIT, PTE_SHIFT, Op, P> {
+    ModifyPteIterator { request: r, n: 0 }
+}
+
+/// Require that a PTE is present and descend to the next-level table.
+/// `PTE_ADDR_MASK` is arch-specific (must mask out flag bits including NX).
+///
+/// # Safety
+/// `op` must provide valid page table memory.
+pub(crate) unsafe fn require_pte_exist<
+    const PTE_ADDR_MASK: u64,
+    Op: TableReadOps,
+    P: UpdateParent<Op>,
+>(
+    op: &Op,
+    x: MapResponse<Op, P>,
+) -> Option<MapRequest<Op, P::ChildType>>
+where
+    P::ChildType: UpdateParent<Op>,
+{
+    unsafe { read_pte_if_present(op, x.entry_ptr) }.map(|pte| MapRequest {
+        #[allow(clippy::unnecessary_cast)]
+        table_base: Op::from_phys((pte & PTE_ADDR_MASK) as PhysAddr),
+        vmin: x.vmin,
+        len: x.len,
+        update_parent: x.update_parent.for_child_at_entry(x.entry_ptr),
+    })
+}
 
 /// The read-only operations used to actually access the page table
 /// structures, used to allow the same code to be used in the host and
@@ -120,18 +332,12 @@ mod sealed {
 }
 use sealed::*;
 
-/// A sealed trait used to collect some information about the marker structures [`MayMoveTable`] and [`MayNotMoveTable`]
-pub trait TableMovability<Op: TableReadOps + ?Sized>:
-    TableMovabilityBase<Op>
-    + arch::TableMovability<Op, <Self as TableMovabilityBase<Op>>::TableMoveInfo>
-{
-}
-impl<
-    Op: TableReadOps,
-    T: TableMovabilityBase<Op>
-        + arch::TableMovability<Op, <Self as TableMovabilityBase<Op>>::TableMoveInfo>,
-> TableMovability<Op> for T
-{
+/// Collects information about [`MayMoveTable`] / [`MayNotMoveTable`],
+/// including which [`UpdateParent`] type to use at the root level.
+/// Implemented in each arch module.
+pub trait TableMovability<Op: TableReadOps + ?Sized>: TableMovabilityBase<Op> {
+    type RootUpdateParent: UpdateParent<Op, TableMoveInfo = <Self as TableMovabilityBase<Op>>::TableMoveInfo>;
+    fn root_update_parent() -> Self::RootUpdateParent;
 }
 
 /// The operations used to actually access the page table structures

--- a/src/hyperlight_common/src/vmem.rs
+++ b/src/hyperlight_common/src/vmem.rs
@@ -98,35 +98,6 @@ pub trait UpdateParent<Op: TableReadOps + ?Sized>: Copy {
     fn for_child_at_entry(self, entry_ptr: Op::TableAddr) -> Self::ChildType;
 }
 
-/// A struct implementing [`UpdateParent`] that keeps track of the
-/// fact that the parent table is itself another table, whose own
-/// ancestors may need to be recursively updated.
-/// The `MayMoveTable` impl lives in each arch module (needs `pte_for_table`).
-#[allow(dead_code)] // used only by archs that support MayMoveTable
-pub struct UpdateParentTable<Op: TableOps, P: UpdateParent<Op>> {
-    pub(crate) parent: P,
-    pub(crate) entry_ptr: Op::TableAddr,
-}
-impl<Op: TableOps, P: UpdateParent<Op>> Clone for UpdateParentTable<Op, P> {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl<Op: TableOps, P: UpdateParent<Op>> Copy for UpdateParentTable<Op, P> {}
-impl<Op: TableOps, P: UpdateParent<Op>> UpdateParentTable<Op, P> {
-    #[allow(dead_code)]
-    pub(crate) fn new(parent: P, entry_ptr: Op::TableAddr) -> Self {
-        UpdateParentTable { parent, entry_ptr }
-    }
-}
-
-/// A struct implementing [`UpdateParent`] that keeps track of the
-/// fact that the parent "table" is actually the root (e.g. the value
-/// of CR3 in the guest).
-/// `MayMoveTable` impl lives in each arch module.
-#[derive(Copy, Clone)]
-pub struct UpdateParentRoot {}
-
 /// A struct implementing [`UpdateParent`] that is impossible to use
 /// (since its [`UpdateParent::update_parent`] method takes [`Void`]),
 /// used when it is statically known that a table operation cannot

--- a/src/hyperlight_common/src/vmem.rs
+++ b/src/hyperlight_common/src/vmem.rs
@@ -47,7 +47,7 @@ pub const PAGE_TABLE_ENTRIES_PER_TABLE: usize =
 /// Utility function to extract an (inclusive on both ends) bit range
 /// from a quadword.
 #[inline(always)]
-pub(crate) fn bits<const HIGH_BIT: u8, const LOW_BIT: u8>(x: u64) -> u64 {
+pub(in crate::vmem) fn bits<const HIGH_BIT: u8, const LOW_BIT: u8>(x: u64) -> u64 {
     (x & ((1 << (HIGH_BIT + 1)) - 1)) >> LOW_BIT
 }
 
@@ -56,7 +56,7 @@ pub(crate) fn bits<const HIGH_BIT: u8, const LOW_BIT: u8>(x: u64) -> u64 {
 ///
 /// # Safety
 /// Same requirements as [`TableOps::write_entry`].
-pub(crate) unsafe fn write_entry_updating<
+pub(in crate::vmem) unsafe fn write_entry_updating<
     Op: TableOps,
     P: UpdateParent<
             Op,
@@ -117,7 +117,7 @@ impl<Op: TableReadOps> UpdateParent<Op> for UpdateParentNone {
 
 /// A helper structure indicating a mapping operation that needs to be
 /// performed.
-pub(crate) struct MapRequest<Op: TableReadOps, P: UpdateParent<Op>> {
+pub(in crate::vmem) struct MapRequest<Op: TableReadOps, P: UpdateParent<Op>> {
     pub table_base: Op::TableAddr,
     pub vmin: u64,
     pub len: u64,
@@ -126,7 +126,7 @@ pub(crate) struct MapRequest<Op: TableReadOps, P: UpdateParent<Op>> {
 
 /// A helper structure indicating that a particular PTE needs to be
 /// modified.
-pub(crate) struct MapResponse<Op: TableReadOps, P: UpdateParent<Op>> {
+pub(in crate::vmem) struct MapResponse<Op: TableReadOps, P: UpdateParent<Op>> {
     pub entry_ptr: Op::TableAddr,
     pub vmin: u64,
     pub len: u64,
@@ -149,7 +149,7 @@ pub(crate) struct MapResponse<Op: TableReadOps, P: UpdateParent<Op>> {
 /// On i686:
 /// - PD:   HIGH_BIT=31, LOW_BIT=22 (10 bits = 1024 entries, each covering 4MB)
 /// - PT:   HIGH_BIT=21, LOW_BIT=12 (10 bits = 1024 entries, each covering 4KB)
-pub(crate) struct ModifyPteIterator<
+pub(in crate::vmem) struct ModifyPteIterator<
     const HIGH_BIT: u8,
     const LOW_BIT: u8,
     Op: TableReadOps,
@@ -230,7 +230,7 @@ impl<const HIGH_BIT: u8, const LOW_BIT: u8, Op: TableReadOps, P: UpdateParent<Op
     }
 }
 
-pub(crate) fn modify_ptes<
+pub(in crate::vmem) fn modify_ptes<
     const HIGH_BIT: u8,
     const LOW_BIT: u8,
     Op: TableReadOps,

--- a/src/hyperlight_common/src/vmem.rs
+++ b/src/hyperlight_common/src/vmem.rs
@@ -14,17 +14,18 @@ See the License for the specific language governing permissions and
 limitations under the License.
  */
 
-#[cfg_attr(target_arch = "x86_64", path = "arch/amd64/vmem.rs")]
 #[cfg_attr(target_arch = "x86", path = "arch/i686/vmem.rs")]
+#[cfg_attr(
+    all(target_arch = "x86_64", not(feature = "i686-guest")),
+    path = "arch/amd64/vmem.rs"
+)]
+#[cfg_attr(
+    all(target_arch = "x86_64", feature = "i686-guest"),
+    path = "arch/i686/vmem.rs"
+)]
 #[cfg_attr(target_arch = "aarch64", path = "arch/aarch64/vmem.rs")]
 mod arch;
 
-// The `i686-guest` feature is consumed two ways: the guest itself
-// compiles for `target_arch = "x86"`, and the x86_64 host compiles
-// it to pick up the PT walker under `vmem::i686_guest`. Enabling
-// the feature on any other host (e.g. aarch64) would leave the
-// re-export missing and produce confusing errors in downstream
-// crates — surface it up front.
 #[cfg(all(
     feature = "i686-guest",
     not(any(target_arch = "x86", target_arch = "x86_64"))
@@ -37,10 +38,7 @@ compile_error!(
 /// This is always the page size that the /guest/ is being compiled
 /// for, which may or may not be the same as the host page size.
 pub use arch::PAGE_SIZE;
-#[cfg(all(feature = "i686-guest", target_arch = "x86_64"))]
-#[path = "arch/i686/vmem.rs"]
-pub mod i686_guest;
-pub use arch::{PAGE_TABLE_SIZE, PageTableEntry, PhysAddr, VirtAddr};
+pub use arch::{PAGE_PRESENT, PAGE_TABLE_SIZE, PageTableEntry, PhysAddr, VirtAddr};
 pub const PAGE_TABLE_ENTRIES_PER_TABLE: usize =
     PAGE_TABLE_SIZE / core::mem::size_of::<PageTableEntry>();
 
@@ -63,7 +61,11 @@ pub(crate) unsafe fn read_pte_if_present<Op: TableReadOps>(
     entry_ptr: Op::TableAddr,
 ) -> Option<u64> {
     let pte: u64 = unsafe { op.read_entry(entry_ptr) }.into();
-    if (pte & 1) != 0 { Some(pte) } else { None }
+    if (pte & PAGE_PRESENT) != 0 {
+        Some(pte)
+    } else {
+        None
+    }
 }
 
 /// Write a PTE, recursively updating parent entries if the table was moved.
@@ -105,6 +107,7 @@ pub trait UpdateParent<Op: TableReadOps + ?Sized>: Copy {
 
 /// Parent is another page table whose ancestors may also need updating.
 /// The `MayMoveTable` impl lives in each arch module (needs `pte_for_table`).
+#[allow(dead_code)] // used only by archs that support MayMoveTable
 pub struct UpdateParentTable<Op: TableOps, P: UpdateParent<Op>> {
     pub(crate) parent: P,
     pub(crate) entry_ptr: Op::TableAddr,
@@ -116,6 +119,7 @@ impl<Op: TableOps, P: UpdateParent<Op>> Clone for UpdateParentTable<Op, P> {
 }
 impl<Op: TableOps, P: UpdateParent<Op>> Copy for UpdateParentTable<Op, P> {}
 impl<Op: TableOps, P: UpdateParent<Op>> UpdateParentTable<Op, P> {
+    #[allow(dead_code)]
     pub(crate) fn new(parent: P, entry_ptr: Op::TableAddr) -> Self {
         UpdateParentTable { parent, entry_ptr }
     }
@@ -432,6 +436,10 @@ pub struct Mapping {
     pub virt_base: u64,
     pub len: u64,
     pub kind: MappingKind,
+    /// Whether ring-3 (user mode) code can access these pages.
+    /// On i686, controls the PAGE_USER bit on PDEs and leaf PTEs.
+    /// On amd64/aarch64, currently unused.
+    pub user_accessible: bool,
 }
 
 /// Assumption: all are page-aligned

--- a/src/hyperlight_common/src/vmem.rs
+++ b/src/hyperlight_common/src/vmem.rs
@@ -491,9 +491,10 @@ pub struct Mapping {
     pub virt_base: u64,
     pub len: u64,
     pub kind: MappingKind,
-    /// Whether ring-3 (user mode) code can access these pages.
-    /// On i686, controls the PAGE_USER bit on PDEs and leaf PTEs.
-    /// On amd64/aarch64, currently unused.
+    /// On architectures that support multiple privilege levels inside
+    /// the guest, whether the mapping is accessible to the
+    /// lower-privileged level (with the same permissions/behaviour as
+    /// the upper-privileged level, for now).
     pub user_accessible: bool,
 }
 
@@ -581,11 +582,8 @@ pub enum SpaceAwareMapping {
 /// that points at whatever intermediate table the owning space ended
 /// up with at `ref_map.their_va` (in `built_roots[ref_map.space]`).
 ///
-/// Callers must process [`SpaceAwareMapping`]s in the order returned
-/// by `walk_va_spaces`, populating `built_roots` with each space's
-/// rebuilt root PA before moving on to the next space — that way, by
-/// the time we see an `AnotherSpace` entry, the owning space's
-/// rebuilt root is guaranteed to be in `built_roots`.
+/// Callers must ensure that `built_roots` contains populated page
+/// tables for any other space referenced by the mapping.
 ///
 /// # Safety
 /// Same invariants as [`map`]: the caller owns the concurrency story
@@ -599,15 +597,14 @@ pub use arch::space_aware_map;
 /// The caller passes `roots` in their preferred order of primacy. The
 /// first root to visit a particular intermediate PA becomes the
 /// "owner" of that sub-table — subsequent roots that alias it receive
-/// `AnotherSpace` entries pointing back at the owner. Concretely for
-/// Nanvix: pass the kernel PD first so user PDs inherit kernel PTs by
-/// reference.
+/// `AnotherSpace` entries referencing the owner.
 ///
 /// The returned `Vec` is ordered the same way `roots` was passed — so
 /// by construction the result is topologically sorted: every
 /// `AnotherSpace` reference points to a space that appears earlier in
 /// the list. This lets a rebuilder process roots in iteration order
-/// without a separate sort pass.
+/// without a separate sort pass, and guarantees that the
+/// [`space_aware_map`] invariant is met.
 ///
 /// # Safety
 /// Same invariants as [`virt_to_phys`]. Callers must ensure the page

--- a/src/hyperlight_common/src/vmem.rs
+++ b/src/hyperlight_common/src/vmem.rs
@@ -576,6 +576,22 @@ pub enum SpaceAwareMapping {
     AnotherSpace(SpaceReferenceMapping),
 }
 
+/// Counterpart of [`walk_va_spaces`]'s `AnotherSpace` entries on the
+/// write side: installs a link in `op`'s root PT tree at `ref_map.our_va`
+/// that points at whatever intermediate table the owning space ended
+/// up with at `ref_map.their_va` (in `built_roots[ref_map.space]`).
+///
+/// Callers must process [`SpaceAwareMapping`]s in the order returned
+/// by `walk_va_spaces`, populating `built_roots` with each space's
+/// rebuilt root PA before moving on to the next space — that way, by
+/// the time we see an `AnotherSpace` entry, the owning space's
+/// rebuilt root is guaranteed to be in `built_roots`.
+///
+/// # Safety
+/// Same invariants as [`map`]: the caller owns the concurrency story
+/// around the page tables being written, and must invalidate TLBs
+/// afterwards if they were live.
+pub use arch::space_aware_map;
 /// Walk multiple page-table roots together, emitting either a normal
 /// leaf mapping (`ThisSpace`) or a reference to an alias that was
 /// already seen via an earlier root (`AnotherSpace`).
@@ -597,20 +613,3 @@ pub enum SpaceAwareMapping {
 /// Same invariants as [`virt_to_phys`]. Callers must ensure the page
 /// tables are not being mutated concurrently.
 pub use arch::walk_va_spaces;
-
-/// Counterpart of [`walk_va_spaces`]'s `AnotherSpace` entries on the
-/// write side: installs a link in `op`'s root PT tree at `ref_map.our_va`
-/// that points at whatever intermediate table the owning space ended
-/// up with at `ref_map.their_va` (in `built_roots[ref_map.space]`).
-///
-/// Callers must process [`SpaceAwareMapping`]s in the order returned
-/// by `walk_va_spaces`, populating `built_roots` with each space's
-/// rebuilt root PA before moving on to the next space — that way, by
-/// the time we see an `AnotherSpace` entry, the owning space's
-/// rebuilt root is guaranteed to be in `built_roots`.
-///
-/// # Safety
-/// Same invariants as [`map`]: the caller owns the concurrency story
-/// around the page tables being written, and must invalidate TLBs
-/// afterwards if they were live.
-pub use arch::space_aware_map;

--- a/src/hyperlight_guest/Cargo.toml
+++ b/src/hyperlight_guest/Cargo.toml
@@ -24,4 +24,5 @@ hyperlight-guest-tracing = { workspace = true, default-features = false, optiona
 [features]
 default = []
 trace_guest = ["dep:hyperlight-guest-tracing", "hyperlight-guest-tracing?/trace"]
-nanvix-unstable = ["hyperlight-common/nanvix-unstable"]
+i686-guest = ["hyperlight-common/i686-guest"]
+guest-counter = ["hyperlight-common/guest-counter"]

--- a/src/hyperlight_guest/src/layout.rs
+++ b/src/hyperlight_guest/src/layout.rs
@@ -35,7 +35,7 @@ pub fn snapshot_pt_gpa_base_gva() -> *mut u64 {
 pub use arch::{scratch_base_gpa, scratch_base_gva};
 
 /// Returns a pointer to the guest counter u64 in scratch memory.
-#[cfg(feature = "nanvix-unstable")]
+#[cfg(feature = "guest-counter")]
 pub fn guest_counter_gva() -> *const u64 {
     use hyperlight_common::layout::{MAX_GVA, SCRATCH_TOP_GUEST_COUNTER_OFFSET};
     (MAX_GVA as u64 - SCRATCH_TOP_GUEST_COUNTER_OFFSET + 1) as *const u64

--- a/src/hyperlight_guest/src/layout.rs
+++ b/src/hyperlight_guest/src/layout.rs
@@ -32,6 +32,10 @@ pub fn snapshot_pt_gpa_base_gva() -> *mut u64 {
     use hyperlight_common::layout::{MAX_GVA, SCRATCH_TOP_SNAPSHOT_PT_GPA_BASE_OFFSET};
     (MAX_GVA as u64 - SCRATCH_TOP_SNAPSHOT_PT_GPA_BASE_OFFSET + 1) as *mut u64
 }
+pub fn snapshot_generation_gva() -> *mut u64 {
+    use hyperlight_common::layout::{MAX_GVA, SCRATCH_TOP_SNAPSHOT_GENERATION_OFFSET};
+    (MAX_GVA as u64 - SCRATCH_TOP_SNAPSHOT_GENERATION_OFFSET + 1) as *mut u64
+}
 pub use arch::{scratch_base_gpa, scratch_base_gva};
 
 /// Returns a pointer to the guest counter u64 in scratch memory.

--- a/src/hyperlight_guest_bin/src/paging.rs
+++ b/src/hyperlight_guest_bin/src/paging.rs
@@ -132,6 +132,7 @@ pub unsafe fn map_region(phys_base: u64, virt_base: *mut u8, len: u64, kind: vme
                 virt_base: virt_base as u64,
                 len,
                 kind,
+                user_accessible: false,
             },
         );
     }

--- a/src/hyperlight_host/Cargo.toml
+++ b/src/hyperlight_host/Cargo.toml
@@ -138,6 +138,7 @@ gdb = ["dep:gdbstub", "dep:gdbstub_arch"]
 fuzzing = ["hyperlight-common/fuzzing"]
 build-metadata = ["dep:built"]
 i686-guest = ["hyperlight-common/i686-guest"]
+nanvix-unstable = ["i686-guest", "hyperlight-common/nanvix-unstable"]
 guest-counter = ["hyperlight-common/guest-counter"]
 
 [[bench]]

--- a/src/hyperlight_host/Cargo.toml
+++ b/src/hyperlight_host/Cargo.toml
@@ -137,7 +137,8 @@ hw-interrupts = []
 gdb = ["dep:gdbstub", "dep:gdbstub_arch"]
 fuzzing = ["hyperlight-common/fuzzing"]
 build-metadata = ["dep:built"]
-nanvix-unstable = ["hyperlight-common/nanvix-unstable"]
+i686-guest = ["hyperlight-common/i686-guest"]
+guest-counter = ["hyperlight-common/guest-counter"]
 
 [[bench]]
 name = "benchmarks"

--- a/src/hyperlight_host/build.rs
+++ b/src/hyperlight_host/build.rs
@@ -105,10 +105,8 @@ fn main() -> Result<()> {
         crashdump: { all(feature = "crashdump", target_arch = "x86_64") },
         // print_debug feature is aliased with debug_assertions to make it only available in debug-builds.
         print_debug: { all(feature = "print_debug", debug_assertions) },
-        // the nanvix-unstable and gdb features both (only
-        // temporarily!) need to use writable/un-shared snapshot
-        // memories, and so can't share
-        unshared_snapshot_mem: { any(feature = "nanvix-unstable", feature = "gdb") },
+        // gdb needs writable snapshot memory for debug access.
+        unshared_snapshot_mem: { feature = "gdb" },
     }
 
     #[cfg(feature = "build-metadata")]

--- a/src/hyperlight_host/build.rs
+++ b/src/hyperlight_host/build.rs
@@ -105,8 +105,10 @@ fn main() -> Result<()> {
         crashdump: { all(feature = "crashdump", target_arch = "x86_64") },
         // print_debug feature is aliased with debug_assertions to make it only available in debug-builds.
         print_debug: { all(feature = "print_debug", debug_assertions) },
-        // gdb needs writable snapshot memory for debug access.
-        unshared_snapshot_mem: { any(feature = "gdb", feature = "nanvix-unstable") },
+        // the nanvix-unstable and gdb features both (only
+        // temporarily!) need to use writable/un-shared snapshot
+        // memories, and so can't share
+        unshared_snapshot_mem: { any(feature = "nanvix-unstable", feature = "gdb") },
     }
 
     #[cfg(feature = "build-metadata")]

--- a/src/hyperlight_host/build.rs
+++ b/src/hyperlight_host/build.rs
@@ -106,7 +106,7 @@ fn main() -> Result<()> {
         // print_debug feature is aliased with debug_assertions to make it only available in debug-builds.
         print_debug: { all(feature = "print_debug", debug_assertions) },
         // gdb needs writable snapshot memory for debug access.
-        unshared_snapshot_mem: { feature = "gdb" },
+        unshared_snapshot_mem: { any(feature = "gdb", feature = "nanvix-unstable") },
     }
 
     #[cfg(feature = "build-metadata")]

--- a/src/hyperlight_host/src/hypervisor/hyperlight_vm/aarch64.rs
+++ b/src/hyperlight_host/src/hypervisor/hyperlight_vm/aarch64.rs
@@ -41,7 +41,7 @@ impl HyperlightVm {
     pub(crate) fn new(
         _snapshot_mem: GuestSharedMemory,
         _scratch_mem: GuestSharedMemory,
-        _pml4_addr: u64,
+        _root_pt_addr: u64,
         _entrypoint: NextAction,
         _rsp_gva: u64,
         _config: &SandboxConfiguration,

--- a/src/hyperlight_host/src/hypervisor/hyperlight_vm/x86_64.rs
+++ b/src/hyperlight_host/src/hypervisor/hyperlight_vm/x86_64.rs
@@ -1424,7 +1424,7 @@ mod tests {
         let mut layout = SandboxMemoryLayout::new(config, code.len(), 4096, None).unwrap();
 
         let pt_base_gpa = layout.get_pt_base_gpa();
-        let pt_buf = GuestPageTableBuffer::new(pt_base_gpa as usize);
+        let pt_buf = GuestPageTableBuffer::<8>::new(pt_base_gpa as usize);
 
         for rgn in layout
             .get_memory_regions_::<GuestMemoryRegion>(())

--- a/src/hyperlight_host/src/hypervisor/hyperlight_vm/x86_64.rs
+++ b/src/hyperlight_host/src/hypervisor/hyperlight_vm/x86_64.rs
@@ -251,7 +251,6 @@ impl HyperlightVm {
     }
 
     /// Get the current base page table physical address from CR3.
-    #[allow(dead_code)]
     pub(crate) fn get_root_pt(&self) -> Result<u64, AccessPageTableError> {
         let sregs = self.vm.sregs()?;
         // Mask off the flags bits

--- a/src/hyperlight_host/src/hypervisor/hyperlight_vm/x86_64.rs
+++ b/src/hyperlight_host/src/hypervisor/hyperlight_vm/x86_64.rs
@@ -101,8 +101,10 @@ impl HyperlightVm {
         };
 
         #[cfg(not(feature = "i686-guest"))]
-        vm.set_sregs(&CommonSpecialRegisters::standard_64bit_defaults(_root_pt_addr))
-            .map_err(VmError::Register)?;
+        vm.set_sregs(&CommonSpecialRegisters::standard_64bit_defaults(
+            _root_pt_addr,
+        ))
+        .map_err(VmError::Register)?;
         #[cfg(feature = "i686-guest")]
         vm.set_sregs(&CommonSpecialRegisters::standard_32bit_paging_defaults(
             _root_pt_addr,

--- a/src/hyperlight_host/src/hypervisor/hyperlight_vm/x86_64.rs
+++ b/src/hyperlight_host/src/hypervisor/hyperlight_vm/x86_64.rs
@@ -76,7 +76,7 @@ impl HyperlightVm {
     pub(crate) fn new(
         snapshot_mem: SnapshotSharedMemory<GuestSharedMemory>,
         scratch_mem: GuestSharedMemory,
-        _pml4_addr: u64,
+        _root_pt_addr: u64,
         entrypoint: NextAction,
         rsp_gva: u64,
         page_size: usize,
@@ -101,11 +101,11 @@ impl HyperlightVm {
         };
 
         #[cfg(not(feature = "i686-guest"))]
-        vm.set_sregs(&CommonSpecialRegisters::standard_64bit_defaults(_pml4_addr))
+        vm.set_sregs(&CommonSpecialRegisters::standard_64bit_defaults(_root_pt_addr))
             .map_err(VmError::Register)?;
         #[cfg(feature = "i686-guest")]
         vm.set_sregs(&CommonSpecialRegisters::standard_32bit_paging_defaults(
-            _pml4_addr,
+            _root_pt_addr,
         ))
         .map_err(VmError::Register)?;
 
@@ -934,7 +934,7 @@ mod tests {
 
     /// Build dirty special registers for testing reset_vcpu.
     /// Must be consistent for 64-bit long mode (CR0/CR4/EFER).
-    fn dirty_sregs(_pml4_addr: u64) -> CommonSpecialRegisters {
+    fn dirty_sregs(_root_pt_addr: u64) -> CommonSpecialRegisters {
         let segment = CommonSegmentRegister {
             base: 0x1000,
             limit: 0xFFFF,
@@ -987,10 +987,10 @@ mod tests {
             idt: table,
             cr0: 0x80000011, // PE + ET + PG
             cr2: 0xBADC0DE,
-            // MSHV validates cr3 and rejects bogus values; use valid _pml4_addr for MSHV
+            // MSHV validates cr3 and rejects bogus values; use valid _root_pt_addr for MSHV
             cr3: match get_available_hypervisor() {
                 #[cfg(mshv3)]
-                Some(HypervisorType::Mshv) => _pml4_addr,
+                Some(HypervisorType::Mshv) => _root_pt_addr,
                 _ => 0x12345000,
             },
             cr4: 0x20, // PAE
@@ -1211,8 +1211,8 @@ mod tests {
 
     /// Assert that special registers are in reset state.
     /// Handles hypervisor-specific differences in hidden descriptor cache fields.
-    fn assert_sregs_reset(vm: &dyn VirtualMachine, pml4_addr: u64) {
-        let defaults = CommonSpecialRegisters::standard_64bit_defaults(pml4_addr);
+    fn assert_sregs_reset(vm: &dyn VirtualMachine, root_pt_addr: u64) {
+        let defaults = CommonSpecialRegisters::standard_64bit_defaults(root_pt_addr);
         let sregs = vm.sregs().unwrap();
         let mut expected_sregs = defaults;
         // Normalize hypervisor implementation-specific fields.

--- a/src/hyperlight_host/src/hypervisor/hyperlight_vm/x86_64.rs
+++ b/src/hyperlight_host/src/hypervisor/hyperlight_vm/x86_64.rs
@@ -1424,7 +1424,7 @@ mod tests {
         let mut layout = SandboxMemoryLayout::new(config, code.len(), 4096, None).unwrap();
 
         let pt_base_gpa = layout.get_pt_base_gpa();
-        let pt_buf = GuestPageTableBuffer::<8>::new(pt_base_gpa as usize);
+        let pt_buf = GuestPageTableBuffer::new(pt_base_gpa as usize);
 
         for rgn in layout
             .get_memory_regions_::<GuestMemoryRegion>(())
@@ -1443,6 +1443,7 @@ mod tests {
                     writable,
                     executable,
                 }),
+                user_accessible: false,
             };
             unsafe { vmem::map(&pt_buf, mapping) };
         }
@@ -1460,6 +1461,7 @@ mod tests {
                 writable: true,
                 executable: true, // Match regular codepath (map_specials)
             }),
+            user_accessible: false,
         };
         unsafe { vmem::map(&pt_buf, scratch_mapping) };
 

--- a/src/hyperlight_host/src/hypervisor/hyperlight_vm/x86_64.rs
+++ b/src/hyperlight_host/src/hypervisor/hyperlight_vm/x86_64.rs
@@ -251,6 +251,7 @@ impl HyperlightVm {
     }
 
     /// Get the current base page table physical address from CR3.
+    #[allow(dead_code)]
     pub(crate) fn get_root_pt(&self) -> Result<u64, AccessPageTableError> {
         let sregs = self.vm.sregs()?;
         // Mask off the flags bits

--- a/src/hyperlight_host/src/hypervisor/hyperlight_vm/x86_64.rs
+++ b/src/hyperlight_host/src/hypervisor/hyperlight_vm/x86_64.rs
@@ -104,8 +104,10 @@ impl HyperlightVm {
         vm.set_sregs(&CommonSpecialRegisters::standard_64bit_defaults(_pml4_addr))
             .map_err(VmError::Register)?;
         #[cfg(feature = "i686-guest")]
-        vm.set_sregs(&CommonSpecialRegisters::standard_real_mode_defaults())
-            .map_err(VmError::Register)?;
+        vm.set_sregs(&CommonSpecialRegisters::standard_32bit_paging_defaults(
+            _pml4_addr,
+        ))
+        .map_err(VmError::Register)?;
 
         #[cfg(any(kvm, mshv3))]
         let interrupt_handle: Arc<dyn InterruptHandleImpl> = Arc::new(LinuxInterruptHandle {
@@ -248,21 +250,11 @@ impl HyperlightVm {
         Ok(())
     }
 
-    /// Get the current base page table physical address.
-    ///
-    /// By default, reads CR3 from the vCPU special registers.
-    /// With `i686-guest`, returns 0 (identity-mapped, no page tables).
+    /// Get the current base page table physical address from CR3.
     pub(crate) fn get_root_pt(&self) -> Result<u64, AccessPageTableError> {
-        #[cfg(not(feature = "i686-guest"))]
-        {
-            let sregs = self.vm.sregs()?;
-            // Mask off the flags bits
-            Ok(sregs.cr3 & !0xfff_u64)
-        }
-        #[cfg(feature = "i686-guest")]
-        {
-            Ok(0)
-        }
+        let sregs = self.vm.sregs()?;
+        // Mask off the flags bits
+        Ok(sregs.cr3 & !0xfff_u64)
     }
 
     /// Get the special registers that need to be stored in a snapshot.
@@ -352,23 +344,12 @@ impl HyperlightVm {
         self.vm.set_debug_regs(&CommonDebugRegs::default())?;
         self.vm.reset_xsave()?;
 
-        #[cfg(not(feature = "i686-guest"))]
-        {
-            // Restore the full special registers from snapshot, but update CR3
-            // to point to the new (relocated) page tables
-            let mut sregs = *sregs;
-            sregs.cr3 = cr3;
-            self.pending_tlb_flush = true;
-            self.vm.set_sregs(&sregs)?;
-        }
-        #[cfg(feature = "i686-guest")]
-        {
-            let _ = (cr3, sregs); // suppress unused warnings
-            // TODO: This is probably not correct.
-            // Let's deal with it when we clean up the i686-guest feature
-            self.vm
-                .set_sregs(&CommonSpecialRegisters::standard_real_mode_defaults())?;
-        }
+        // Restore the full special registers from snapshot, but update CR3
+        // to point to the new (relocated) page tables
+        let mut sregs = *sregs;
+        sregs.cr3 = cr3;
+        self.pending_tlb_flush = true;
+        self.vm.set_sregs(&sregs)?;
 
         Ok(())
     }

--- a/src/hyperlight_host/src/hypervisor/hyperlight_vm/x86_64.rs
+++ b/src/hyperlight_host/src/hypervisor/hyperlight_vm/x86_64.rs
@@ -100,10 +100,10 @@ impl HyperlightVm {
             None => return Err(CreateHyperlightVmError::NoHypervisorFound),
         };
 
-        #[cfg(not(feature = "nanvix-unstable"))]
+        #[cfg(not(feature = "i686-guest"))]
         vm.set_sregs(&CommonSpecialRegisters::standard_64bit_defaults(_pml4_addr))
             .map_err(VmError::Register)?;
-        #[cfg(feature = "nanvix-unstable")]
+        #[cfg(feature = "i686-guest")]
         vm.set_sregs(&CommonSpecialRegisters::standard_real_mode_defaults())
             .map_err(VmError::Register)?;
 
@@ -251,15 +251,15 @@ impl HyperlightVm {
     /// Get the current base page table physical address.
     ///
     /// By default, reads CR3 from the vCPU special registers.
-    /// With `nanvix-unstable`, returns 0 (identity-mapped, no page tables).
+    /// With `i686-guest`, returns 0 (identity-mapped, no page tables).
     pub(crate) fn get_root_pt(&self) -> Result<u64, AccessPageTableError> {
-        #[cfg(not(feature = "nanvix-unstable"))]
+        #[cfg(not(feature = "i686-guest"))]
         {
             let sregs = self.vm.sregs()?;
             // Mask off the flags bits
             Ok(sregs.cr3 & !0xfff_u64)
         }
-        #[cfg(feature = "nanvix-unstable")]
+        #[cfg(feature = "i686-guest")]
         {
             Ok(0)
         }
@@ -352,7 +352,7 @@ impl HyperlightVm {
         self.vm.set_debug_regs(&CommonDebugRegs::default())?;
         self.vm.reset_xsave()?;
 
-        #[cfg(not(feature = "nanvix-unstable"))]
+        #[cfg(not(feature = "i686-guest"))]
         {
             // Restore the full special registers from snapshot, but update CR3
             // to point to the new (relocated) page tables
@@ -361,11 +361,11 @@ impl HyperlightVm {
             self.pending_tlb_flush = true;
             self.vm.set_sregs(&sregs)?;
         }
-        #[cfg(feature = "nanvix-unstable")]
+        #[cfg(feature = "i686-guest")]
         {
             let _ = (cr3, sregs); // suppress unused warnings
             // TODO: This is probably not correct.
-            // Let's deal with it when we clean up the nanvix-unstable feature
+            // Let's deal with it when we clean up the i686-guest feature
             self.vm
                 .set_sregs(&CommonSpecialRegisters::standard_real_mode_defaults())?;
         }
@@ -874,7 +874,7 @@ pub(super) mod debug {
 }
 
 #[cfg(test)]
-#[cfg(not(feature = "nanvix-unstable"))]
+#[cfg(not(feature = "i686-guest"))]
 #[allow(clippy::needless_range_loop)]
 mod tests {
     use std::sync::{Arc, Mutex};

--- a/src/hyperlight_host/src/hypervisor/regs/x86_64/special_regs.rs
+++ b/src/hyperlight_host/src/hypervisor/regs/x86_64/special_regs.rs
@@ -104,36 +104,54 @@ impl CommonSpecialRegisters {
         }
     }
 
+    /// Returns special registers for 32-bit protected mode with paging enabled.
+    /// Used for i686 guests that need CoW page tables from boot.
     #[cfg(feature = "i686-guest")]
-    pub(crate) fn standard_real_mode_defaults() -> Self {
+    pub(crate) fn standard_32bit_paging_defaults(pd_addr: u64) -> Self {
+        // Flat 32-bit code segment: base=0, limit=4GB, 32-bit, executable
+        let code_seg = CommonSegmentRegister {
+            base: 0,
+            selector: 0x08,
+            limit: 0xFFFFFFFF,
+            type_: 11, // Execute/Read, Accessed
+            present: 1,
+            s: 1,
+            db: 1, // 32-bit
+            g: 1,  // 4KB granularity
+            ..Default::default()
+        };
+        // Flat 32-bit data segment: base=0, limit=4GB, 32-bit, writable
+        let data_seg = CommonSegmentRegister {
+            base: 0,
+            selector: 0x10,
+            limit: 0xFFFFFFFF,
+            type_: 3, // Read/Write, Accessed
+            present: 1,
+            s: 1,
+            db: 1, // 32-bit
+            g: 1,  // 4KB granularity
+            ..Default::default()
+        };
+        let tr_seg = CommonSegmentRegister {
+            base: 0,
+            selector: 0,
+            limit: 0xFFFF,
+            type_: 11,
+            present: 1,
+            s: 0,
+            ..Default::default()
+        };
         CommonSpecialRegisters {
-            cs: CommonSegmentRegister {
-                base: 0,
-                selector: 0,
-                limit: 0xFFFF,
-                type_: 11,
-                present: 1,
-                s: 1,
-                ..Default::default()
-            },
-            ds: CommonSegmentRegister {
-                base: 0,
-                selector: 0,
-                limit: 0xFFFF,
-                type_: 3,
-                present: 1,
-                s: 1,
-                ..Default::default()
-            },
-            tr: CommonSegmentRegister {
-                base: 0,
-                selector: 0,
-                limit: 0xFFFF,
-                type_: 11,
-                present: 1,
-                s: 0,
-                ..Default::default()
-            },
+            cs: code_seg,
+            ds: data_seg,
+            es: data_seg,
+            ss: data_seg,
+            fs: data_seg,
+            gs: data_seg,
+            tr: tr_seg,
+            cr0: 0x80010011, // PE + ET + WP (write-protect for CoW) + PG
+            cr3: pd_addr,
+            cr4: 0, // No PAE, no PSE
             ..Default::default()
         }
     }

--- a/src/hyperlight_host/src/hypervisor/regs/x86_64/special_regs.rs
+++ b/src/hyperlight_host/src/hypervisor/regs/x86_64/special_regs.rs
@@ -73,7 +73,7 @@ pub(crate) struct CommonSpecialRegisters {
 
 impl CommonSpecialRegisters {
     #[cfg(not(feature = "i686-guest"))]
-    pub(crate) fn standard_64bit_defaults(pml4_addr: u64) -> Self {
+    pub(crate) fn standard_64bit_defaults(root_pt_addr: u64) -> Self {
         CommonSpecialRegisters {
             cs: CommonSegmentRegister {
                 l: 1,          // 64-bit
@@ -100,7 +100,7 @@ impl CommonSpecialRegisters {
             cr0: CR0_PE | CR0_MP | CR0_ET | CR0_NE | CR0_AM | CR0_WP | CR0_PG,
             cr2: 0,
             cr4: CR4_PAE | CR4_OSFXSR | CR4_OSXMMEXCPT,
-            cr3: pml4_addr,
+            cr3: root_pt_addr,
             cr8: 0,
             apic_base: 0,
             interrupt_bitmap: [0; 4],
@@ -110,7 +110,7 @@ impl CommonSpecialRegisters {
     /// Returns special registers for 32-bit protected mode with paging enabled.
     /// Used for i686 guests that need CoW page tables from boot.
     #[cfg(feature = "i686-guest")]
-    pub(crate) fn standard_32bit_paging_defaults(pd_addr: u64) -> Self {
+    pub(crate) fn standard_32bit_paging_defaults(root_pt_addr: u64) -> Self {
         // Flat 32-bit code segment: base=0, limit=4GB, 32-bit, executable
         let code_seg = CommonSegmentRegister {
             base: 0,
@@ -153,7 +153,7 @@ impl CommonSpecialRegisters {
             gs: data_seg,
             tr: tr_seg,
             cr0: CR0_PE | CR0_ET | CR0_WP | CR0_PG,
-            cr3: pd_addr,
+            cr3: root_pt_addr,
             cr4: 0, // No PAE, no PSE
             ..Default::default()
         }

--- a/src/hyperlight_host/src/hypervisor/regs/x86_64/special_regs.rs
+++ b/src/hyperlight_host/src/hypervisor/regs/x86_64/special_regs.rs
@@ -28,7 +28,7 @@ use windows::Win32::System::Hypervisor::*;
 use super::FromWhpRegisterError;
 
 cfg_if::cfg_if! {
-    if #[cfg(not(feature = "nanvix-unstable"))] {
+    if #[cfg(not(feature = "i686-guest"))] {
         pub(crate) const CR4_PAE: u64 = 1 << 5;
         pub(crate) const CR4_OSFXSR: u64 = 1 << 9;
         pub(crate) const CR4_OSXMMEXCPT: u64 = 1 << 10;
@@ -69,7 +69,7 @@ pub(crate) struct CommonSpecialRegisters {
 }
 
 impl CommonSpecialRegisters {
-    #[cfg(not(feature = "nanvix-unstable"))]
+    #[cfg(not(feature = "i686-guest"))]
     pub(crate) fn standard_64bit_defaults(pml4_addr: u64) -> Self {
         CommonSpecialRegisters {
             cs: CommonSegmentRegister {
@@ -104,7 +104,7 @@ impl CommonSpecialRegisters {
         }
     }
 
-    #[cfg(feature = "nanvix-unstable")]
+    #[cfg(feature = "i686-guest")]
     pub(crate) fn standard_real_mode_defaults() -> Self {
         CommonSpecialRegisters {
             cs: CommonSegmentRegister {

--- a/src/hyperlight_host/src/hypervisor/regs/x86_64/special_regs.rs
+++ b/src/hyperlight_host/src/hypervisor/regs/x86_64/special_regs.rs
@@ -27,24 +27,27 @@ use windows::Win32::System::Hypervisor::*;
 #[cfg(target_os = "windows")]
 use super::FromWhpRegisterError;
 
-cfg_if::cfg_if! {
-    if #[cfg(not(feature = "i686-guest"))] {
-        pub(crate) const CR4_PAE: u64 = 1 << 5;
-        pub(crate) const CR4_OSFXSR: u64 = 1 << 9;
-        pub(crate) const CR4_OSXMMEXCPT: u64 = 1 << 10;
-        pub(crate) const CR0_PE: u64 = 1;
-        pub(crate) const CR0_MP: u64 = 1 << 1;
-        pub(crate) const CR0_ET: u64 = 1 << 4;
-        pub(crate) const CR0_NE: u64 = 1 << 5;
-        pub(crate) const CR0_WP: u64 = 1 << 16;
-        pub(crate) const CR0_AM: u64 = 1 << 18;
-        pub(crate) const CR0_PG: u64 = 1 << 31;
-        pub(crate) const EFER_LME: u64 = 1 << 8;
-        pub(crate) const EFER_LMA: u64 = 1 << 10;
-        pub(crate) const EFER_SCE: u64 = 1;
-        pub(crate) const EFER_NX: u64 = 1 << 11;
-    }
+// CR0 bits used by both 32-bit and 64-bit guest
+const CR0_PE: u64 = 1;
+const CR0_ET: u64 = 1 << 4;
+const CR0_WP: u64 = 1 << 16;
+const CR0_PG: u64 = 1 << 31;
+
+#[cfg(not(feature = "i686-guest"))]
+mod amd64_consts {
+    pub(crate) const CR4_PAE: u64 = 1 << 5;
+    pub(crate) const CR4_OSFXSR: u64 = 1 << 9;
+    pub(crate) const CR4_OSXMMEXCPT: u64 = 1 << 10;
+    pub(crate) const CR0_MP: u64 = 1 << 1;
+    pub(crate) const CR0_NE: u64 = 1 << 5;
+    pub(crate) const CR0_AM: u64 = 1 << 18;
+    pub(crate) const EFER_LME: u64 = 1 << 8;
+    pub(crate) const EFER_LMA: u64 = 1 << 10;
+    pub(crate) const EFER_SCE: u64 = 1;
+    pub(crate) const EFER_NX: u64 = 1 << 11;
 }
+#[cfg(not(feature = "i686-guest"))]
+use amd64_consts::*;
 
 #[derive(Debug, Default, Copy, Clone, PartialEq)]
 pub(crate) struct CommonSpecialRegisters {
@@ -149,7 +152,7 @@ impl CommonSpecialRegisters {
             fs: data_seg,
             gs: data_seg,
             tr: tr_seg,
-            cr0: 0x80010011, // PE + ET + WP (write-protect for CoW) + PG
+            cr0: CR0_PE | CR0_ET | CR0_WP | CR0_PG,
             cr3: pd_addr,
             cr4: 0, // No PAE, no PSE
             ..Default::default()

--- a/src/hyperlight_host/src/hypervisor/virtual_machine/kvm/x86_64.rs
+++ b/src/hyperlight_host/src/hypervisor/virtual_machine/kvm/x86_64.rs
@@ -36,7 +36,7 @@ use crate::hypervisor::regs::{
     CommonDebugRegs, CommonFpu, CommonRegisters, CommonSpecialRegisters, FP_CONTROL_WORD_DEFAULT,
     MXCSR_DEFAULT,
 };
-#[cfg(all(test, not(feature = "nanvix-unstable")))]
+#[cfg(all(test, not(feature = "i686-guest")))]
 use crate::hypervisor::virtual_machine::XSAVE_BUFFER_SIZE;
 #[cfg(feature = "hw-interrupts")]
 use crate::hypervisor::virtual_machine::x86_64::hw_interrupts::TimerThread;
@@ -446,7 +446,7 @@ impl VirtualMachine for KvmVm {
     }
 
     #[cfg(test)]
-    #[cfg(not(feature = "nanvix-unstable"))]
+    #[cfg(not(feature = "i686-guest"))]
     fn set_xsave(&self, xsave: &[u32]) -> std::result::Result<(), RegisterError> {
         if std::mem::size_of_val(xsave) != XSAVE_BUFFER_SIZE {
             return Err(RegisterError::XsaveSizeMismatch {

--- a/src/hyperlight_host/src/hypervisor/virtual_machine/mod.rs
+++ b/src/hyperlight_host/src/hypervisor/virtual_machine/mod.rs
@@ -112,7 +112,7 @@ pub(crate) const XSAVE_MIN_SIZE: usize = 576;
 
 /// Standard XSAVE buffer size (4KB) used by KVM and MSHV.
 /// WHP queries the required size dynamically.
-#[cfg(all(any(kvm, mshv3), test, not(feature = "nanvix-unstable")))]
+#[cfg(all(any(kvm, mshv3), test, not(feature = "i686-guest")))]
 pub(crate) const XSAVE_BUFFER_SIZE: usize = 4096;
 
 // Compiler error if no hypervisor type is available (not applicable on aarch64 yet)
@@ -350,7 +350,7 @@ pub(crate) trait VirtualMachine: Debug + Send {
     fn reset_xsave(&self) -> std::result::Result<(), RegisterError>;
     /// Set xsave - only used for tests
     #[cfg(test)]
-    #[cfg(not(feature = "nanvix-unstable"))]
+    #[cfg(not(feature = "i686-guest"))]
     fn set_xsave(&self, xsave: &[u32]) -> std::result::Result<(), RegisterError>;
 
     /// Get partition handle

--- a/src/hyperlight_host/src/hypervisor/virtual_machine/mshv/x86_64.rs
+++ b/src/hyperlight_host/src/hypervisor/virtual_machine/mshv/x86_64.rs
@@ -51,7 +51,7 @@ use crate::hypervisor::regs::{
     CommonDebugRegs, CommonFpu, CommonRegisters, CommonSpecialRegisters, FP_CONTROL_WORD_DEFAULT,
     MXCSR_DEFAULT,
 };
-#[cfg(all(test, not(feature = "nanvix-unstable")))]
+#[cfg(all(test, not(feature = "i686-guest")))]
 use crate::hypervisor::virtual_machine::XSAVE_BUFFER_SIZE;
 #[cfg(feature = "hw-interrupts")]
 use crate::hypervisor::virtual_machine::x86_64::hw_interrupts::TimerThread;
@@ -445,7 +445,7 @@ impl VirtualMachine for MshvVm {
     }
 
     #[cfg(test)]
-    #[cfg(not(feature = "nanvix-unstable"))]
+    #[cfg(not(feature = "i686-guest"))]
     fn set_xsave(&self, xsave: &[u32]) -> std::result::Result<(), RegisterError> {
         if std::mem::size_of_val(xsave) != XSAVE_BUFFER_SIZE {
             return Err(RegisterError::XsaveSizeMismatch {

--- a/src/hyperlight_host/src/hypervisor/virtual_machine/whp.rs
+++ b/src/hyperlight_host/src/hypervisor/virtual_machine/whp.rs
@@ -754,7 +754,7 @@ impl VirtualMachine for WhpVm {
     }
 
     #[cfg(test)]
-    #[cfg(not(feature = "nanvix-unstable"))]
+    #[cfg(not(feature = "i686-guest"))]
     fn set_xsave(&self, xsave: &[u32]) -> std::result::Result<(), RegisterError> {
         // Get the required buffer size by calling with NULL buffer.
         // If the buffer is not large enough (0 won't be), WHvGetVirtualProcessorXsaveState returns

--- a/src/hyperlight_host/src/lib.rs
+++ b/src/hyperlight_host/src/lib.rs
@@ -94,7 +94,7 @@ pub use sandbox::UninitializedSandbox;
 /// The re-export for the `GuestBinary` type
 pub use sandbox::uninitialized::GuestBinary;
 /// The re-export for the `GuestCounter` type
-#[cfg(feature = "nanvix-unstable")]
+#[cfg(feature = "guest-counter")]
 pub use sandbox::uninitialized::GuestCounter;
 
 /// The universal `Result` type used throughout the Hyperlight codebase.

--- a/src/hyperlight_host/src/mem/exe.rs
+++ b/src/hyperlight_host/src/mem/exe.rs
@@ -88,6 +88,12 @@ impl ExeInfo {
             ExeInfo::Elf(elf) => Offset::from(elf.entrypoint_va()),
         }
     }
+    /// Returns the base virtual address of the loaded binary (lowest PT_LOAD p_vaddr).
+    pub fn base_va(&self) -> u64 {
+        match self {
+            ExeInfo::Elf(elf) => elf.get_base_va(),
+        }
+    }
     pub fn loaded_size(&self) -> usize {
         match self {
             ExeInfo::Elf(elf) => elf.get_va_size(),

--- a/src/hyperlight_host/src/mem/layout.rs
+++ b/src/hyperlight_host/src/mem/layout.rs
@@ -140,7 +140,7 @@ impl<'a> ResolvedGpa<&'a [u8], &'a [u8]> {
     }
 }
 #[cfg(any(gdb, feature = "mem_profile"))]
-#[allow(unused)] // may be unused when nanvix-unstable is also enabled
+#[allow(unused)] // may be unused when i686-guest is also enabled
 pub(crate) trait ReadableSharedMemory {
     fn copy_to_slice(&self, slice: &mut [u8], offset: usize) -> Result<()>;
 }
@@ -178,7 +178,7 @@ impl<T: coherence_hack::SharedMemoryAsRefMarker> ReadableSharedMemory for T {
 }
 #[cfg(any(gdb, feature = "mem_profile"))]
 impl<Sn: ReadableSharedMemory, Sc: ReadableSharedMemory> ResolvedGpa<Sn, Sc> {
-    #[allow(unused)] // may be unused when nanvix-unstable is also enabled
+    #[allow(unused)] // may be unused when i686-guest is also enabled
     pub(crate) fn copy_to_slice(&self, slice: &mut [u8]) -> Result<()> {
         match &self.base {
             BaseGpaRegion::Snapshot(sn) => sn.copy_to_slice(slice, self.offset),
@@ -239,7 +239,7 @@ pub(crate) struct SandboxMemoryLayout {
     code_size: usize,
     // The offset in the sandbox memory where the code starts
     guest_code_offset: usize,
-    #[cfg_attr(feature = "nanvix-unstable", allow(unused))]
+    #[cfg_attr(feature = "i686-guest", allow(unused))]
     pub(crate) init_data_permissions: Option<MemoryRegionFlags>,
 
     // The size of the scratch region in physical memory; note that
@@ -316,10 +316,7 @@ impl SandboxMemoryLayout {
     const MAX_MEMORY_SIZE: usize = (16 * 1024 * 1024 * 1024) - Self::BASE_ADDRESS; // 16 GiB - BASE_ADDRESS
 
     /// The base address of the sandbox's memory.
-    #[cfg(not(feature = "nanvix-unstable"))]
     pub(crate) const BASE_ADDRESS: usize = 0x1000;
-    #[cfg(feature = "nanvix-unstable")]
-    pub(crate) const BASE_ADDRESS: usize = 0x0;
 
     // the offset into a sandbox's input/output buffer where the stack starts
     pub(crate) const STACK_POINTER_SIZE_BYTES: u64 = 8;
@@ -619,7 +616,7 @@ impl SandboxMemoryLayout {
 
     /// Returns the memory regions associated with this memory layout,
     /// suitable for passing to a hypervisor for mapping into memory
-    #[cfg_attr(feature = "nanvix-unstable", allow(unused))]
+    #[cfg_attr(feature = "i686-guest", allow(unused))]
     pub(crate) fn get_memory_regions_<K: MemoryRegionKind>(
         &self,
         host_base: K::HostBaseType,

--- a/src/hyperlight_host/src/mem/layout.rs
+++ b/src/hyperlight_host/src/mem/layout.rs
@@ -245,8 +245,10 @@ pub(crate) struct SandboxMemoryLayout {
     // The size of the scratch region in physical memory; note that
     // this will appear under the top of physical memory.
     scratch_size: usize,
-    // The size of the snapshot region in physical memory; note that
-    // this will appear somewhere near the base of physical memory.
+    // The guest-visible size of the snapshot region in physical
+    // memory. After compaction this may be smaller than the full
+    // snapshot blob (which also contains a PT tail that is only
+    // host-accessible).
     snapshot_size: usize,
 }
 

--- a/src/hyperlight_host/src/mem/memory_region.rs
+++ b/src/hyperlight_host/src/mem/memory_region.rs
@@ -276,7 +276,7 @@ impl MemoryRegionKind for HostGuestMemoryRegion {
 
 /// Type for memory regions that only track guest addresses.
 ///
-#[cfg_attr(feature = "nanvix-unstable", allow(dead_code))]
+#[cfg_attr(feature = "i686-guest", allow(dead_code))]
 #[derive(Debug, PartialEq, Eq, Copy, Clone, Hash)]
 pub(crate) struct GuestMemoryRegion {}
 
@@ -329,7 +329,7 @@ impl MemoryRegionKind for CrashDumpMemoryRegion {
 #[cfg(crashdump)]
 pub(crate) type CrashDumpRegion = MemoryRegion_<CrashDumpMemoryRegion>;
 
-#[cfg(all(crashdump, feature = "nanvix-unstable"))]
+#[cfg(all(crashdump, feature = "i686-guest"))]
 impl HostGuestMemoryRegion {
     /// Extract the raw `usize` host address from the platform-specific
     /// host base type.
@@ -349,7 +349,7 @@ impl HostGuestMemoryRegion {
     }
 }
 
-#[cfg_attr(feature = "nanvix-unstable", allow(unused))]
+#[cfg_attr(feature = "i686-guest", allow(unused))]
 pub(crate) struct MemoryRegionVecBuilder<K: MemoryRegionKind> {
     guest_base_phys_addr: usize,
     host_base_virt_addr: K::HostBaseType,

--- a/src/hyperlight_host/src/mem/mgr.rs
+++ b/src/hyperlight_host/src/mem/mgr.rs
@@ -148,9 +148,12 @@ pub(crate) struct SandboxMemoryManager<S: SharedMemory> {
     pub(crate) mapped_rgns: u64,
     /// Buffer for accumulating guest abort messages
     pub(crate) abort_buffer: Vec<u8>,
-    /// Snapshot restore generation counter. 0 means no restore
-    /// and is incremented on each `restore_snapshot` call.
-    pub(crate) restore_count: u64,
+    /// Generation counter: how many snapshots have been taken from
+    /// this sandbox's execution path from init to here. Incremented
+    /// on each `snapshot` call; on `restore_snapshot` we inherit the
+    /// restored snapshot's own generation number so the guest-visible
+    /// counter tracks which snapshot the sandbox is a clone of.
+    pub(crate) snapshot_count: u64,
 }
 
 /// Buffer for building guest page tables during snapshot creation.
@@ -277,7 +280,7 @@ where
             entrypoint,
             mapped_rgns: 0,
             abort_buffer: Vec::new(),
-            restore_count: 0,
+            snapshot_count: 0,
         }
     }
 
@@ -296,6 +299,7 @@ where
         sregs: CommonSpecialRegisters,
         entrypoint: NextAction,
     ) -> Result<Snapshot> {
+        self.snapshot_count += 1;
         Snapshot::new(
             &mut self.shared_mem,
             &mut self.scratch_mem,
@@ -307,6 +311,7 @@ where
             rsp_gva,
             sregs,
             entrypoint,
+            self.snapshot_count,
         )
     }
 }
@@ -345,7 +350,7 @@ impl SandboxMemoryManager<ExclusiveSharedMemory> {
             entrypoint: self.entrypoint,
             mapped_rgns: self.mapped_rgns,
             abort_buffer: self.abort_buffer,
-            restore_count: self.restore_count,
+            snapshot_count: self.snapshot_count,
         };
         let guest_mgr = SandboxMemoryManager {
             shared_mem: gshm,
@@ -354,7 +359,7 @@ impl SandboxMemoryManager<ExclusiveSharedMemory> {
             entrypoint: self.entrypoint,
             mapped_rgns: self.mapped_rgns,
             abort_buffer: Vec::new(), // Guest doesn't need abort buffer
-            restore_count: self.restore_count,
+            snapshot_count: self.snapshot_count,
         };
         host_mgr.update_scratch_bookkeeping()?;
         host_mgr.copy_pt_to_scratch()?;
@@ -547,7 +552,11 @@ impl SandboxMemoryManager<HostSharedMemory> {
             Some(gscratch)
         };
         self.layout = *snapshot.layout();
-        self.restore_count += 1;
+        // Inherit the snapshot's own generation number — the
+        // guest-visible counter reflects "which snapshot is the
+        // sandbox currently a clone of", not "how many restores have
+        // happened into this (possibly-reused) partition".
+        self.snapshot_count = snapshot.snapshot_generation();
 
         self.update_scratch_bookkeeping()?;
         self.copy_pt_to_scratch()?;
@@ -582,7 +591,7 @@ impl SandboxMemoryManager<HostSharedMemory> {
         )?;
         self.update_scratch_bookkeeping_item(
             SCRATCH_TOP_SNAPSHOT_GENERATION_OFFSET,
-            self.restore_count,
+            self.snapshot_count,
         )?;
 
         // Initialise the guest input and output data buffers in

--- a/src/hyperlight_host/src/mem/mgr.rs
+++ b/src/hyperlight_host/src/mem/mgr.rs
@@ -362,7 +362,6 @@ impl SandboxMemoryManager<ExclusiveSharedMemory> {
             snapshot_count: self.snapshot_count,
         };
         host_mgr.update_scratch_bookkeeping()?;
-        host_mgr.copy_pt_to_scratch()?;
         Ok((host_mgr, guest_mgr))
     }
 }
@@ -559,7 +558,6 @@ impl SandboxMemoryManager<HostSharedMemory> {
         self.snapshot_count = snapshot.snapshot_generation();
 
         self.update_scratch_bookkeeping()?;
-        self.copy_pt_to_scratch()?;
         Ok((gsnapshot, gscratch))
     }
 
@@ -579,10 +577,11 @@ impl SandboxMemoryManager<HostSharedMemory> {
             self.layout.get_first_free_scratch_gpa(),
         )?;
         // Record the GPA of the snapshot's copy of the page tables.
-        // The copy lives at the tail of the snapshot blob (see
-        // `copy_pt_to_scratch` below). The guest reads this GPA
-        // during CoW fault-in to follow the original PTs on the first
-        // write — until the HV can execute directly out of the
+        // The copy lives at the tail of the snapshot blob; we copy it
+        // into scratch below so the guest walker can run against
+        // mutable, TLB-fresh tables. The guest reads this GPA during
+        // CoW fault-in to follow the original PTs on the first write
+        // — until the HV can execute directly out of the
         // snapshot-resident PTs, at which point the whole split goes
         // away.
         self.update_scratch_bookkeeping_item(
@@ -605,21 +604,12 @@ impl SandboxMemoryManager<HostSharedMemory> {
             SandboxMemoryLayout::STACK_POINTER_SIZE_BYTES,
         )?;
 
-        Ok(())
-    }
-
-    /// Copy page tables from `shared_mem` into the scratch region.
-    ///
-    /// PT bytes are appended to the snapshot blob at build time and
-    /// live just past the end of the guest-visible KVM slot (see
-    /// `Snapshot::new`). Keeping them outside the KVM slot avoids
-    /// overlapping with `map_file_cow` regions that the embedder
-    /// installs immediately after the snapshot in the guest PA space
-    /// — if we left the PT tail inside the slot, the first
-    /// `map_file_cow` page would sit on top of the last PT page. On
-    /// restore we copy the PT tail into scratch so the guest walker
-    /// can run against mutable, TLB-fresh tables.
-    fn copy_pt_to_scratch(&mut self) -> Result<()> {
+        // Copy page tables from `shared_mem` into scratch. PT bytes
+        // are appended to the snapshot blob at build time and live
+        // just past the end of the guest-visible KVM slot (see
+        // `Snapshot::new`). Keeping them outside the KVM slot avoids
+        // overlapping with `map_file_cow` regions installed
+        // immediately after the snapshot in the guest PA space.
         let snapshot_pt_end = self.shared_mem.mem_size();
         let snapshot_pt_size = self.layout.get_pt_size();
         let snapshot_pt_start = snapshot_pt_end - snapshot_pt_size;
@@ -636,6 +626,7 @@ impl SandboxMemoryManager<HostSharedMemory> {
             #[allow(clippy::needless_borrow)]
             scratch.copy_from_slice(&bytes, self.layout.get_pt_base_scratch_offset())
         })??;
+
         Ok(())
     }
 

--- a/src/hyperlight_host/src/mem/mgr.rs
+++ b/src/hyperlight_host/src/mem/mgr.rs
@@ -154,7 +154,7 @@ pub(crate) struct SandboxMemoryManager<S: SharedMemory> {
 /// `PTE_BYTES` is the guest PTE size (8 for amd64, 4 for i686).
 /// `TableAddr` is a byte offset (GPA) so the same address space
 /// is used regardless of entry size.
-pub(crate) struct GuestPageTableBuffer<const PTE_BYTES: usize> {
+pub(crate) struct GuestPageTableBuffer {
     buffer: std::cell::RefCell<Vec<u8>>,
     phys_base: usize,
     /// Byte offset from phys_base to the active PD root.
@@ -163,7 +163,7 @@ pub(crate) struct GuestPageTableBuffer<const PTE_BYTES: usize> {
     root_offset: std::cell::Cell<usize>,
 }
 
-impl<const PTE_BYTES: usize> vmem::TableReadOps for GuestPageTableBuffer<PTE_BYTES> {
+impl vmem::TableReadOps for GuestPageTableBuffer {
     type TableAddr = u64;
 
     fn entry_addr(addr: u64, offset: u64) -> u64 {
@@ -173,16 +173,13 @@ impl<const PTE_BYTES: usize> vmem::TableReadOps for GuestPageTableBuffer<PTE_BYT
     unsafe fn read_entry(&self, addr: u64) -> vmem::PageTableEntry {
         let buffer = self.buffer.borrow();
         let byte_offset = addr as usize - self.phys_base;
-        let Some(bytes) = buffer.get(byte_offset..byte_offset + PTE_BYTES) else {
+        let pte_size = core::mem::size_of::<vmem::PageTableEntry>();
+        let Some(bytes) = buffer.get(byte_offset..byte_offset + pte_size) else {
             return 0;
         };
-        // The slice is exactly PTE_BYTES long, so try_into always succeeds.
-        #[allow(clippy::unwrap_used)]
-        if PTE_BYTES == 4 {
-            u32::from_le_bytes(bytes.try_into().unwrap()) as u64
-        } else {
-            u64::from_le_bytes(bytes.try_into().unwrap())
-        }
+        let mut buf = [0u8; 8];
+        buf[..pte_size].copy_from_slice(bytes);
+        vmem::PageTableEntry::from_le_bytes(buf[..pte_size].try_into().unwrap_or_default())
     }
 
     fn to_phys(addr: u64) -> vmem::PhysAddr {
@@ -208,7 +205,7 @@ impl<const PTE_BYTES: usize> vmem::TableReadOps for GuestPageTableBuffer<PTE_BYT
     }
 }
 
-impl<const PTE_BYTES: usize> vmem::TableOps for GuestPageTableBuffer<PTE_BYTES> {
+impl vmem::TableOps for GuestPageTableBuffer {
     type TableMovability = vmem::MayNotMoveTable;
 
     unsafe fn alloc_table(&self) -> u64 {
@@ -221,8 +218,9 @@ impl<const PTE_BYTES: usize> vmem::TableOps for GuestPageTableBuffer<PTE_BYTES> 
     unsafe fn write_entry(&self, addr: u64, entry: vmem::PageTableEntry) -> Option<vmem::Void> {
         let mut b = self.buffer.borrow_mut();
         let byte_offset = addr as usize - self.phys_base;
-        if let Some(slice) = b.get_mut(byte_offset..byte_offset + PTE_BYTES) {
-            slice.copy_from_slice(&entry.to_le_bytes()[..PTE_BYTES]);
+        let pte_size = core::mem::size_of::<vmem::PageTableEntry>();
+        if let Some(slice) = b.get_mut(byte_offset..byte_offset + pte_size) {
+            slice.copy_from_slice(&entry.to_le_bytes()[..pte_size]);
         }
         None
     }
@@ -232,15 +230,13 @@ impl<const PTE_BYTES: usize> vmem::TableOps for GuestPageTableBuffer<PTE_BYTES> 
     }
 }
 
-impl<const PTE_BYTES: usize> core::convert::AsRef<GuestPageTableBuffer<PTE_BYTES>>
-    for GuestPageTableBuffer<PTE_BYTES>
-{
+impl core::convert::AsRef<GuestPageTableBuffer> for GuestPageTableBuffer {
     fn as_ref(&self) -> &Self {
         self
     }
 }
 
-impl<const PTE_BYTES: usize> GuestPageTableBuffer<PTE_BYTES> {
+impl GuestPageTableBuffer {
     pub(crate) fn new(phys_base: usize) -> Self {
         GuestPageTableBuffer {
             buffer: std::cell::RefCell::new(vec![0u8; PAGE_TABLE_SIZE]),
@@ -262,29 +258,6 @@ impl<const PTE_BYTES: usize> GuestPageTableBuffer<PTE_BYTES> {
     pub(crate) fn copy_within(&self, src: std::ops::Range<usize>, dst: usize) {
         let mut buf = self.buffer.borrow_mut();
         buf.copy_within(src, dst);
-    }
-
-    /// Set a flag on a range of 4-byte PDE entries within a PD.
-    /// `pd_offset` is the byte offset to the PD page in the buffer.
-    /// `pde_range` is the range of PDE indices to modify.
-    #[cfg(feature = "i686-guest")]
-    pub(crate) fn set_pde_flag(
-        &self,
-        pd_offset: usize,
-        pde_range: std::ops::Range<usize>,
-        flag: u32,
-    ) {
-        let mut buf = self.buffer.borrow_mut();
-        for pdi in pde_range {
-            let off = pd_offset + pdi * 4;
-            if let Some(bytes) = buf.get(off..off + 4) {
-                let pde = u32::from_le_bytes(bytes.try_into().unwrap_or([0; 4]));
-                if pde != 0 {
-                    let updated = pde | flag;
-                    buf[off..off + 4].copy_from_slice(&updated.to_le_bytes());
-                }
-            }
-        }
     }
 
     /// Finalize multi-root i686 page directories after all per-root
@@ -309,7 +282,6 @@ impl<const PTE_BYTES: usize> GuestPageTableBuffer<PTE_BYTES> {
         scratch_gva: u64,
         scratch_len: u64,
     ) {
-        use hyperlight_common::vmem::i686_guest::PAGE_USER;
         use hyperlight_common::vmem::{BasicMapping, MappingKind};
 
         // Step 1: copy kernel PDEs from root 0 to all other roots.
@@ -322,7 +294,7 @@ impl<const PTE_BYTES: usize> GuestPageTableBuffer<PTE_BYTES> {
         for i in 1..n_roots {
             self.set_root_offset(i * PAGE_TABLE_SIZE);
             unsafe {
-                hyperlight_common::vmem::i686_guest::map(
+                vmem::map(
                     self,
                     vmem::Mapping {
                         phys_base: scratch_gpa,
@@ -333,20 +305,10 @@ impl<const PTE_BYTES: usize> GuestPageTableBuffer<PTE_BYTES> {
                             writable: true,
                             executable: false,
                         }),
+                        user_accessible: false,
                     },
                 );
             }
-        }
-
-        // Step 3: set PAGE_USER on user-space PDEs.
-        let scratch_pdi = (scratch_gva >> 22) as usize;
-        let page_user = PAGE_USER as u32;
-        for root_idx in 0..n_roots {
-            self.set_pde_flag(
-                root_idx * PAGE_TABLE_SIZE,
-                user_pde_start..scratch_pdi,
-                page_user,
-            );
         }
     }
     #[cfg(test)]

--- a/src/hyperlight_host/src/mem/mgr.rs
+++ b/src/hyperlight_host/src/mem/mgr.rs
@@ -22,8 +22,7 @@ use hyperlight_common::flatbuffer_wrappers::function_call::{
 };
 use hyperlight_common::flatbuffer_wrappers::function_types::FunctionCallResult;
 use hyperlight_common::flatbuffer_wrappers::guest_log_data::GuestLogData;
-#[cfg(not(feature = "i686-guest"))]
-use hyperlight_common::vmem::{self, PAGE_TABLE_SIZE, PageTableEntry, PhysAddr};
+use hyperlight_common::vmem::{self, PAGE_TABLE_SIZE};
 #[cfg(all(feature = "crashdump", not(feature = "i686-guest")))]
 use hyperlight_common::vmem::{BasicMapping, MappingKind};
 use tracing::{Span, instrument};
@@ -151,69 +150,79 @@ pub(crate) struct SandboxMemoryManager<S: SharedMemory> {
     pub(crate) abort_buffer: Vec<u8>,
 }
 
-#[cfg(not(feature = "i686-guest"))]
-pub(crate) struct GuestPageTableBuffer {
+/// Buffer for building guest page tables during snapshot creation.
+/// `PTE_BYTES` is the guest PTE size (8 for amd64, 4 for i686).
+/// `TableAddr` is a byte offset (GPA) so the same address space
+/// is used regardless of entry size.
+pub(crate) struct GuestPageTableBuffer<const PTE_BYTES: usize> {
     buffer: std::cell::RefCell<Vec<u8>>,
     phys_base: usize,
+    /// Byte offset from phys_base to the active PD root.
+    /// Used on i686 to target different per-process PDs.
+    #[cfg(feature = "i686-guest")]
+    root_offset: std::cell::Cell<usize>,
 }
 
-#[cfg(not(feature = "i686-guest"))]
-impl vmem::TableReadOps for GuestPageTableBuffer {
-    type TableAddr = (usize, usize); // (table_index, entry_index)
+impl<const PTE_BYTES: usize> vmem::TableReadOps for GuestPageTableBuffer<PTE_BYTES> {
+    type TableAddr = u64;
 
-    fn entry_addr(addr: (usize, usize), offset: u64) -> (usize, usize) {
-        // Convert to physical address, add offset, convert back
-        let phys = Self::to_phys(addr) + offset;
-        Self::from_phys(phys)
+    fn entry_addr(addr: u64, offset: u64) -> u64 {
+        addr + offset
     }
 
-    unsafe fn read_entry(&self, addr: (usize, usize)) -> PageTableEntry {
-        let b = self.buffer.borrow();
-        let byte_offset =
-            (addr.0 - self.phys_base / PAGE_TABLE_SIZE) * PAGE_TABLE_SIZE + addr.1 * 8;
-        b.get(byte_offset..byte_offset + 8)
-            .and_then(|s| <[u8; 8]>::try_from(s).ok())
-            .map(u64::from_ne_bytes)
-            .unwrap_or(0)
+    unsafe fn read_entry(&self, addr: u64) -> vmem::PageTableEntry {
+        let buffer = self.buffer.borrow();
+        let byte_offset = addr as usize - self.phys_base;
+        let Some(bytes) = buffer.get(byte_offset..byte_offset + PTE_BYTES) else {
+            return 0;
+        };
+        // The slice is exactly PTE_BYTES long, so try_into always succeeds.
+        #[allow(clippy::unwrap_used)]
+        if PTE_BYTES == 4 {
+            u32::from_le_bytes(bytes.try_into().unwrap()) as u64
+        } else {
+            u64::from_le_bytes(bytes.try_into().unwrap())
+        }
     }
 
-    fn to_phys(addr: (usize, usize)) -> PhysAddr {
-        (addr.0 as u64 * PAGE_TABLE_SIZE as u64) + (addr.1 as u64 * 8)
+    fn to_phys(addr: u64) -> vmem::PhysAddr {
+        addr as vmem::PhysAddr
     }
 
-    fn from_phys(addr: PhysAddr) -> (usize, usize) {
-        (
-            addr as usize / PAGE_TABLE_SIZE,
-            (addr as usize % PAGE_TABLE_SIZE) / 8,
-        )
+    fn from_phys(addr: vmem::PhysAddr) -> u64 {
+        #[allow(clippy::unnecessary_cast)]
+        {
+            addr as u64
+        }
     }
 
-    fn root_table(&self) -> (usize, usize) {
-        (self.phys_base / PAGE_TABLE_SIZE, 0)
+    fn root_table(&self) -> u64 {
+        #[cfg(feature = "i686-guest")]
+        {
+            (self.phys_base + self.root_offset.get()) as u64
+        }
+        #[cfg(not(feature = "i686-guest"))]
+        {
+            self.phys_base as u64
+        }
     }
 }
-#[cfg(not(feature = "i686-guest"))]
-impl vmem::TableOps for GuestPageTableBuffer {
+
+impl<const PTE_BYTES: usize> vmem::TableOps for GuestPageTableBuffer<PTE_BYTES> {
     type TableMovability = vmem::MayNotMoveTable;
 
-    unsafe fn alloc_table(&self) -> (usize, usize) {
+    unsafe fn alloc_table(&self) -> u64 {
         let mut b = self.buffer.borrow_mut();
-        let table_index = b.len() / PAGE_TABLE_SIZE;
-        let new_len = b.len() + PAGE_TABLE_SIZE;
-        b.resize(new_len, 0);
-        (self.phys_base / PAGE_TABLE_SIZE + table_index, 0)
+        let offset = b.len();
+        b.resize(offset + PAGE_TABLE_SIZE, 0);
+        (self.phys_base + offset) as u64
     }
 
-    unsafe fn write_entry(
-        &self,
-        addr: (usize, usize),
-        entry: PageTableEntry,
-    ) -> Option<vmem::Void> {
+    unsafe fn write_entry(&self, addr: u64, entry: vmem::PageTableEntry) -> Option<vmem::Void> {
         let mut b = self.buffer.borrow_mut();
-        let byte_offset =
-            (addr.0 - self.phys_base / PAGE_TABLE_SIZE) * PAGE_TABLE_SIZE + addr.1 * 8;
-        if let Some(slice) = b.get_mut(byte_offset..byte_offset + 8) {
-            slice.copy_from_slice(&entry.to_ne_bytes());
+        let byte_offset = addr as usize - self.phys_base;
+        if let Some(slice) = b.get_mut(byte_offset..byte_offset + PTE_BYTES) {
+            slice.copy_from_slice(&entry.to_le_bytes()[..PTE_BYTES]);
         }
         None
     }
@@ -223,15 +232,123 @@ impl vmem::TableOps for GuestPageTableBuffer {
     }
 }
 
-#[cfg(not(feature = "i686-guest"))]
-impl GuestPageTableBuffer {
+impl<const PTE_BYTES: usize> core::convert::AsRef<GuestPageTableBuffer<PTE_BYTES>>
+    for GuestPageTableBuffer<PTE_BYTES>
+{
+    fn as_ref(&self) -> &Self {
+        self
+    }
+}
+
+impl<const PTE_BYTES: usize> GuestPageTableBuffer<PTE_BYTES> {
     pub(crate) fn new(phys_base: usize) -> Self {
         GuestPageTableBuffer {
             buffer: std::cell::RefCell::new(vec![0u8; PAGE_TABLE_SIZE]),
             phys_base,
+            #[cfg(feature = "i686-guest")]
+            root_offset: std::cell::Cell::new(0),
         }
     }
 
+    /// Set the root offset to target a specific PD root.
+    /// Root i's PD starts at byte offset `i * PAGE_TABLE_SIZE` in the buffer.
+    #[cfg(feature = "i686-guest")]
+    pub(crate) fn set_root_offset(&self, offset: usize) {
+        self.root_offset.set(offset);
+    }
+
+    /// Copy a range of bytes within the buffer.
+    #[cfg(feature = "i686-guest")]
+    pub(crate) fn copy_within(&self, src: std::ops::Range<usize>, dst: usize) {
+        let mut buf = self.buffer.borrow_mut();
+        buf.copy_within(src, dst);
+    }
+
+    /// Set a flag on a range of 4-byte PDE entries within a PD.
+    /// `pd_offset` is the byte offset to the PD page in the buffer.
+    /// `pde_range` is the range of PDE indices to modify.
+    #[cfg(feature = "i686-guest")]
+    pub(crate) fn set_pde_flag(
+        &self,
+        pd_offset: usize,
+        pde_range: std::ops::Range<usize>,
+        flag: u32,
+    ) {
+        let mut buf = self.buffer.borrow_mut();
+        for pdi in pde_range {
+            let off = pd_offset + pdi * 4;
+            if let Some(bytes) = buf.get(off..off + 4) {
+                let pde = u32::from_le_bytes(bytes.try_into().unwrap_or([0; 4]));
+                if pde != 0 {
+                    let updated = pde | flag;
+                    buf[off..off + 4].copy_from_slice(&updated.to_le_bytes());
+                }
+            }
+        }
+    }
+
+    /// Finalize multi-root i686 page directories after all per-root
+    /// mappings have been written into root 0 (kernel) and per-root
+    /// PDs (user).
+    ///
+    /// This performs three steps:
+    /// 1. Copy kernel PDEs (0..`user_pde_start`) from root 0 to all
+    ///    other roots so every PD shares the same kernel page tables.
+    /// 2. Map the scratch region into every additional root.
+    /// 3. Set `PAGE_USER` on user-space PDEs (`user_pde_start`..scratch)
+    ///    in all roots so user-mode code can access its pages.
+    ///
+    /// # Safety
+    /// Caller must ensure the scratch parameters describe a valid region.
+    #[cfg(feature = "i686-guest")]
+    pub(crate) unsafe fn finalize_multi_root(
+        &self,
+        n_roots: usize,
+        user_pde_start: usize,
+        scratch_gpa: u64,
+        scratch_gva: u64,
+        scratch_len: u64,
+    ) {
+        use hyperlight_common::vmem::i686_guest::PAGE_USER;
+        use hyperlight_common::vmem::{BasicMapping, MappingKind};
+
+        // Step 1: copy kernel PDEs from root 0 to all other roots.
+        let kernel_pde_bytes = user_pde_start * 4;
+        for i in 1..n_roots {
+            self.copy_within(0..kernel_pde_bytes, i * PAGE_TABLE_SIZE);
+        }
+
+        // Step 2: map scratch into all other roots.
+        for i in 1..n_roots {
+            self.set_root_offset(i * PAGE_TABLE_SIZE);
+            unsafe {
+                hyperlight_common::vmem::i686_guest::map(
+                    self,
+                    vmem::Mapping {
+                        phys_base: scratch_gpa,
+                        virt_base: scratch_gva,
+                        len: scratch_len,
+                        kind: MappingKind::Basic(BasicMapping {
+                            readable: true,
+                            writable: true,
+                            executable: false,
+                        }),
+                    },
+                );
+            }
+        }
+
+        // Step 3: set PAGE_USER on user-space PDEs.
+        let scratch_pdi = (scratch_gva >> 22) as usize;
+        let page_user = PAGE_USER as u32;
+        for root_idx in 0..n_roots {
+            self.set_pde_flag(
+                root_idx * PAGE_TABLE_SIZE,
+                user_pde_start..scratch_pdi,
+                page_user,
+            );
+        }
+    }
     #[cfg(test)]
     #[allow(dead_code)]
     pub(crate) fn size(&self) -> usize {
@@ -530,55 +647,24 @@ impl SandboxMemoryManager<HostSharedMemory> {
         };
         self.layout = *snapshot.layout();
         self.update_scratch_bookkeeping()?;
-        // i686 snapshots store PT bytes separately (not appended to shared_mem)
-        // to avoid overlapping with map_file_cow regions.
-        // x86_64 snapshots have PTs appended to shared_mem.
+        // On x86_64, PTs are appended to the snapshot shared_mem and
+        // copy_pt_to_scratch reads them from the tail.
+        //
+        // On i686, PTs are stored separately because appending them
+        // to shared_mem would grow the snapshot region's GPA range,
+        // potentially overlapping with map_file_cow regions (e.g.
+        // RAMFS) that were placed at GPAs just above the original
+        // snapshot end. The KVM memory slots would conflict.
         #[cfg(feature = "i686-guest")]
         {
             let sep_pt = snapshot.separate_pt_bytes();
             self.scratch_mem.with_exclusivity(|scratch| {
                 scratch.copy_from_slice(sep_pt, self.layout.get_pt_base_scratch_offset())
             })??;
-            // Rewrite the PD-roots bookkeeping. `restore_snapshot`
-            // clears scratch above, so without this step a later
-            // `snapshot()` would read count=0 and fail. Root `i`
-            // lands at `pt_base_gpa + i * PAGE_SIZE` — the same
-            // layout `compact_i686_snapshot` used when building the
-            // rebuilt PDs.
-            self.update_pd_roots_bookkeeping(snapshot.n_pd_roots())?;
         }
         #[cfg(not(feature = "i686-guest"))]
         self.copy_pt_to_scratch()?;
         Ok((gsnapshot, gscratch))
-    }
-
-    /// Write the PD-roots count and compacted root GPAs into the
-    /// scratch bookkeeping area. Called from `restore_snapshot` on
-    /// the i686-guest path so the scratch state mirrors what it
-    /// looked like right after the snapshot was taken.
-    #[cfg(feature = "i686-guest")]
-    fn update_pd_roots_bookkeeping(&mut self, n_roots: usize) -> Result<()> {
-        use hyperlight_common::layout::{
-            MAX_PD_ROOTS, SCRATCH_TOP_PD_ROOTS_ARRAY_OFFSET, SCRATCH_TOP_PD_ROOTS_COUNT_OFFSET,
-        };
-        if n_roots > MAX_PD_ROOTS {
-            return Err(crate::new_error!(
-                "snapshot has {} PD roots, more than MAX_PD_ROOTS={}",
-                n_roots,
-                MAX_PD_ROOTS
-            ));
-        }
-        let scratch_size = self.scratch_mem.mem_size();
-        let count_off = scratch_size - SCRATCH_TOP_PD_ROOTS_COUNT_OFFSET as usize;
-        let array_off = scratch_size - SCRATCH_TOP_PD_ROOTS_ARRAY_OFFSET as usize;
-        self.scratch_mem.write::<u32>(count_off, n_roots as u32)?;
-        let pt_base = self.layout.get_pt_base_gpa();
-        for i in 0..n_roots {
-            let gpa = pt_base + (i as u64) * 4096;
-            self.scratch_mem
-                .write::<u32>(array_off + i * 4, gpa as u32)?;
-        }
-        Ok(())
     }
 
     #[inline]

--- a/src/hyperlight_host/src/mem/mgr.rs
+++ b/src/hyperlight_host/src/mem/mgr.rs
@@ -23,7 +23,7 @@ use hyperlight_common::flatbuffer_wrappers::function_call::{
 use hyperlight_common::flatbuffer_wrappers::function_types::FunctionCallResult;
 use hyperlight_common::flatbuffer_wrappers::guest_log_data::GuestLogData;
 use hyperlight_common::vmem::{self, PAGE_TABLE_SIZE, PageTableEntry, PhysAddr};
-#[cfg(all(feature = "crashdump", not(feature = "nanvix-unstable")))]
+#[cfg(all(feature = "crashdump", not(feature = "i686-guest")))]
 use hyperlight_common::vmem::{BasicMapping, MappingKind};
 use tracing::{Span, instrument};
 
@@ -38,7 +38,7 @@ use crate::mem::memory_region::{CrashDumpRegion, MemoryRegionFlags, MemoryRegion
 use crate::sandbox::snapshot::{NextAction, Snapshot};
 use crate::{Result, new_error};
 
-#[cfg(all(feature = "crashdump", not(feature = "nanvix-unstable")))]
+#[cfg(all(feature = "crashdump", not(feature = "i686-guest")))]
 fn mapping_kind_to_flags(kind: &MappingKind) -> (MemoryRegionFlags, MemoryRegionType) {
     match kind {
         MappingKind::Basic(BasicMapping {
@@ -76,7 +76,7 @@ fn mapping_kind_to_flags(kind: &MappingKind) -> (MemoryRegionFlags, MemoryRegion
 /// in both guest and host address space and has the same flags.
 ///
 /// Returns `true` if the region was coalesced, `false` if a new region is needed.
-#[cfg(all(feature = "crashdump", not(feature = "nanvix-unstable")))]
+#[cfg(all(feature = "crashdump", not(feature = "i686-guest")))]
 fn try_coalesce_region(
     regions: &mut [CrashDumpRegion],
     virt_base: usize,
@@ -101,7 +101,7 @@ fn try_coalesce_region(
 // fact that the snapshot shared memory is `ReadonlySharedMemory`
 // normally, but there is (temporary) support for writable
 // `GuestSharedMemory` with `#[cfg(feature =
-// "nanvix-unstable")]`. Unfortunately, rustc gets annoyed about an
+// "i686-guest")]`. Unfortunately, rustc gets annoyed about an
 // unused type parameter, unless one goes to a little bit of effort to
 // trick it...
 mod unused_hack {
@@ -579,7 +579,7 @@ impl SandboxMemoryManager<HostSharedMemory> {
     ///
     /// By default, walks the guest page tables to discover
     /// GVA→GPA mappings and translates them to host-backed regions.
-    #[cfg(all(feature = "crashdump", not(feature = "nanvix-unstable")))]
+    #[cfg(all(feature = "crashdump", not(feature = "i686-guest")))]
     pub(crate) fn get_guest_memory_regions(
         &mut self,
         root_pt: u64,
@@ -641,7 +641,7 @@ impl SandboxMemoryManager<HostSharedMemory> {
     /// Without paging, GVA == GPA (identity mapped), so we return the
     /// snapshot and scratch regions directly at their known addresses
     /// alongside any dynamic mmap regions.
-    #[cfg(all(feature = "crashdump", feature = "nanvix-unstable"))]
+    #[cfg(all(feature = "crashdump", feature = "i686-guest"))]
     pub(crate) fn get_guest_memory_regions(
         &mut self,
         _root_pt: u64,
@@ -796,7 +796,7 @@ impl SandboxMemoryManager<HostSharedMemory> {
 }
 
 #[cfg(test)]
-#[cfg(all(not(feature = "nanvix-unstable"), target_arch = "x86_64"))]
+#[cfg(all(not(feature = "i686-guest"), target_arch = "x86_64"))]
 mod tests {
     use hyperlight_common::vmem::{MappingKind, PAGE_TABLE_SIZE};
     use hyperlight_testing::sandbox_sizes::{LARGE_HEAP_SIZE, MEDIUM_HEAP_SIZE, SMALL_HEAP_SIZE};

--- a/src/hyperlight_host/src/mem/mgr.rs
+++ b/src/hyperlight_host/src/mem/mgr.rs
@@ -157,16 +157,16 @@ pub(crate) struct SandboxMemoryManager<S: SharedMemory> {
 }
 
 /// Buffer for building guest page tables during snapshot creation.
-/// `PTE_BYTES` is the guest PTE size (8 for amd64, 4 for i686).
-/// `TableAddr` is a byte offset (GPA) so the same address space
-/// is used regardless of entry size.
+/// `TableAddr` is an absolute GPA (u64) so the same address space is
+/// used regardless of entry size.
 pub(crate) struct GuestPageTableBuffer {
     buffer: std::cell::RefCell<Vec<u8>>,
     phys_base: usize,
-    /// Byte offset from phys_base to the active root page table.
-    /// For multi-root guests, each root's PD starts at a different
-    /// offset in the buffer.
-    root_offset: std::cell::Cell<usize>,
+    /// Absolute GPA of the currently-active root table. For
+    /// multi-root guests, `set_root` switches which root subsequent
+    /// `vmem::map` / `vmem::space_aware_map` calls target — typically
+    /// to an address previously returned by `alloc_table`.
+    root: std::cell::Cell<u64>,
 }
 
 impl vmem::TableReadOps for GuestPageTableBuffer {
@@ -200,7 +200,7 @@ impl vmem::TableReadOps for GuestPageTableBuffer {
     }
 
     fn root_table(&self) -> u64 {
-        (self.phys_base + self.root_offset.get()) as u64
+        self.root.get()
     }
 }
 
@@ -236,18 +236,26 @@ impl core::convert::AsRef<GuestPageTableBuffer> for GuestPageTableBuffer {
 }
 
 impl GuestPageTableBuffer {
+    /// Create a new buffer with an initial zeroed root table at
+    /// `phys_base`. The returned buffer's current root is `phys_base`;
+    /// additional roots can be obtained by calling `alloc_table`.
     pub(crate) fn new(phys_base: usize) -> Self {
         GuestPageTableBuffer {
             buffer: std::cell::RefCell::new(vec![0u8; PAGE_TABLE_SIZE]),
             phys_base,
-            root_offset: std::cell::Cell::new(0),
+            root: std::cell::Cell::new(phys_base as u64),
         }
     }
 
-    /// Set the root offset to target a specific root page table.
-    /// Root i starts at byte offset `i * PAGE_TABLE_SIZE` in the buffer.
-    pub(crate) fn set_root_offset(&self, offset: usize) {
-        self.root_offset.set(offset);
+    /// Switch the active root. `addr` must have been obtained either
+    /// as the initial root GPA (`phys_base`) or via `alloc_table`.
+    pub(crate) fn set_root(&self, addr: u64) {
+        self.root.set(addr);
+    }
+
+    /// GPA of the initial root allocated by `new`.
+    pub(crate) fn initial_root(&self) -> u64 {
+        self.phys_base as u64
     }
 
     #[cfg(test)]

--- a/src/hyperlight_host/src/mem/mgr.rs
+++ b/src/hyperlight_host/src/mem/mgr.rs
@@ -157,9 +157,9 @@ pub(crate) struct SandboxMemoryManager<S: SharedMemory> {
 pub(crate) struct GuestPageTableBuffer {
     buffer: std::cell::RefCell<Vec<u8>>,
     phys_base: usize,
-    /// Byte offset from phys_base to the active PD root.
-    /// Used on i686 to target different per-process PDs.
-    #[cfg(feature = "i686-guest")]
+    /// Byte offset from phys_base to the active root page table.
+    /// For multi-root guests, each root's PD starts at a different
+    /// offset in the buffer.
     root_offset: std::cell::Cell<usize>,
 }
 
@@ -194,14 +194,7 @@ impl vmem::TableReadOps for GuestPageTableBuffer {
     }
 
     fn root_table(&self) -> u64 {
-        #[cfg(feature = "i686-guest")]
-        {
-            (self.phys_base + self.root_offset.get()) as u64
-        }
-        #[cfg(not(feature = "i686-guest"))]
-        {
-            self.phys_base as u64
-        }
+        (self.phys_base + self.root_offset.get()) as u64
     }
 }
 
@@ -241,76 +234,16 @@ impl GuestPageTableBuffer {
         GuestPageTableBuffer {
             buffer: std::cell::RefCell::new(vec![0u8; PAGE_TABLE_SIZE]),
             phys_base,
-            #[cfg(feature = "i686-guest")]
             root_offset: std::cell::Cell::new(0),
         }
     }
 
-    /// Set the root offset to target a specific PD root.
-    /// Root i's PD starts at byte offset `i * PAGE_TABLE_SIZE` in the buffer.
-    #[cfg(feature = "i686-guest")]
+    /// Set the root offset to target a specific root page table.
+    /// Root i starts at byte offset `i * PAGE_TABLE_SIZE` in the buffer.
     pub(crate) fn set_root_offset(&self, offset: usize) {
         self.root_offset.set(offset);
     }
 
-    /// Copy a range of bytes within the buffer.
-    #[cfg(feature = "i686-guest")]
-    pub(crate) fn copy_within(&self, src: std::ops::Range<usize>, dst: usize) {
-        let mut buf = self.buffer.borrow_mut();
-        buf.copy_within(src, dst);
-    }
-
-    /// Finalize multi-root i686 page directories after all per-root
-    /// mappings have been written into root 0 (kernel) and per-root
-    /// PDs (user).
-    ///
-    /// This performs three steps:
-    /// 1. Copy kernel PDEs (0..`user_pde_start`) from root 0 to all
-    ///    other roots so every PD shares the same kernel page tables.
-    /// 2. Map the scratch region into every additional root.
-    /// 3. Set `PAGE_USER` on user-space PDEs (`user_pde_start`..scratch)
-    ///    in all roots so user-mode code can access its pages.
-    ///
-    /// # Safety
-    /// Caller must ensure the scratch parameters describe a valid region.
-    #[cfg(feature = "i686-guest")]
-    pub(crate) unsafe fn finalize_multi_root(
-        &self,
-        n_roots: usize,
-        user_pde_start: usize,
-        scratch_gpa: u64,
-        scratch_gva: u64,
-        scratch_len: u64,
-    ) {
-        use hyperlight_common::vmem::{BasicMapping, MappingKind};
-
-        // Step 1: copy kernel PDEs from root 0 to all other roots.
-        let kernel_pde_bytes = user_pde_start * 4;
-        for i in 1..n_roots {
-            self.copy_within(0..kernel_pde_bytes, i * PAGE_TABLE_SIZE);
-        }
-
-        // Step 2: map scratch into all other roots.
-        for i in 1..n_roots {
-            self.set_root_offset(i * PAGE_TABLE_SIZE);
-            unsafe {
-                vmem::map(
-                    self,
-                    vmem::Mapping {
-                        phys_base: scratch_gpa,
-                        virt_base: scratch_gva,
-                        len: scratch_len,
-                        kind: MappingKind::Basic(BasicMapping {
-                            readable: true,
-                            writable: true,
-                            executable: false,
-                        }),
-                        user_accessible: false,
-                    },
-                );
-            }
-        }
-    }
     #[cfg(test)]
     #[allow(dead_code)]
     pub(crate) fn size(&self) -> usize {

--- a/src/hyperlight_host/src/mem/mgr.rs
+++ b/src/hyperlight_host/src/mem/mgr.rs
@@ -22,6 +22,7 @@ use hyperlight_common::flatbuffer_wrappers::function_call::{
 };
 use hyperlight_common::flatbuffer_wrappers::function_types::FunctionCallResult;
 use hyperlight_common::flatbuffer_wrappers::guest_log_data::GuestLogData;
+#[cfg(not(feature = "i686-guest"))]
 use hyperlight_common::vmem::{self, PAGE_TABLE_SIZE, PageTableEntry, PhysAddr};
 #[cfg(all(feature = "crashdump", not(feature = "i686-guest")))]
 use hyperlight_common::vmem::{BasicMapping, MappingKind};
@@ -150,11 +151,13 @@ pub(crate) struct SandboxMemoryManager<S: SharedMemory> {
     pub(crate) abort_buffer: Vec<u8>,
 }
 
+#[cfg(not(feature = "i686-guest"))]
 pub(crate) struct GuestPageTableBuffer {
     buffer: std::cell::RefCell<Vec<u8>>,
     phys_base: usize,
 }
 
+#[cfg(not(feature = "i686-guest"))]
 impl vmem::TableReadOps for GuestPageTableBuffer {
     type TableAddr = (usize, usize); // (table_index, entry_index)
 
@@ -189,6 +192,7 @@ impl vmem::TableReadOps for GuestPageTableBuffer {
         (self.phys_base / PAGE_TABLE_SIZE, 0)
     }
 }
+#[cfg(not(feature = "i686-guest"))]
 impl vmem::TableOps for GuestPageTableBuffer {
     type TableMovability = vmem::MayNotMoveTable;
 
@@ -219,6 +223,7 @@ impl vmem::TableOps for GuestPageTableBuffer {
     }
 }
 
+#[cfg(not(feature = "i686-guest"))]
 impl GuestPageTableBuffer {
     pub(crate) fn new(phys_base: usize) -> Self {
         GuestPageTableBuffer {
@@ -270,7 +275,7 @@ where
         &mut self,
         sandbox_id: u64,
         mapped_regions: Vec<MemoryRegion>,
-        root_pt_gpa: u64,
+        root_pt_gpas: &[u64],
         rsp_gva: u64,
         sregs: CommonSpecialRegisters,
         entrypoint: NextAction,
@@ -282,7 +287,7 @@ where
             self.layout,
             crate::mem::exe::LoadInfo::dummy(),
             mapped_regions,
-            root_pt_gpa,
+            root_pt_gpas,
             rsp_gva,
             sregs,
             entrypoint,
@@ -334,6 +339,7 @@ impl SandboxMemoryManager<ExclusiveSharedMemory> {
             abort_buffer: Vec::new(), // Guest doesn't need abort buffer
         };
         host_mgr.update_scratch_bookkeeping()?;
+        host_mgr.copy_pt_to_scratch()?;
         Ok((host_mgr, guest_mgr))
     }
 }
@@ -524,6 +530,18 @@ impl SandboxMemoryManager<HostSharedMemory> {
         };
         self.layout = *snapshot.layout();
         self.update_scratch_bookkeeping()?;
+        // i686 snapshots store PT bytes separately (not appended to shared_mem)
+        // to avoid overlapping with map_file_cow regions.
+        // x86_64 snapshots have PTs appended to shared_mem.
+        #[cfg(feature = "i686-guest")]
+        {
+            let sep_pt = snapshot.separate_pt_bytes();
+            self.scratch_mem.with_exclusivity(|scratch| {
+                scratch.copy_from_slice(sep_pt, self.layout.get_pt_base_scratch_offset())
+            })??;
+        }
+        #[cfg(not(feature = "i686-guest"))]
+        self.copy_pt_to_scratch()?;
         Ok((gsnapshot, gscratch))
     }
 
@@ -542,6 +560,10 @@ impl SandboxMemoryManager<HostSharedMemory> {
             SCRATCH_TOP_ALLOCATOR_OFFSET,
             self.layout.get_first_free_scratch_gpa(),
         )?;
+        self.update_scratch_bookkeeping_item(
+            SCRATCH_TOP_SNAPSHOT_PT_GPA_BASE_OFFSET,
+            self.layout.get_pt_base_gpa(),
+        )?;
 
         // Initialise the guest input and output data buffers in
         // scratch memory. TODO: remove the need for this.
@@ -554,7 +576,11 @@ impl SandboxMemoryManager<HostSharedMemory> {
             SandboxMemoryLayout::STACK_POINTER_SIZE_BYTES,
         )?;
 
-        // Copy the page tables into the scratch region
+        Ok(())
+    }
+
+    /// Copy page tables from shared_mem into the scratch region.
+    fn copy_pt_to_scratch(&mut self) -> Result<()> {
         let snapshot_pt_end = self.shared_mem.mem_size();
         let snapshot_pt_size = self.layout.get_pt_size();
         let snapshot_pt_start = snapshot_pt_end - snapshot_pt_size;
@@ -571,7 +597,6 @@ impl SandboxMemoryManager<HostSharedMemory> {
             #[allow(clippy::needless_borrow)]
             scratch.copy_from_slice(&bytes, self.layout.get_pt_base_scratch_offset())
         })??;
-
         Ok(())
     }
 

--- a/src/hyperlight_host/src/mem/mgr.rs
+++ b/src/hyperlight_host/src/mem/mgr.rs
@@ -569,6 +569,13 @@ impl SandboxMemoryManager<HostSharedMemory> {
             SCRATCH_TOP_ALLOCATOR_OFFSET,
             self.layout.get_first_free_scratch_gpa(),
         )?;
+        // Record the GPA of the snapshot's copy of the page tables.
+        // The copy lives at the tail of the snapshot blob (see
+        // `copy_pt_to_scratch` below). The guest reads this GPA
+        // during CoW fault-in to follow the original PTs on the first
+        // write — until the HV can execute directly out of the
+        // snapshot-resident PTs, at which point the whole split goes
+        // away.
         self.update_scratch_bookkeeping_item(
             SCRATCH_TOP_SNAPSHOT_PT_GPA_BASE_OFFSET,
             self.layout.get_pt_base_gpa(),
@@ -592,7 +599,17 @@ impl SandboxMemoryManager<HostSharedMemory> {
         Ok(())
     }
 
-    /// Copy page tables from shared_mem into the scratch region.
+    /// Copy page tables from `shared_mem` into the scratch region.
+    ///
+    /// PT bytes are appended to the snapshot blob at build time and
+    /// live just past the end of the guest-visible KVM slot (see
+    /// `Snapshot::new`). Keeping them outside the KVM slot avoids
+    /// overlapping with `map_file_cow` regions that the embedder
+    /// installs immediately after the snapshot in the guest PA space
+    /// — if we left the PT tail inside the slot, the first
+    /// `map_file_cow` page would sit on top of the last PT page. On
+    /// restore we copy the PT tail into scratch so the guest walker
+    /// can run against mutable, TLB-fresh tables.
     fn copy_pt_to_scratch(&mut self) -> Result<()> {
         let snapshot_pt_end = self.shared_mem.mem_size();
         let snapshot_pt_size = self.layout.get_pt_size();

--- a/src/hyperlight_host/src/mem/mgr.rs
+++ b/src/hyperlight_host/src/mem/mgr.rs
@@ -148,6 +148,9 @@ pub(crate) struct SandboxMemoryManager<S: SharedMemory> {
     pub(crate) mapped_rgns: u64,
     /// Buffer for accumulating guest abort messages
     pub(crate) abort_buffer: Vec<u8>,
+    /// Snapshot restore generation counter. 0 means no restore
+    /// and is incremented on each `restore_snapshot` call.
+    pub(crate) restore_count: u64,
 }
 
 /// Buffer for building guest page tables during snapshot creation.
@@ -274,6 +277,7 @@ where
             entrypoint,
             mapped_rgns: 0,
             abort_buffer: Vec::new(),
+            restore_count: 0,
         }
     }
 
@@ -341,6 +345,7 @@ impl SandboxMemoryManager<ExclusiveSharedMemory> {
             entrypoint: self.entrypoint,
             mapped_rgns: self.mapped_rgns,
             abort_buffer: self.abort_buffer,
+            restore_count: self.restore_count,
         };
         let guest_mgr = SandboxMemoryManager {
             shared_mem: gshm,
@@ -349,6 +354,7 @@ impl SandboxMemoryManager<ExclusiveSharedMemory> {
             entrypoint: self.entrypoint,
             mapped_rgns: self.mapped_rgns,
             abort_buffer: Vec::new(), // Guest doesn't need abort buffer
+            restore_count: self.restore_count,
         };
         host_mgr.update_scratch_bookkeeping()?;
         host_mgr.copy_pt_to_scratch()?;
@@ -541,6 +547,8 @@ impl SandboxMemoryManager<HostSharedMemory> {
             Some(gscratch)
         };
         self.layout = *snapshot.layout();
+        self.restore_count += 1;
+
         self.update_scratch_bookkeeping()?;
         self.copy_pt_to_scratch()?;
         Ok((gsnapshot, gscratch))
@@ -564,6 +572,10 @@ impl SandboxMemoryManager<HostSharedMemory> {
         self.update_scratch_bookkeeping_item(
             SCRATCH_TOP_SNAPSHOT_PT_GPA_BASE_OFFSET,
             self.layout.get_pt_base_gpa(),
+        )?;
+        self.update_scratch_bookkeeping_item(
+            SCRATCH_TOP_SNAPSHOT_GENERATION_OFFSET,
+            self.restore_count,
         )?;
 
         // Initialise the guest input and output data buffers in

--- a/src/hyperlight_host/src/mem/mgr.rs
+++ b/src/hyperlight_host/src/mem/mgr.rs
@@ -539,10 +539,46 @@ impl SandboxMemoryManager<HostSharedMemory> {
             self.scratch_mem.with_exclusivity(|scratch| {
                 scratch.copy_from_slice(sep_pt, self.layout.get_pt_base_scratch_offset())
             })??;
+            // Rewrite the PD-roots bookkeeping. `restore_snapshot`
+            // clears scratch above, so without this step a later
+            // `snapshot()` would read count=0 and fail. Root `i`
+            // lands at `pt_base_gpa + i * PAGE_SIZE` — the same
+            // layout `compact_i686_snapshot` used when building the
+            // rebuilt PDs.
+            self.update_pd_roots_bookkeeping(snapshot.n_pd_roots())?;
         }
         #[cfg(not(feature = "i686-guest"))]
         self.copy_pt_to_scratch()?;
         Ok((gsnapshot, gscratch))
+    }
+
+    /// Write the PD-roots count and compacted root GPAs into the
+    /// scratch bookkeeping area. Called from `restore_snapshot` on
+    /// the i686-guest path so the scratch state mirrors what it
+    /// looked like right after the snapshot was taken.
+    #[cfg(feature = "i686-guest")]
+    fn update_pd_roots_bookkeeping(&mut self, n_roots: usize) -> Result<()> {
+        use hyperlight_common::layout::{
+            MAX_PD_ROOTS, SCRATCH_TOP_PD_ROOTS_ARRAY_OFFSET, SCRATCH_TOP_PD_ROOTS_COUNT_OFFSET,
+        };
+        if n_roots > MAX_PD_ROOTS {
+            return Err(crate::new_error!(
+                "snapshot has {} PD roots, more than MAX_PD_ROOTS={}",
+                n_roots,
+                MAX_PD_ROOTS
+            ));
+        }
+        let scratch_size = self.scratch_mem.mem_size();
+        let count_off = scratch_size - SCRATCH_TOP_PD_ROOTS_COUNT_OFFSET as usize;
+        let array_off = scratch_size - SCRATCH_TOP_PD_ROOTS_ARRAY_OFFSET as usize;
+        self.scratch_mem.write::<u32>(count_off, n_roots as u32)?;
+        let pt_base = self.layout.get_pt_base_gpa();
+        for i in 0..n_roots {
+            let gpa = pt_base + (i as u64) * 4096;
+            self.scratch_mem
+                .write::<u32>(array_off + i * 4, gpa as u32)?;
+        }
+        Ok(())
     }
 
     #[inline]

--- a/src/hyperlight_host/src/mem/mgr.rs
+++ b/src/hyperlight_host/src/mem/mgr.rs
@@ -647,22 +647,6 @@ impl SandboxMemoryManager<HostSharedMemory> {
         };
         self.layout = *snapshot.layout();
         self.update_scratch_bookkeeping()?;
-        // On x86_64, PTs are appended to the snapshot shared_mem and
-        // copy_pt_to_scratch reads them from the tail.
-        //
-        // On i686, PTs are stored separately because appending them
-        // to shared_mem would grow the snapshot region's GPA range,
-        // potentially overlapping with map_file_cow regions (e.g.
-        // RAMFS) that were placed at GPAs just above the original
-        // snapshot end. The KVM memory slots would conflict.
-        #[cfg(feature = "i686-guest")]
-        {
-            let sep_pt = snapshot.separate_pt_bytes();
-            self.scratch_mem.with_exclusivity(|scratch| {
-                scratch.copy_from_slice(sep_pt, self.layout.get_pt_base_scratch_offset())
-            })??;
-        }
-        #[cfg(not(feature = "i686-guest"))]
         self.copy_pt_to_scratch()?;
         Ok((gsnapshot, gscratch))
     }

--- a/src/hyperlight_host/src/mem/shared_mem.rs
+++ b/src/hyperlight_host/src/mem/shared_mem.rs
@@ -668,7 +668,7 @@ impl ExclusiveSharedMemory {
     /// Create a [`HostSharedMemory`] view of this region without
     /// consuming `self`. Used in tests where the full `build()` /
     /// `evolve()` pipeline is not available.
-    #[cfg(all(test, feature = "nanvix-unstable"))]
+    #[cfg(all(test, feature = "guest-counter"))]
     pub(crate) fn as_host_shared_memory(&self) -> HostSharedMemory {
         let lock = Arc::new(RwLock::new(()));
         HostSharedMemory {

--- a/src/hyperlight_host/src/mem/shared_mem.rs
+++ b/src/hyperlight_host/src/mem/shared_mem.rs
@@ -681,14 +681,16 @@ impl ExclusiveSharedMemory {
 fn mapping_at(
     s: &impl SharedMemory,
     gpa: u64,
+    size: usize,
     region_type: MemoryRegionType,
     flags: MemoryRegionFlags,
 ) -> MemoryRegion {
     let guest_base = gpa as usize;
 
     MemoryRegion {
-        guest_region: guest_base..(guest_base + s.mem_size()),
-        host_region: s.host_region_base()..s.host_region_end(),
+        guest_region: guest_base..(guest_base + size),
+        host_region: s.host_region_base()
+            ..<HostGuestMemoryRegion as MemoryRegionKind>::add(s.host_region_base(), size),
         region_type,
         flags,
     }
@@ -723,7 +725,7 @@ impl GuestSharedMemory {
                 "GuestSharedMemory::mapping_at should only be used for Scratch or Snapshot regions"
             ),
         };
-        mapping_at(self, guest_base, region_type, flags)
+        mapping_at(self, guest_base, self.mem_size(), region_type, flags)
     }
 }
 
@@ -2006,6 +2008,10 @@ mod tests {
 #[derive(Clone, Debug)]
 pub struct ReadonlySharedMemory {
     region: Arc<HostMapping>,
+    /// If `Some`, only this many bytes are mapped into guest PA space
+    /// by `mapping_at`. If `None`, the full `mem_size()` is mapped.
+    #[cfg_attr(unshared_snapshot_mem, allow(dead_code))]
+    guest_mapped_size: Option<usize>,
 }
 // Safety: HostMapping is only non-Send/Sync (causing
 // ReadonlySharedMemory to not be automatically Send/Sync) because raw
@@ -2026,7 +2032,27 @@ impl ReadonlySharedMemory {
         anon.copy_from_slice(contents, 0)?;
         Ok(ReadonlySharedMemory {
             region: anon.region,
+            guest_mapped_size: None,
         })
+    }
+
+    pub(crate) fn from_bytes_with_mapped_size(
+        contents: &[u8],
+        guest_mapped_size: usize,
+    ) -> Result<Self> {
+        let mut anon = ExclusiveSharedMemory::new(contents.len())?;
+        anon.copy_from_slice(contents, 0)?;
+        Ok(ReadonlySharedMemory {
+            region: anon.region,
+            guest_mapped_size: Some(guest_mapped_size),
+        })
+    }
+
+    /// The number of bytes that should be mapped into guest PA space.
+    /// Returns `guest_mapped_size` if set, otherwise `mem_size()`.
+    #[cfg(not(unshared_snapshot_mem))]
+    pub(crate) fn guest_mapped_size(&self) -> usize {
+        self.guest_mapped_size.unwrap_or_else(|| self.mem_size())
     }
 
     pub(crate) fn as_slice(&self) -> &[u8] {
@@ -2061,6 +2087,7 @@ impl ReadonlySharedMemory {
         mapping_at(
             self,
             guest_base,
+            self.guest_mapped_size(),
             region_type,
             MemoryRegionFlags::READ | MemoryRegionFlags::EXECUTE,
         )

--- a/src/hyperlight_host/src/sandbox/initialized_multi_use.rs
+++ b/src/hyperlight_host/src/sandbox/initialized_multi_use.rs
@@ -94,7 +94,22 @@ pub struct MultiUseSandbox {
     /// If the current state of the sandbox has been captured in a snapshot,
     /// that snapshot is stored here.
     snapshot: Option<Arc<Snapshot>>,
+    /// Optional callback to discover page table roots from guest memory.
+    /// Given (snapshot_mem, scratch_mem, cr3), returns a list of root GPAs.
+    /// If not set, only CR3 is used as the single root.
+    pt_root_finder: Option<PtRootFinder>,
 }
+
+/// Callback for discovering page table roots from guest memory.
+///
+/// Called during [`MultiUseSandbox::snapshot`] with:
+/// - `snapshot_mem` - the sandbox's snapshot (shared) memory as a byte slice
+/// - `scratch_mem` - the sandbox's scratch memory as a byte slice
+/// - `cr3` - the vCPU's CR3 register value (root page table GPA)
+///
+/// Returns a list of root page table GPAs to walk. If the list is
+/// empty, only `cr3` is used.
+pub type PtRootFinder = Box<dyn Fn(&[u8], &[u8], u64) -> Vec<u64> + Send>;
 
 impl MultiUseSandbox {
     /// Move an `UninitializedSandbox` into a new `MultiUseSandbox` instance.
@@ -118,7 +133,15 @@ impl MultiUseSandbox {
             #[cfg(gdb)]
             dbg_mem_access_fn,
             snapshot: None,
+            pt_root_finder: None,
         }
+    }
+
+    /// Set a callback that discovers page table roots from guest memory.
+    /// The callback receives (snapshot_mem, scratch_mem, cr3) and returns
+    /// the list of root GPAs to walk during snapshot creation.
+    pub fn set_pt_root_finder(&mut self, finder: PtRootFinder) {
+        self.pt_root_finder = Some(finder);
     }
 
     /// Creates a snapshot of the sandbox's current memory state.
@@ -160,15 +183,22 @@ impl MultiUseSandbox {
         }
         let mapped_regions_iter = self.vm.get_mapped_regions();
         let mapped_regions_vec: Vec<MemoryRegion> = mapped_regions_iter.cloned().collect();
-        // Discover page table roots. For i686 guests, read the PD roots
-        // table from scratch bookkeeping. For x86_64, just use CR3.
-        #[cfg(feature = "i686-guest")]
-        let root_pt_gpas = self.read_pd_roots_from_scratch()?;
-        #[cfg(not(feature = "i686-guest"))]
-        let root_pt_gpas = [self
+        // Get CR3 from the vCPU
+        let cr3 = self
             .vm
             .get_root_pt()
-            .map_err(|e| HyperlightError::HyperlightVmError(e.into()))?];
+            .map_err(|e| HyperlightError::HyperlightVmError(e.into()))?;
+        // Use the callback if set, otherwise just CR3
+        let root_pt_gpas = if let Some(finder) = &self.pt_root_finder {
+            let roots = self.mem_mgr.shared_mem.with_contents(|snap| {
+                self.mem_mgr
+                    .scratch_mem
+                    .with_contents(|scratch| finder(snap, scratch, cr3))
+            })??;
+            if roots.is_empty() { vec![cr3] } else { roots }
+        } else {
+            vec![cr3]
+        };
 
         let stack_top_gpa = self.vm.get_stack_top();
         let sregs = self
@@ -187,54 +217,6 @@ impl MultiUseSandbox {
         let snapshot = Arc::new(memory_snapshot);
         self.snapshot = Some(snapshot.clone());
         Ok(snapshot)
-    }
-
-    /// Reads the PD roots table from the scratch bookkeeping area.
-    /// Returns an error if the guest did not write valid PD roots
-    /// before signaling boot-complete.
-    #[cfg(feature = "i686-guest")]
-    fn read_pd_roots_from_scratch(&mut self) -> Result<Vec<u64>> {
-        use hyperlight_common::layout::{
-            MAX_PD_ROOTS, SCRATCH_TOP_PD_ROOTS_ARRAY_OFFSET, SCRATCH_TOP_PD_ROOTS_COUNT_OFFSET,
-        };
-
-        let scratch_size = self.mem_mgr.layout.get_scratch_size();
-        let count_off = scratch_size - SCRATCH_TOP_PD_ROOTS_COUNT_OFFSET as usize;
-        let array_off = scratch_size - SCRATCH_TOP_PD_ROOTS_ARRAY_OFFSET as usize;
-
-        self.mem_mgr.scratch_mem.with_contents(|scratch| {
-            let count = scratch
-                .get(count_off..count_off + 4)
-                .map(|b| u32::from_le_bytes([b[0], b[1], b[2], b[3]]))
-                .unwrap_or(0) as usize;
-
-            if count == 0 {
-                return Err(crate::new_error!(
-                    "i686 guest did not write PD roots to scratch bookkeeping (count=0)"
-                ));
-            }
-            if count > MAX_PD_ROOTS {
-                return Err(crate::new_error!(
-                    "i686 guest wrote invalid PD roots count: {} (max {})",
-                    count,
-                    MAX_PD_ROOTS
-                ));
-            }
-
-            let mut roots = Vec::with_capacity(count);
-            for i in 0..count {
-                let off = array_off + i * 4;
-                let b = scratch.get(off..off + 4).ok_or_else(|| {
-                    crate::new_error!("PD root {} at offset {} is out of scratch bounds", i, off)
-                })?;
-                let gpa = u32::from_le_bytes([b[0], b[1], b[2], b[3]]);
-                if gpa == 0 {
-                    return Err(crate::new_error!("PD root {} has GPA 0", i));
-                }
-                roots.push(gpa as u64);
-            }
-            Ok(roots)
-        })?
     }
 
     /// Restores the sandbox's memory to a previously captured snapshot state.

--- a/src/hyperlight_host/src/sandbox/initialized_multi_use.rs
+++ b/src/hyperlight_host/src/sandbox/initialized_multi_use.rs
@@ -105,10 +105,10 @@ pub struct MultiUseSandbox {
 /// Called during [`MultiUseSandbox::snapshot`] with:
 /// - `snapshot_mem` - the sandbox's snapshot (shared) memory as a byte slice
 /// - `scratch_mem` - the sandbox's scratch memory as a byte slice
-/// - `cr3` - the vCPU's CR3 register value (root page table GPA)
+/// - `root_pt_gpa` - the root page table GPA (from the vCPU's CR3)
 ///
 /// Returns a list of root page table GPAs to walk. If the list is
-/// empty, only `cr3` is used.
+/// empty, only `root_pt_gpa` is used.
 pub type PtRootFinder = Box<dyn Fn(&[u8], &[u8], u64) -> Vec<u64> + Send>;
 
 impl MultiUseSandbox {

--- a/src/hyperlight_host/src/sandbox/initialized_multi_use.rs
+++ b/src/hyperlight_host/src/sandbox/initialized_multi_use.rs
@@ -105,7 +105,8 @@ pub struct MultiUseSandbox {
 /// Called during [`MultiUseSandbox::snapshot`] with:
 /// - `snapshot_mem` - the sandbox's snapshot (shared) memory as a byte slice
 /// - `scratch_mem` - the sandbox's scratch memory as a byte slice
-/// - `root_pt_gpa` - the root page table GPA (from the vCPU's CR3)
+/// - `root_pt_gpa` - the root page table GPA of the currently-executing
+///   address space
 ///
 /// Returns a list of root page table GPAs to walk. If the list is
 /// empty, only `root_pt_gpa` is used.

--- a/src/hyperlight_host/src/sandbox/initialized_multi_use.rs
+++ b/src/hyperlight_host/src/sandbox/initialized_multi_use.rs
@@ -160,10 +160,16 @@ impl MultiUseSandbox {
         }
         let mapped_regions_iter = self.vm.get_mapped_regions();
         let mapped_regions_vec: Vec<MemoryRegion> = mapped_regions_iter.cloned().collect();
-        let root_pt_gpa = self
+        // Discover page table roots. For i686 guests, read the PD roots
+        // table from scratch bookkeeping. For x86_64, just use CR3.
+        #[cfg(feature = "i686-guest")]
+        let root_pt_gpas = self.read_pd_roots_from_scratch()?;
+        #[cfg(not(feature = "i686-guest"))]
+        let root_pt_gpas = [self
             .vm
             .get_root_pt()
-            .map_err(|e| HyperlightError::HyperlightVmError(e.into()))?;
+            .map_err(|e| HyperlightError::HyperlightVmError(e.into()))?];
+
         let stack_top_gpa = self.vm.get_stack_top();
         let sregs = self
             .vm
@@ -173,7 +179,7 @@ impl MultiUseSandbox {
         let memory_snapshot = self.mem_mgr.snapshot(
             self.id,
             mapped_regions_vec,
-            root_pt_gpa,
+            &root_pt_gpas,
             stack_top_gpa,
             sregs,
             entrypoint,
@@ -181,6 +187,54 @@ impl MultiUseSandbox {
         let snapshot = Arc::new(memory_snapshot);
         self.snapshot = Some(snapshot.clone());
         Ok(snapshot)
+    }
+
+    /// Reads the PD roots table from the scratch bookkeeping area.
+    /// Returns an error if the guest did not write valid PD roots
+    /// before signaling boot-complete.
+    #[cfg(feature = "i686-guest")]
+    fn read_pd_roots_from_scratch(&mut self) -> Result<Vec<u64>> {
+        use hyperlight_common::layout::{
+            MAX_PD_ROOTS, SCRATCH_TOP_PD_ROOTS_ARRAY_OFFSET, SCRATCH_TOP_PD_ROOTS_COUNT_OFFSET,
+        };
+
+        let scratch_size = self.mem_mgr.layout.get_scratch_size();
+        let count_off = scratch_size - SCRATCH_TOP_PD_ROOTS_COUNT_OFFSET as usize;
+        let array_off = scratch_size - SCRATCH_TOP_PD_ROOTS_ARRAY_OFFSET as usize;
+
+        self.mem_mgr.scratch_mem.with_contents(|scratch| {
+            let count = scratch
+                .get(count_off..count_off + 4)
+                .map(|b| u32::from_le_bytes([b[0], b[1], b[2], b[3]]))
+                .unwrap_or(0) as usize;
+
+            if count == 0 {
+                return Err(crate::new_error!(
+                    "i686 guest did not write PD roots to scratch bookkeeping (count=0)"
+                ));
+            }
+            if count > MAX_PD_ROOTS {
+                return Err(crate::new_error!(
+                    "i686 guest wrote invalid PD roots count: {} (max {})",
+                    count,
+                    MAX_PD_ROOTS
+                ));
+            }
+
+            let mut roots = Vec::with_capacity(count);
+            for i in 0..count {
+                let off = array_off + i * 4;
+                let b = scratch.get(off..off + 4).ok_or_else(|| {
+                    crate::new_error!("PD root {} at offset {} is out of scratch bounds", i, off)
+                })?;
+                let gpa = u32::from_le_bytes([b[0], b[1], b[2], b[3]]);
+                if gpa == 0 {
+                    return Err(crate::new_error!("PD root {} has GPA 0", i));
+                }
+                roots.push(gpa as u64);
+            }
+            Ok(roots)
+        })?
     }
 
     /// Restores the sandbox's memory to a previously captured snapshot state.

--- a/src/hyperlight_host/src/sandbox/mod.rs
+++ b/src/hyperlight_host/src/sandbox/mod.rs
@@ -46,7 +46,7 @@ pub use callable::Callable;
 /// Re-export for `SandboxConfiguration` type
 pub use config::SandboxConfiguration;
 /// Re-export for the `MultiUseSandbox` type
-pub use initialized_multi_use::MultiUseSandbox;
+pub use initialized_multi_use::{MultiUseSandbox, PtRootFinder};
 /// Re-export for `GuestBinary` type
 pub use uninitialized::GuestBinary;
 /// Re-export for `UninitializedSandbox` type

--- a/src/hyperlight_host/src/sandbox/snapshot.rs
+++ b/src/hyperlight_host/src/sandbox/snapshot.rs
@@ -314,12 +314,12 @@ fn build_cow_map(
     scratch: &[u8],
     layout: SandboxMemoryLayout,
     kernel_root: u64,
-) -> std::collections::HashMap<u64, u64> {
+) -> crate::Result<std::collections::HashMap<u64, u64>> {
     use hyperlight_common::layout::scratch_base_gpa;
     let mut cow_map = std::collections::HashMap::new();
     let scratch_base = scratch_base_gpa(layout.get_scratch_size());
     let scratch_end = scratch_base + layout.get_scratch_size() as u64;
-    let mem_size = layout.get_memory_size().unwrap_or(0) as u64;
+    let mem_size = layout.get_memory_size()? as u64;
 
     for pdi in 0..1024u64 {
         let pde_addr = kernel_root + pdi * 4;
@@ -347,7 +347,7 @@ fn build_cow_map(
             }
         }
     }
-    cow_map
+    Ok(cow_map)
 }
 
 /// Helper for building i686 2-level page tables as a flat byte buffer.
@@ -925,7 +925,7 @@ impl Snapshot {
                     let kernel_root = root_pt_gpas.first().copied().ok_or_else(|| {
                         crate::new_error!("snapshot requires at least one page directory root")
                     })?;
-                    build_cow_map(snap_c, scratch_c, layout, kernel_root)
+                    build_cow_map(snap_c, scratch_c, layout, kernel_root)?
                 };
 
                 // Pass 1: collect live pages
@@ -1201,5 +1201,343 @@ mod tests {
         mgr.shared_mem
             .with_contents(|contents| assert_eq!(&contents[0..pattern_b.len()], &pattern_b[..]))
             .unwrap();
+    }
+}
+
+#[cfg(test)]
+#[cfg(feature = "i686-guest")]
+mod tests {
+    use std::collections::HashMap;
+
+    use hyperlight_common::vmem::i686_guest::{PAGE_ACCESSED, PAGE_PRESENT, PAGE_RW};
+    use hyperlight_common::vmem::{BasicMapping, Mapping, MappingKind};
+
+    use super::i686_pt::{self, ADDR_MASK, PTE_COW, RW_FLAGS};
+    use crate::mem::layout::SandboxMemoryLayout;
+    use crate::mem::memory_region::{GuestMemoryRegion, MemoryRegionFlags};
+    use crate::sandbox::SandboxConfiguration;
+
+    const PAGE_SIZE: usize = 4096;
+
+    struct TestEnv {
+        layout: SandboxMemoryLayout,
+        snap: Vec<u8>,
+        scratch: Vec<u8>,
+        pt_base: u64,
+    }
+
+    fn make_env(pt_bytes: &[u8]) -> TestEnv {
+        let mut cfg = SandboxConfiguration::default();
+        cfg.set_heap_size(PAGE_SIZE as u64);
+        let layout = SandboxMemoryLayout::new(cfg, PAGE_SIZE, PAGE_SIZE, None).unwrap();
+        let scratch_size = layout.get_scratch_size();
+        let snapshot_size = layout.get_memory_size().unwrap();
+        let snap = vec![0u8; snapshot_size];
+        let mut scratch = vec![0u8; scratch_size];
+
+        let pt_scratch_offset = layout.get_pt_base_scratch_offset();
+        assert!(pt_scratch_offset + pt_bytes.len() <= scratch.len(),);
+
+        scratch[pt_scratch_offset..pt_scratch_offset + pt_bytes.len()].copy_from_slice(pt_bytes);
+
+        TestEnv {
+            snap,
+            scratch,
+            layout,
+            pt_base: layout.get_pt_base_gpa(),
+        }
+    }
+
+    /// Decode a PTE from raw page table bytes at the given VA.
+    fn read_pte(pt_bytes: &[u8], pt_base_gpa: usize, va: u64) -> u32 {
+        let pdi = ((va >> 22) & 0x3FF) as usize;
+        let pti = ((va >> 12) & 0x3FF) as usize;
+        let pde = u32::from_le_bytes(pt_bytes[pdi * 4..pdi * 4 + 4].try_into().unwrap());
+        assert_ne!(
+            pde & PAGE_PRESENT as u32,
+            0,
+            "PDE for VA {va:#x} not present"
+        );
+        let pt_offset = (pde & ADDR_MASK) as usize - pt_base_gpa;
+        u32::from_le_bytes(
+            pt_bytes[pt_offset + pti * 4..pt_offset + pti * 4 + 4]
+                .try_into()
+                .unwrap(),
+        )
+    }
+
+    #[test]
+    fn builder_map_page_writes_pde_and_pte() {
+        let pd_base = 0x10_0000;
+        let mut b = i686_pt::Builder::new(pd_base);
+        let va = 0x0040_0000u64; // PD index 1, PT index 0
+        let pa = 0x0020_0000u64;
+        b.map_page(0, va, pa, RW_FLAGS);
+
+        let pde = b.read_u32(4);
+        assert_ne!(pde & PAGE_PRESENT as u32, 0, "PDE should be present");
+        assert_eq!((pde & ADDR_MASK) as usize, pd_base + PAGE_SIZE);
+
+        let pte = b.read_u32(PAGE_SIZE); // PT index 0
+        assert_eq!(pte & ADDR_MASK, pa as u32);
+        assert_eq!(pte & 0xFFF, RW_FLAGS);
+
+        // Map a second page in the same 4MB region - PT must be reused
+        b.map_page(0, 0x0040_1000, 0x20_1000, RW_FLAGS);
+        assert_eq!(b.bytes.len(), 2 * PAGE_SIZE, "PT should be reused");
+        let pte1 = b.read_u32(PAGE_SIZE + 4);
+        assert_eq!(pte1 & ADDR_MASK, 0x20_1000);
+    }
+
+    #[test]
+    fn builder_map_range_crosses_pde_boundary() {
+        let pd_base = 0x10_0000;
+        let mut b = i686_pt::Builder::new(pd_base);
+        // Last page of PD[0] to first page of PD[1]
+        let va_start = 0x003F_F000u64;
+        let pa_start = 0x5_0000u64;
+        b.map_range(0, va_start, pa_start, 2 * PAGE_SIZE as u64, RW_FLAGS);
+
+        assert_eq!(b.bytes.len(), 3 * PAGE_SIZE, "should allocate 2 PTs");
+
+        // Verify PTE contents across the boundary
+        let pt0_offset = (b.read_u32(0) & ADDR_MASK) as usize - pd_base;
+        let pte_last = b.read_u32(pt0_offset + 0x3FF * 4); // last entry in PT[0]
+        assert_eq!(pte_last & ADDR_MASK, pa_start as u32);
+
+        let pt1_offset = (b.read_u32(4) & ADDR_MASK) as usize - pd_base;
+        let pte_first = b.read_u32(pt1_offset); // first entry in PT[1]
+        assert_eq!(pte_first & ADDR_MASK, (pa_start + PAGE_SIZE as u64) as u32);
+    }
+
+    #[test]
+    fn builder_cow_flags_preserved_pde_stays_rw() {
+        let pd_base = 0x10_0000;
+        let mut b = i686_pt::Builder::new(pd_base);
+        let cow_flags = PAGE_PRESENT as u32 | PAGE_ACCESSED as u32 | PTE_COW;
+        b.map_page(0, 0x1000, 0x2000, cow_flags);
+
+        let pti = ((0x1000u64 >> 12) & 0x3FF) as usize;
+        let pte = b.read_u32(PAGE_SIZE + pti * 4);
+        assert_ne!(pte & PTE_COW, 0, "CoW bit should be set on PTE");
+        assert_eq!(pte & PAGE_RW as u32, 0, "RW should be clear for CoW PTE");
+
+        // PDE must remain RW so the CPU can walk the PT
+        let pde = b.read_u32(0);
+        assert_ne!(
+            pde & PAGE_RW as u32,
+            0,
+            "PDE must stay RW even for CoW PTEs"
+        );
+    }
+
+    #[test]
+    fn builder_multiple_pds_independent() {
+        let pd_base = 0x10_0000;
+        let mut b = i686_pt::Builder::with_pds(pd_base, 2);
+        b.map_page(0, 0x1000, 0xA000, RW_FLAGS);
+        b.map_page(PAGE_SIZE, 0x1000, 0xB000, RW_FLAGS);
+
+        // PTs start after the 2 PD pages
+        let pde0 = b.read_u32(0);
+        let pde1 = b.read_u32(PAGE_SIZE);
+        assert_eq!(
+            (pde0 & ADDR_MASK) as usize,
+            pd_base + 2 * PAGE_SIZE,
+            "PD[0] PT should be at first slot after PDs"
+        );
+        assert_eq!(
+            (pde1 & ADDR_MASK) as usize,
+            pd_base + 3 * PAGE_SIZE,
+            "PD[1] PT should be at second slot after PDs"
+        );
+
+        // Verify the PTEs point to the correct PAs
+        let pti = ((0x1000u64 >> 12) & 0x3FF) as usize;
+        let pte0 = b.read_u32(2 * PAGE_SIZE + pti * 4);
+        let pte1 = b.read_u32(3 * PAGE_SIZE + pti * 4);
+        assert_eq!(pte0 & ADDR_MASK, 0xA000);
+        assert_eq!(pte1 & ADDR_MASK, 0xB000);
+    }
+
+    #[test]
+    fn cow_map_finds_scratch_backed_pages() {
+        let cfg = SandboxConfiguration::default();
+        let scratch_size = cfg.get_scratch_size();
+        let scratch_base = hyperlight_common::layout::scratch_base_gpa(scratch_size);
+        let layout = SandboxMemoryLayout::new(cfg, PAGE_SIZE, PAGE_SIZE, None).unwrap();
+        let pt_base = layout.get_pt_base_gpa() as usize;
+
+        let mut b = i686_pt::Builder::new(pt_base);
+        let cow_frame = scratch_base + 0x5000;
+        let cow_va = 0x1000u64;
+        b.map_page(0, cow_va, cow_frame, RW_FLAGS);
+
+        let TestEnv {
+            snap,
+            scratch,
+            layout,
+            pt_base,
+        } = make_env(&b.into_bytes());
+        let cow_map = super::build_cow_map(&snap, &scratch, layout, pt_base).unwrap();
+
+        assert_eq!(cow_map.len(), 1);
+        assert_eq!(cow_map[&cow_va], cow_frame);
+    }
+
+    #[test]
+    fn cow_map_filtering() {
+        let cfg = SandboxConfiguration::default();
+        let scratch_size = cfg.get_scratch_size();
+        let scratch_base = hyperlight_common::layout::scratch_base_gpa(scratch_size);
+        let layout = SandboxMemoryLayout::new(cfg, PAGE_SIZE, PAGE_SIZE, None).unwrap();
+        let pt_base = layout.get_pt_base_gpa() as usize;
+        let mem_size = layout.get_memory_size().unwrap();
+
+        let mut b = i686_pt::Builder::new(pt_base);
+        b.map_page(
+            0,
+            0x1000,
+            SandboxMemoryLayout::BASE_ADDRESS as u64,
+            RW_FLAGS,
+        );
+        let far_va = (mem_size as u64).next_multiple_of(0x0040_0000);
+        b.map_page(0, far_va, scratch_base + 0x1000, RW_FLAGS);
+
+        let TestEnv {
+            snap,
+            scratch,
+            layout,
+            pt_base,
+        } = make_env(&b.into_bytes());
+        let cow_map = super::build_cow_map(&snap, &scratch, layout, pt_base).unwrap();
+
+        assert!(
+            cow_map.is_empty(),
+            "neither non-scratch nor beyond-mem-size VAs should appear"
+        );
+    }
+
+    #[test]
+    fn cow_map_empty_pd() {
+        let cfg = SandboxConfiguration::default();
+        let layout = SandboxMemoryLayout::new(cfg, PAGE_SIZE, PAGE_SIZE, None).unwrap();
+        let pt_base = layout.get_pt_base_gpa() as usize;
+        let b = i686_pt::Builder::new(pt_base);
+
+        let TestEnv {
+            snap,
+            scratch,
+            layout,
+            pt_base,
+        } = make_env(&b.into_bytes());
+        let cow_map = super::build_cow_map(&snap, &scratch, layout, pt_base).unwrap();
+
+        assert!(cow_map.is_empty());
+    }
+
+    #[test]
+    fn initial_pt_scratch_rw_and_region_flags() {
+        let cfg = SandboxConfiguration::default();
+        let layout = SandboxMemoryLayout::new(cfg, PAGE_SIZE, PAGE_SIZE, None).unwrap();
+
+        let pt_bytes = super::build_initial_i686_page_tables(&layout).unwrap();
+        let pt_base = layout.get_pt_base_gpa() as usize;
+
+        // Scratch must be mapped as RW without CoW
+        let scratch_size = layout.get_scratch_size();
+        let scratch_gva = hyperlight_common::layout::scratch_base_gva(scratch_size);
+        let scratch_pte = read_pte(&pt_bytes, pt_base, scratch_gva);
+        assert_ne!(scratch_pte & PAGE_PRESENT as u32, 0);
+        assert_ne!(scratch_pte & PAGE_RW as u32, 0, "scratch must be writable");
+        assert_eq!(scratch_pte & PTE_COW, 0, "scratch must not be CoW");
+
+        // Verify region permissions: writable -> CoW, read-only -> no CoW
+        let regions = layout.get_memory_regions_::<GuestMemoryRegion>(()).unwrap();
+
+        for rgn in &regions {
+            let is_writable = rgn.flags.contains(MemoryRegionFlags::WRITE);
+            let va = rgn.guest_region.start as u64;
+            let pte = read_pte(&pt_bytes, pt_base, va);
+            assert_ne!(pte & PAGE_PRESENT as u32, 0);
+            if is_writable {
+                assert_ne!(pte & PTE_COW, 0, "writable region at {va:#x} should be CoW");
+                assert_eq!(pte & PAGE_RW as u32, 0, "CoW at {va:#x} must clear RW");
+            } else {
+                assert_eq!(pte & PTE_COW, 0, "RO region at {va:#x} must not be CoW");
+            }
+        }
+    }
+
+    #[test]
+    fn compact_deduplicates_shared_physical_pages() {
+        let shared_phys = 0x2000u64;
+        let page_data = vec![0xAAu8; PAGE_SIZE];
+
+        let make_mapping = |virt_base: u64| Mapping {
+            phys_base: shared_phys,
+            virt_base,
+            len: PAGE_SIZE as u64,
+            kind: MappingKind::Basic(BasicMapping {
+                readable: true,
+                writable: true,
+                executable: false,
+            }),
+        };
+
+        let TestEnv {
+            snap,
+            scratch,
+            layout,
+            pt_base,
+        } = make_env(&[0u8; PAGE_SIZE]);
+
+        let cow_map = HashMap::new();
+        let mut phys_seen = HashMap::new();
+
+        let live_pages: Vec<(Mapping, &[u8])> = vec![
+            (make_mapping(0x1000), &page_data),
+            (make_mapping(0x5000), &page_data),
+        ];
+
+        let (snapshot_mem, _pt_bytes) = super::compact_i686_snapshot(
+            &snap,
+            &scratch,
+            layout,
+            live_pages,
+            &[pt_base],
+            &cow_map,
+            &mut phys_seen,
+        )
+        .unwrap();
+
+        assert_eq!(
+            snapshot_mem.len(),
+            PAGE_SIZE,
+            "shared physical page should be deduplicated"
+        );
+    }
+
+    #[test]
+    fn compact_empty_roots_returns_error() {
+        let TestEnv {
+            snap,
+            scratch,
+            layout,
+            ..
+        } = make_env(&[0u8; PAGE_SIZE]);
+        let cow_map = HashMap::new();
+        let mut phys_seen = HashMap::new();
+
+        let result = super::compact_i686_snapshot(
+            &snap,
+            &scratch,
+            layout,
+            Vec::new(),
+            &[],
+            &cow_map,
+            &mut phys_seen,
+        );
+        assert!(result.is_err(), "empty root_pt_gpas should return an error");
     }
 }

--- a/src/hyperlight_host/src/sandbox/snapshot.rs
+++ b/src/hyperlight_host/src/sandbox/snapshot.rs
@@ -108,6 +108,13 @@ pub struct Snapshot {
 
     /// The next action that should be performed on this snapshot
     entrypoint: NextAction,
+
+    /// The generation number assigned to this snapshot when it was
+    /// taken — i.e. "this is the Nth snapshot taken from the sandbox's
+    /// execution path from init to here". Propagated into the
+    /// restored sandbox's guest-visible counter so the guest can tell
+    /// which snapshot it is currently a clone of.
+    snapshot_generation: u64,
 }
 impl core::convert::AsRef<Snapshot> for Snapshot {
     fn as_ref(&self) -> &Self {
@@ -415,6 +422,7 @@ impl Snapshot {
             stack_top_gva: exn_stack_top_gva,
             sregs: None,
             entrypoint: NextAction::Initialise(load_addr + entrypoint_va - base_va),
+            snapshot_generation: 0,
         })
     }
 
@@ -438,6 +446,7 @@ impl Snapshot {
         stack_top_gva: u64,
         sregs: CommonSpecialRegisters,
         entrypoint: NextAction,
+        snapshot_generation: u64,
     ) -> Result<Self> {
         let mut phys_seen = HashMap::<u64, usize>::new();
         let scratch_gva = scratch_base_gva(layout.get_scratch_size());
@@ -599,7 +608,13 @@ impl Snapshot {
             stack_top_gva,
             sregs: Some(sregs),
             entrypoint,
+            snapshot_generation,
         })
+    }
+
+    /// Generation number assigned to this snapshot when it was taken.
+    pub(crate) fn snapshot_generation(&self) -> u64 {
+        self.snapshot_generation
     }
 
     /// The id of the sandbox this snapshot was taken from.
@@ -730,6 +745,7 @@ mod tests {
             0,
             default_sregs(),
             super::NextAction::None,
+            1,
         )
         .unwrap();
 
@@ -746,6 +762,7 @@ mod tests {
             0,
             default_sregs(),
             super::NextAction::None,
+            2,
         )
         .unwrap();
 

--- a/src/hyperlight_host/src/sandbox/snapshot.rs
+++ b/src/hyperlight_host/src/sandbox/snapshot.rs
@@ -20,8 +20,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use hyperlight_common::layout::{scratch_base_gpa, scratch_base_gva};
 use hyperlight_common::vmem;
 use hyperlight_common::vmem::{
-    BasicMapping, CowMapping, Mapping, MappingKind, PAGE_SIZE, SpaceAwareMapping, SpaceId,
-    TableOps,
+    BasicMapping, CowMapping, Mapping, MappingKind, PAGE_SIZE, SpaceAwareMapping, SpaceId, TableOps,
 };
 use tracing::{Span, instrument};
 
@@ -495,7 +494,13 @@ impl Snapshot {
                                     continue;
                                 }
                                 let Some(contents) = (unsafe {
-                                    guest_page(snap_c, scratch_c, &regions, layout, mapping.phys_base)
+                                    guest_page(
+                                        snap_c,
+                                        scratch_c,
+                                        &regions,
+                                        layout,
+                                        mapping.phys_base,
+                                    )
                                 }) else {
                                     continue;
                                 };

--- a/src/hyperlight_host/src/sandbox/snapshot.rs
+++ b/src/hyperlight_host/src/sandbox/snapshot.rs
@@ -17,7 +17,6 @@ limitations under the License.
 use std::sync::atomic::{AtomicU64, Ordering};
 
 use hyperlight_common::layout::scratch_base_gva;
-#[cfg(not(feature = "i686-guest"))]
 use hyperlight_common::vmem;
 #[cfg(feature = "i686-guest")]
 use hyperlight_common::vmem::TableOps;
@@ -117,26 +116,23 @@ impl hyperlight_common::vmem::TableReadOps for Snapshot {
     fn entry_addr(addr: u64, offset: u64) -> u64 {
         addr + offset
     }
-    unsafe fn read_entry(&self, addr: u64) -> u64 {
+    unsafe fn read_entry(&self, addr: u64) -> vmem::PageTableEntry {
         let addr = addr as usize;
-        let Some(pte_bytes) = self.memory.as_slice().get(addr..addr + 8) else {
-            // Attacker-controlled data pointed out-of-bounds. We'll
-            // default to returning 0 in this case, which, for most
-            // architectures (including x86-64 and arm64, the ones we
-            // care about presently) will be a not-present entry.
+        let pte_size = core::mem::size_of::<vmem::PageTableEntry>();
+        let Some(pte_bytes) = self.memory.as_slice().get(addr..addr + pte_size) else {
             return 0;
         };
-        // this is statically the correct size, so using unwrap() here
-        // doesn't make this any more panic-y.
-        #[allow(clippy::unwrap_used)]
-        let n: [u8; 8] = pte_bytes.try_into().unwrap();
-        u64::from_ne_bytes(n)
+        let mut buf = [0u8; 8];
+        buf[..pte_size].copy_from_slice(pte_bytes);
+        vmem::PageTableEntry::from_le_bytes(buf[..pte_size].try_into().unwrap_or_default())
     }
-    fn to_phys(addr: u64) -> u64 {
-        addr
+    #[allow(clippy::unnecessary_cast)]
+    fn to_phys(addr: u64) -> vmem::PhysAddr {
+        addr as vmem::PhysAddr
     }
-    fn from_phys(addr: u64) -> u64 {
-        addr
+    #[allow(clippy::unnecessary_cast)]
+    fn from_phys(addr: vmem::PhysAddr) -> u64 {
+        addr as u64
     }
     fn root_table(&self) -> u64 {
         self.root_pt_gpa()
@@ -227,7 +223,7 @@ impl<'a> hyperlight_common::vmem::TableReadOps for SharedMemoryPageTableBuffer<'
     fn entry_addr(addr: u64, offset: u64) -> u64 {
         addr + offset
     }
-    unsafe fn read_entry(&self, addr: u64) -> u64 {
+    unsafe fn read_entry(&self, addr: u64) -> vmem::PageTableEntry {
         // For i686: if the GPA was CoW'd, read from the scratch copy instead.
         #[cfg(feature = "i686-guest")]
         let addr = {
@@ -243,41 +239,21 @@ impl<'a> hyperlight_common::vmem::TableReadOps for SharedMemoryPageTableBuffer<'
             }
         };
         let memoff = access_gpa(self.snap, self.scratch, self.layout, addr);
-        // For i686 guests, page table entries are 4 bytes; for x86_64 they
-        // are 8 bytes. Read the correct size based on the feature flag.
-        #[cfg(feature = "i686-guest")]
-        {
-            let Some(pte_bytes) = memoff.and_then(|(mem, off)| mem.get(off..off + 4)) else {
-                // Out-of-bounds: return 0, which is a not-present entry.
-                return 0;
-            };
-            #[allow(clippy::unwrap_used)]
-            let n: [u8; 4] = pte_bytes.try_into().unwrap();
-            // Page-table entries are little-endian by arch spec;
-            // use `from_le_bytes` so host endianness doesn't leak in.
-            u32::from_le_bytes(n) as u64
-        }
-        #[cfg(not(feature = "i686-guest"))]
-        {
-            let Some(pte_bytes) = memoff.and_then(|(mem, off)| mem.get(off..off + 8)) else {
-                // Attacker-controlled data pointed out-of-bounds. We'll
-                // default to returning 0 in this case, which, for most
-                // architectures (including x86-64 and arm64, the ones we
-                // care about presently) will be a not-present entry.
-                return 0;
-            };
-            // this is statically the correct size, so using unwrap() here
-            // doesn't make this any more panic-y.
-            #[allow(clippy::unwrap_used)]
-            let n: [u8; 8] = pte_bytes.try_into().unwrap();
-            u64::from_ne_bytes(n)
-        }
+        let pte_size = core::mem::size_of::<vmem::PageTableEntry>();
+        let Some(pte_bytes) = memoff.and_then(|(mem, off)| mem.get(off..off + pte_size)) else {
+            return 0;
+        };
+        let mut buf = [0u8; 8];
+        buf[..pte_size].copy_from_slice(pte_bytes);
+        vmem::PageTableEntry::from_le_bytes(buf[..pte_size].try_into().unwrap_or_default())
     }
-    fn to_phys(addr: u64) -> u64 {
-        addr
+    #[allow(clippy::unnecessary_cast)]
+    fn to_phys(addr: u64) -> vmem::PhysAddr {
+        addr as vmem::PhysAddr
     }
-    fn from_phys(addr: u64) -> u64 {
-        addr
+    #[allow(clippy::unnecessary_cast)]
+    fn from_phys(addr: vmem::PhysAddr) -> u64 {
+        addr as u64
     }
     fn root_table(&self) -> u64 {
         self.root
@@ -306,13 +282,7 @@ fn build_cow_map(
     let mem_size = layout.get_memory_size()? as u64;
 
     let op = SharedMemoryPageTableBuffer::new(snap, scratch, layout, kernel_root);
-    let mappings = unsafe {
-        hyperlight_common::vmem::i686_guest::virt_to_phys(
-            &op,
-            0,
-            hyperlight_common::layout::MAX_GVA as u64,
-        )
-    };
+    let mappings = unsafe { vmem::virt_to_phys(&op, 0, hyperlight_common::layout::MAX_GVA as u64) };
     for m in mappings {
         if m.virt_base < mem_size && m.phys_base >= scratch_base && m.phys_base < scratch_end {
             cow_map.insert(m.virt_base, m.phys_base);
@@ -369,18 +339,7 @@ fn filtered_mappings<'a>(
         #[cfg(not(feature = "i686-guest"))]
         let op = SharedMemoryPageTableBuffer::new(snap, scratch, layout, root_pt);
 
-        #[cfg(not(feature = "i686-guest"))]
-        let iter = unsafe {
-            hyperlight_common::vmem::virt_to_phys(&op, 0, hyperlight_common::layout::MAX_GVA as u64)
-        };
-        #[cfg(feature = "i686-guest")]
-        let iter = unsafe {
-            hyperlight_common::vmem::i686_guest::virt_to_phys(
-                &op,
-                0,
-                hyperlight_common::layout::MAX_GVA as u64,
-            )
-        };
+        let iter = unsafe { vmem::virt_to_phys(&op, 0, hyperlight_common::layout::MAX_GVA as u64) };
 
         for m in iter {
             if m.virt_base >= scratch_gva {
@@ -502,19 +461,13 @@ impl Snapshot {
         blob.map(|x| layout.write_init_data(&mut memory, x.data))
             .transpose()?;
 
-        #[cfg(not(feature = "i686-guest"))]
-        use hyperlight_common::vmem;
-
         {
             use hyperlight_common::layout::scratch_base_gpa;
 
             use crate::mem::memory_region::{GuestMemoryRegion, MemoryRegionFlags};
             use crate::mem::mgr::GuestPageTableBuffer;
 
-            #[cfg(not(feature = "i686-guest"))]
-            let pt_buf = GuestPageTableBuffer::<8>::new(layout.get_pt_base_gpa() as usize);
-            #[cfg(feature = "i686-guest")]
-            let pt_buf = GuestPageTableBuffer::<4>::new(layout.get_pt_base_gpa() as usize);
+            let pt_buf = GuestPageTableBuffer::new(layout.get_pt_base_gpa() as usize);
 
             // Map snapshot memory regions (writable -> CoW, read-only -> Basic)
             for rgn in layout.get_memory_regions_::<GuestMemoryRegion>(())?.iter() {
@@ -538,12 +491,10 @@ impl Snapshot {
                     virt_base: rgn.guest_region.start as u64,
                     len: rgn.guest_region.len() as u64,
                     kind,
+                    user_accessible: false,
                 };
                 unsafe {
-                    #[cfg(not(feature = "i686-guest"))]
                     vmem::map(&pt_buf, mapping);
-                    #[cfg(feature = "i686-guest")]
-                    hyperlight_common::vmem::i686_guest::map(&pt_buf, mapping);
                 }
             }
 
@@ -557,12 +508,10 @@ impl Snapshot {
                     writable: true,
                     executable: false,
                 }),
+                user_accessible: false,
             };
             unsafe {
-                #[cfg(not(feature = "i686-guest"))]
                 vmem::map(&pt_buf, scratch_mapping);
-                #[cfg(feature = "i686-guest")]
-                hyperlight_common::vmem::i686_guest::map(&pt_buf, scratch_mapping);
             }
 
             let pt_bytes = pt_buf.into_bytes();
@@ -643,16 +592,11 @@ impl Snapshot {
                 // and build new page tables with compacted GPAs.
                 // TODO: Look for opportunities to hugepage map
                 let mut snapshot_memory: Vec<u8> = Vec::new();
-                #[cfg(not(feature = "i686-guest"))]
-                let pt_buf = GuestPageTableBuffer::<8>::new(layout.get_pt_base_gpa() as usize);
+                let pt_buf = GuestPageTableBuffer::new(layout.get_pt_base_gpa() as usize);
                 #[cfg(feature = "i686-guest")]
-                let pt_buf = {
-                    let buf = GuestPageTableBuffer::<4>::new(layout.get_pt_base_gpa() as usize);
-                    for _ in 1..root_pt_gpas.len() {
-                        unsafe { buf.alloc_table() };
-                    }
-                    buf
-                };
+                for _ in 1..root_pt_gpas.len() {
+                    unsafe { pt_buf.alloc_table() };
+                }
 
                 for (_root_idx, mapping, contents) in live_pages {
                     let kind = compaction_kind(&mapping.kind);
@@ -673,12 +617,10 @@ impl Snapshot {
                         virt_base: mapping.virt_base,
                         len: PAGE_SIZE as u64,
                         kind,
+                        user_accessible: mapping.user_accessible,
                     };
                     unsafe {
-                        #[cfg(not(feature = "i686-guest"))]
                         vmem::map(&pt_buf, new_mapping);
-                        #[cfg(feature = "i686-guest")]
-                        hyperlight_common::vmem::i686_guest::map(&pt_buf, new_mapping);
                     }
                 }
                 #[cfg(feature = "i686-guest")]
@@ -690,7 +632,6 @@ impl Snapshot {
                 let scratch_gva = scratch_base_gva(layout.get_scratch_size());
                 let scratch_len = layout.get_scratch_size() as u64;
                 unsafe {
-                    #[cfg(not(feature = "i686-guest"))]
                     vmem::map(
                         &pt_buf,
                         Mapping {
@@ -702,20 +643,7 @@ impl Snapshot {
                                 writable: true,
                                 executable: false,
                             }),
-                        },
-                    );
-                    #[cfg(feature = "i686-guest")]
-                    hyperlight_common::vmem::i686_guest::map(
-                        &pt_buf,
-                        Mapping {
-                            phys_base: scratch_gpa,
-                            virt_base: scratch_gva,
-                            len: scratch_len,
-                            kind: MappingKind::Basic(BasicMapping {
-                                readable: true,
-                                writable: true,
-                                executable: false,
-                            }),
+                            user_accessible: false,
                         },
                     );
                 }
@@ -752,8 +680,7 @@ impl Snapshot {
         let regions = Vec::new();
 
         let hash = hash(&memory, &regions)?;
-        let rom =
-            ReadonlySharedMemory::from_bytes_with_mapped_size(&memory, guest_visible_size)?;
+        let rom = ReadonlySharedMemory::from_bytes_with_mapped_size(&memory, guest_visible_size)?;
         Ok(Self {
             sandbox_id,
             layout,
@@ -840,7 +767,7 @@ mod tests {
     const SIMPLE_PT_BASE: usize = PAGE_SIZE + SandboxMemoryLayout::BASE_ADDRESS;
 
     fn make_simple_pt_mem(contents: &[u8]) -> SnapshotSharedMemory<ExclusiveSharedMemory> {
-        let pt_buf = GuestPageTableBuffer::<8>::new(SIMPLE_PT_BASE);
+        let pt_buf = GuestPageTableBuffer::new(SIMPLE_PT_BASE);
         let mapping = Mapping {
             phys_base: SandboxMemoryLayout::BASE_ADDRESS as u64,
             virt_base: SandboxMemoryLayout::BASE_ADDRESS as u64,
@@ -850,6 +777,7 @@ mod tests {
                 writable: true,
                 executable: true,
             }),
+            user_accessible: false,
         };
         unsafe { vmem::map(&pt_buf, mapping) };
         // Map the scratch region
@@ -862,6 +790,7 @@ mod tests {
                 writable: true,
                 executable: false,
             }),
+            user_accessible: false,
         };
         unsafe { vmem::map(&pt_buf, scratch_mapping) };
         let pt_bytes = pt_buf.into_bytes();
@@ -942,7 +871,7 @@ mod tests {
 #[cfg(feature = "i686-guest")]
 mod i686_tests {
     use hyperlight_common::vmem::{
-        BasicMapping, CowMapping, Mapping, MappingKind, PAGE_SIZE, i686_guest,
+        self, BasicMapping, CowMapping, Mapping, MappingKind, PAGE_SIZE,
     };
 
     use crate::mem::mgr::GuestPageTableBuffer;
@@ -951,7 +880,7 @@ mod i686_tests {
 
     #[test]
     fn map_single_page() {
-        let pt = GuestPageTableBuffer::<4>::new(PT_BASE);
+        let pt = GuestPageTableBuffer::new(PT_BASE);
         let mapping = Mapping {
             phys_base: 0x2000,
             virt_base: 0x1000,
@@ -961,11 +890,12 @@ mod i686_tests {
                 writable: true,
                 executable: true,
             }),
+            user_accessible: false,
         };
-        unsafe { i686_guest::map(&pt, mapping) };
+        unsafe { vmem::map(&pt, mapping) };
 
         let results: Vec<_> =
-            unsafe { i686_guest::virt_to_phys(&pt, 0x1000, PAGE_SIZE as u64) }.collect();
+            unsafe { vmem::virt_to_phys(&pt, 0x1000, PAGE_SIZE as u64) }.collect();
         assert_eq!(results.len(), 1);
         assert_eq!(results[0].phys_base, 0x2000);
         assert_eq!(results[0].virt_base, 0x1000);
@@ -977,7 +907,7 @@ mod i686_tests {
 
     #[test]
     fn map_cow_page() {
-        let pt = GuestPageTableBuffer::<4>::new(PT_BASE);
+        let pt = GuestPageTableBuffer::new(PT_BASE);
         let mapping = Mapping {
             phys_base: 0x3000,
             virt_base: 0x2000,
@@ -986,11 +916,12 @@ mod i686_tests {
                 readable: true,
                 executable: true,
             }),
+            user_accessible: false,
         };
-        unsafe { i686_guest::map(&pt, mapping) };
+        unsafe { vmem::map(&pt, mapping) };
 
         let results: Vec<_> =
-            unsafe { i686_guest::virt_to_phys(&pt, 0x2000, PAGE_SIZE as u64) }.collect();
+            unsafe { vmem::virt_to_phys(&pt, 0x2000, PAGE_SIZE as u64) }.collect();
         assert_eq!(results.len(), 1);
         assert_eq!(results[0].phys_base, 0x3000);
         assert!(matches!(results[0].kind, MappingKind::Cow(_)));
@@ -998,7 +929,7 @@ mod i686_tests {
 
     #[test]
     fn map_multiple_pages_across_pd_boundary() {
-        let pt = GuestPageTableBuffer::<4>::new(PT_BASE);
+        let pt = GuestPageTableBuffer::new(PT_BASE);
         // Map pages spanning a 4MB PD boundary (PD[0] -> PD[1])
         let va_start = 0x003F_F000u64; // last page of PD[0]
         let pa_start = 0x5000u64;
@@ -1011,11 +942,12 @@ mod i686_tests {
                 writable: false,
                 executable: true,
             }),
+            user_accessible: false,
         };
-        unsafe { i686_guest::map(&pt, mapping) };
+        unsafe { vmem::map(&pt, mapping) };
 
         let results: Vec<_> =
-            unsafe { i686_guest::virt_to_phys(&pt, va_start, 2 * PAGE_SIZE as u64) }.collect();
+            unsafe { vmem::virt_to_phys(&pt, va_start, 2 * PAGE_SIZE as u64) }.collect();
         assert_eq!(results.len(), 2);
         assert_eq!(results[0].phys_base, pa_start);
         assert_eq!(results[0].virt_base, va_start);
@@ -1025,18 +957,18 @@ mod i686_tests {
 
     #[test]
     fn virt_to_phys_unmapped_returns_empty() {
-        let pt = GuestPageTableBuffer::<4>::new(PT_BASE);
+        let pt = GuestPageTableBuffer::new(PT_BASE);
         let results: Vec<_> =
-            unsafe { i686_guest::virt_to_phys(&pt, 0x1000, PAGE_SIZE as u64) }.collect();
+            unsafe { vmem::virt_to_phys(&pt, 0x1000, PAGE_SIZE as u64) }.collect();
         assert!(results.is_empty());
     }
 
     #[test]
     fn map_reuses_existing_page_table() {
-        let pt = GuestPageTableBuffer::<4>::new(PT_BASE);
+        let pt = GuestPageTableBuffer::new(PT_BASE);
         // Map two pages in the same 4MB region (same PD entry)
         unsafe {
-            i686_guest::map(
+            vmem::map(
                 &pt,
                 Mapping {
                     phys_base: 0x1000,
@@ -1047,9 +979,10 @@ mod i686_tests {
                         writable: true,
                         executable: true,
                     }),
+                    user_accessible: false,
                 },
             );
-            i686_guest::map(
+            vmem::map(
                 &pt,
                 Mapping {
                     phys_base: 0x5000,
@@ -1060,14 +993,13 @@ mod i686_tests {
                         writable: true,
                         executable: true,
                     }),
+                    user_accessible: false,
                 },
             );
         }
         // Both should be visible
-        let r1: Vec<_> =
-            unsafe { i686_guest::virt_to_phys(&pt, 0x1000, PAGE_SIZE as u64) }.collect();
-        let r2: Vec<_> =
-            unsafe { i686_guest::virt_to_phys(&pt, 0x5000, PAGE_SIZE as u64) }.collect();
+        let r1: Vec<_> = unsafe { vmem::virt_to_phys(&pt, 0x1000, PAGE_SIZE as u64) }.collect();
+        let r2: Vec<_> = unsafe { vmem::virt_to_phys(&pt, 0x5000, PAGE_SIZE as u64) }.collect();
         assert_eq!(r1.len(), 1);
         assert_eq!(r2.len(), 1);
         assert_eq!(r1[0].phys_base, 0x1000);

--- a/src/hyperlight_host/src/sandbox/snapshot.rs
+++ b/src/hyperlight_host/src/sandbox/snapshot.rs
@@ -997,7 +997,10 @@ impl Snapshot {
                 Ok::<(Vec<u8>, Vec<u8>), crate::HyperlightError>((snapshot_memory, pt_bytes))
             })
         })???;
+        #[cfg(feature = "i686-guest")]
         let (memory, separate_pt_bytes) = memory;
+        #[cfg(not(feature = "i686-guest"))]
+        let (memory, _) = memory;
         layout.set_snapshot_size(memory.len());
 
         // For i686, keep the regions so the RAMFS and other map_file_cow

--- a/src/hyperlight_host/src/sandbox/snapshot.rs
+++ b/src/hyperlight_host/src/sandbox/snapshot.rs
@@ -16,8 +16,12 @@ limitations under the License.
 
 use std::sync::atomic::{AtomicU64, Ordering};
 
-use hyperlight_common::layout::{scratch_base_gpa, scratch_base_gva};
-use hyperlight_common::vmem::{self, BasicMapping, CowMapping, Mapping, MappingKind, PAGE_SIZE};
+#[cfg(not(feature = "i686-guest"))]
+use hyperlight_common::layout::scratch_base_gpa;
+use hyperlight_common::layout::scratch_base_gva;
+#[cfg(not(feature = "i686-guest"))]
+use hyperlight_common::vmem::{self, BasicMapping, CowMapping};
+use hyperlight_common::vmem::{Mapping, MappingKind, PAGE_SIZE};
 use tracing::{Span, instrument};
 
 use crate::HyperlightError::MemoryRegionSizeMismatch;
@@ -26,7 +30,9 @@ use crate::hypervisor::regs::CommonSpecialRegisters;
 use crate::mem::exe::LoadInfo;
 use crate::mem::layout::SandboxMemoryLayout;
 use crate::mem::memory_region::MemoryRegion;
-use crate::mem::mgr::{GuestPageTableBuffer, SnapshotSharedMemory};
+#[cfg(not(feature = "i686-guest"))]
+use crate::mem::mgr::GuestPageTableBuffer;
+use crate::mem::mgr::SnapshotSharedMemory;
 use crate::mem::shared_mem::{ReadonlySharedMemory, SharedMemory};
 use crate::sandbox::SandboxConfiguration;
 use crate::sandbox::uninitialized::{GuestBinary, GuestEnvironment};
@@ -74,6 +80,10 @@ pub struct Snapshot {
     /// The memory regions that were mapped when this snapshot was
     /// taken (excluding initial sandbox regions)
     regions: Vec<MemoryRegion>,
+    /// Separate PT storage for i686 snapshots where PTs are stored
+    /// outside the main snapshot memory to avoid overlap with map_file_cow.
+    #[cfg(feature = "i686-guest")]
+    separate_pt_bytes: Vec<u8>,
     /// Extra debug information about the binary in this snapshot,
     /// from when the binary was first loaded into the snapshot.
     ///
@@ -189,7 +199,12 @@ pub(crate) struct SharedMemoryPageTableBuffer<'a> {
     scratch: &'a [u8],
     layout: SandboxMemoryLayout,
     root: u64,
+    /// CoW resolution map: maps snapshot GPAs to their CoW'd scratch GPAs.
+    /// Built by walking the kernel PD to find pages that were CoW'd during boot.
+    #[cfg(feature = "i686-guest")]
+    cow_map: Option<&'a std::collections::HashMap<u64, u64>>,
 }
+
 impl<'a> SharedMemoryPageTableBuffer<'a> {
     pub(crate) fn new(
         snap: &'a [u8],
@@ -202,7 +217,15 @@ impl<'a> SharedMemoryPageTableBuffer<'a> {
             scratch,
             layout,
             root,
+            #[cfg(feature = "i686-guest")]
+            cow_map: None,
         }
+    }
+
+    #[cfg(feature = "i686-guest")]
+    fn with_cow_map(mut self, cow_map: &'a std::collections::HashMap<u64, u64>) -> Self {
+        self.cow_map = Some(cow_map);
+        self
     }
 }
 impl<'a> hyperlight_common::vmem::TableReadOps for SharedMemoryPageTableBuffer<'a> {
@@ -211,19 +234,48 @@ impl<'a> hyperlight_common::vmem::TableReadOps for SharedMemoryPageTableBuffer<'
         addr + offset
     }
     unsafe fn read_entry(&self, addr: u64) -> u64 {
-        let memoff = access_gpa(self.snap, self.scratch, self.layout, addr);
-        let Some(pte_bytes) = memoff.and_then(|(mem, off)| mem.get(off..off + 8)) else {
-            // Attacker-controlled data pointed out-of-bounds. We'll
-            // default to returning 0 in this case, which, for most
-            // architectures (including x86-64 and arm64, the ones we
-            // care about presently) will be a not-present entry.
-            return 0;
+        // For i686: if the GPA was CoW'd, read from the scratch copy instead.
+        #[cfg(feature = "i686-guest")]
+        let addr = {
+            let page_gpa = addr & 0xFFFFF000;
+            if let Some(map) = self.cow_map {
+                if let Some(&scratch_gpa) = map.get(&page_gpa) {
+                    scratch_gpa + (addr & 0xFFF)
+                } else {
+                    addr
+                }
+            } else {
+                addr
+            }
         };
-        // this is statically the correct size, so using unwrap() here
-        // doesn't make this any more panic-y.
-        #[allow(clippy::unwrap_used)]
-        let n: [u8; 8] = pte_bytes.try_into().unwrap();
-        u64::from_ne_bytes(n)
+        let memoff = access_gpa(self.snap, self.scratch, self.layout, addr);
+        // For i686 guests, page table entries are 4 bytes; for x86_64 they
+        // are 8 bytes. Read the correct size based on the feature flag.
+        #[cfg(feature = "i686-guest")]
+        {
+            let Some(pte_bytes) = memoff.and_then(|(mem, off)| mem.get(off..off + 4)) else {
+                // Out-of-bounds: return 0, which is a not-present entry.
+                return 0;
+            };
+            #[allow(clippy::unwrap_used)]
+            let n: [u8; 4] = pte_bytes.try_into().unwrap();
+            u32::from_ne_bytes(n) as u64
+        }
+        #[cfg(not(feature = "i686-guest"))]
+        {
+            let Some(pte_bytes) = memoff.and_then(|(mem, off)| mem.get(off..off + 8)) else {
+                // Attacker-controlled data pointed out-of-bounds. We'll
+                // default to returning 0 in this case, which, for most
+                // architectures (including x86-64 and arm64, the ones we
+                // care about presently) will be a not-present entry.
+                return 0;
+            };
+            // this is statically the correct size, so using unwrap() here
+            // doesn't make this any more panic-y.
+            #[allow(clippy::unwrap_used)]
+            let n: [u8; 8] = pte_bytes.try_into().unwrap();
+            u64::from_ne_bytes(n)
+        }
     }
     fn to_phys(addr: u64) -> u64 {
         addr
@@ -240,34 +292,424 @@ impl<'a> core::convert::AsRef<SharedMemoryPageTableBuffer<'a>> for SharedMemoryP
         self
     }
 }
+
+/// Build a CoW resolution map by walking a kernel PD.
+/// For each PTE that maps a VA in [0, MEMORY_SIZE) to a PA in scratch,
+/// record: original_gpa -> scratch_gpa.
+#[cfg(feature = "i686-guest")]
+fn build_cow_map(
+    snap: &[u8],
+    scratch: &[u8],
+    layout: SandboxMemoryLayout,
+    kernel_root: u64,
+) -> std::collections::HashMap<u64, u64> {
+    use hyperlight_common::layout::scratch_base_gpa;
+    let mut cow_map = std::collections::HashMap::new();
+    let scratch_base = scratch_base_gpa(layout.get_scratch_size());
+    let scratch_end = scratch_base + layout.get_scratch_size() as u64;
+    let mem_size = layout.get_memory_size().unwrap_or(0) as u64;
+
+    for pdi in 0..1024u64 {
+        let pde_addr = kernel_root + pdi * 4;
+        let pde = access_gpa(snap, scratch, layout, pde_addr)
+            .and_then(|(mem, off)| mem.get(off..off + 4))
+            .map(|b| u32::from_le_bytes([b[0], b[1], b[2], b[3]]))
+            .unwrap_or(0);
+        if (pde & 1) == 0 {
+            continue;
+        }
+        let pt_gpa = (pde & 0xFFFFF000) as u64;
+        for pti in 0..1024u64 {
+            let pte_addr = pt_gpa + pti * 4;
+            let pte = access_gpa(snap, scratch, layout, pte_addr)
+                .and_then(|(mem, off)| mem.get(off..off + 4))
+                .map(|b| u32::from_le_bytes([b[0], b[1], b[2], b[3]]))
+                .unwrap_or(0);
+            if (pte & 1) == 0 {
+                continue;
+            }
+            let frame_gpa = (pte & 0xFFFFF000) as u64;
+            let va = (pdi << 22) | (pti << 12);
+            if va < mem_size && frame_gpa >= scratch_base && frame_gpa < scratch_end {
+                cow_map.insert(va, frame_gpa);
+            }
+        }
+    }
+    cow_map
+}
+
+/// Helper for building i686 2-level page tables as a flat byte buffer.
+///
+/// The buffer stores one or more page directories (PDs) at the front,
+/// followed by page tables (PTs) that are allocated on demand. All
+/// entries use 4-byte i686 PTEs.
+#[cfg(feature = "i686-guest")]
+mod i686_pt {
+    use hyperlight_common::vmem::i686_guest::{PAGE_ACCESSED, PAGE_AVL_COW, PAGE_PRESENT, PAGE_RW};
+
+    const PTE_PRESENT: u32 = PAGE_PRESENT as u32;
+    const PTE_RW: u32 = PAGE_RW as u32;
+    const PTE_ACCESSED: u32 = PAGE_ACCESSED as u32;
+    pub(super) const PTE_COW: u32 = PAGE_AVL_COW as u32;
+    pub(super) const ADDR_MASK: u32 = 0xFFFFF000;
+    pub(super) const RW_FLAGS: u32 = PTE_PRESENT | PTE_RW | PTE_ACCESSED;
+    const PAGE_SIZE: usize = 4096;
+
+    pub(super) struct Builder {
+        pub bytes: Vec<u8>,
+        pd_base_gpa: usize,
+    }
+
+    impl Builder {
+        pub fn new(pd_base_gpa: usize) -> Self {
+            Self {
+                bytes: vec![0u8; PAGE_SIZE],
+                pd_base_gpa,
+            }
+        }
+
+        pub fn with_pds(pd_base_gpa: usize, num_pds: usize) -> Self {
+            Self {
+                bytes: vec![0u8; num_pds * PAGE_SIZE],
+                pd_base_gpa,
+            }
+        }
+
+        pub fn read_u32(&self, offset: usize) -> u32 {
+            let b = &self.bytes[offset..offset + 4];
+            u32::from_le_bytes([b[0], b[1], b[2], b[3]])
+        }
+
+        fn write_u32(&mut self, offset: usize, val: u32) {
+            self.bytes[offset..offset + 4].copy_from_slice(&val.to_le_bytes());
+        }
+
+        /// Ensures a page table exists for PDE index `pdi` within the PD
+        /// at byte offset `pd_offset`. Allocates a new PT page at the end
+        /// of the buffer if absent. Returns the byte offset of the PT.
+        pub fn ensure_pt(&mut self, pd_offset: usize, pdi: usize, pde_flags: u32) -> usize {
+            let pde_off = pd_offset + pdi * 4;
+            let pde = self.read_u32(pde_off);
+            if (pde & PTE_PRESENT) != 0 {
+                (pde & ADDR_MASK) as usize - self.pd_base_gpa
+            } else {
+                let pt_offset = self.bytes.len();
+                self.bytes.resize(pt_offset + PAGE_SIZE, 0);
+                let pt_gpa = (self.pd_base_gpa + pt_offset) as u32;
+                self.write_u32(pde_off, pt_gpa | pde_flags);
+                pt_offset
+            }
+        }
+
+        /// Maps a single 4K page within the PD at `pd_offset`.
+        pub fn map_page(&mut self, pd_offset: usize, va: u64, pa: u64, pte_flags: u32) {
+            let pdi = ((va as u32 >> 22) & 0x3FF) as usize;
+            let pti = ((va as u32 >> 12) & 0x3FF) as usize;
+            let pt_offset = self.ensure_pt(pd_offset, pdi, RW_FLAGS);
+            let pte_off = pt_offset + pti * 4;
+            self.write_u32(pte_off, (pa as u32) | pte_flags);
+        }
+
+        /// Maps a contiguous range of pages with uniform flags.
+        pub fn map_range(
+            &mut self,
+            pd_offset: usize,
+            va_start: u64,
+            pa_start: u64,
+            len: u64,
+            pte_flags: u32,
+        ) {
+            let mut va = va_start;
+            let mut pa = pa_start;
+            let end = va_start + len;
+            while va < end {
+                self.map_page(pd_offset, va, pa, pte_flags);
+                va += PAGE_SIZE as u64;
+                pa += PAGE_SIZE as u64;
+            }
+        }
+
+        pub fn into_bytes(self) -> Vec<u8> {
+            self.bytes
+        }
+    }
+}
+
+/// Build initial i686 page tables for a freshly loaded guest binary.
+/// Maps snapshot regions (with CoW flags for writable pages) and the scratch region.
+#[cfg(feature = "i686-guest")]
+fn build_initial_i686_page_tables(
+    layout: &crate::mem::layout::SandboxMemoryLayout,
+) -> crate::Result<Vec<u8>> {
+    use i686_pt::{PTE_COW, RW_FLAGS};
+
+    use crate::mem::memory_region::{GuestMemoryRegion, MemoryRegionFlags};
+
+    let pd_base_gpa = layout.get_pt_base_gpa() as usize;
+    let mut pt = i686_pt::Builder::new(pd_base_gpa);
+
+    let ro_flags = hyperlight_common::vmem::i686_guest::PAGE_PRESENT as u32
+        | hyperlight_common::vmem::i686_guest::PAGE_ACCESSED as u32;
+
+    // 1. Map snapshot memory regions
+    for rgn in layout.get_memory_regions_::<GuestMemoryRegion>(())?.iter() {
+        let flags = if rgn.flags.contains(MemoryRegionFlags::WRITE) {
+            ro_flags | PTE_COW
+        } else {
+            ro_flags
+        };
+        pt.map_range(
+            0,
+            rgn.guest_region.start as u64,
+            rgn.guest_region.start as u64,
+            rgn.guest_region.len() as u64,
+            flags,
+        );
+    }
+
+    // 2. Map scratch region (writable, not CoW)
+    let scratch_size = layout.get_scratch_size();
+    let scratch_gpa = hyperlight_common::layout::scratch_base_gpa(scratch_size);
+    let scratch_gva = hyperlight_common::layout::scratch_base_gva(scratch_size);
+    pt.map_range(0, scratch_gva, scratch_gpa, scratch_size as u64, RW_FLAGS);
+
+    Ok(pt.into_bytes())
+}
+
+/// Compact an i686 snapshot: densely pack live pages and rebuild
+/// per-process page tables with updated GPAs.
+///
+/// Returns `(snapshot_memory, pt_bytes)`.
+#[cfg(feature = "i686-guest")]
+fn compact_i686_snapshot(
+    snap: &[u8],
+    scratch: &[u8],
+    layout: SandboxMemoryLayout,
+    live_pages: Vec<(Mapping, &[u8])>,
+    root_pt_gpas: &[u64],
+    cow_map: &std::collections::HashMap<u64, u64>,
+    phys_seen: &mut std::collections::HashMap<u64, usize>,
+) -> crate::Result<(Vec<u8>, Vec<u8>)> {
+    use hyperlight_common::vmem::i686_guest::{PAGE_PRESENT, PAGE_USER};
+    use i686_pt::{ADDR_MASK, PTE_COW, RW_FLAGS};
+
+    let page_size: usize = 4096;
+
+    // Phase 1: pack live pages densely into a new snapshot buffer.
+    let mut snapshot_memory: Vec<u8> = Vec::new();
+    for (mapping, contents) in live_pages {
+        if matches!(mapping.kind, MappingKind::Unmapped) {
+            continue;
+        }
+        phys_seen.entry(mapping.phys_base).or_insert_with(|| {
+            let new_offset = snapshot_memory.len();
+            snapshot_memory.extend(contents);
+            new_offset + SandboxMemoryLayout::BASE_ADDRESS
+        });
+    }
+
+    // Phase 2: build per-process page tables with compacted GPAs.
+    let pd_base_gpa = layout.get_pt_base_gpa() as usize;
+    let n_roots = root_pt_gpas.len().max(1);
+    let mut pt = i686_pt::Builder::with_pds(pd_base_gpa, n_roots);
+
+    let scratch_size = layout.get_scratch_size();
+    let scratch_gpa = hyperlight_common::layout::scratch_base_gpa(scratch_size);
+
+    // Helper: read a u32 from guest memory, resolving CoW redirections.
+    let read_u32 = |gpa: u64| -> u32 {
+        let resolved = {
+            let page = gpa & 0xFFFFF000;
+            cow_map
+                .get(&page)
+                .map_or(gpa, |&scratch| scratch + (gpa & 0xFFF))
+        };
+        access_gpa(snap, scratch, layout, resolved)
+            .and_then(|(mem, off)| mem.get(off..off + 4))
+            .map(|b| u32::from_le_bytes([b[0], b[1], b[2], b[3]]))
+            .unwrap_or(0)
+    };
+
+    // Rebuild a single page table with remapped frame GPAs.
+    let rebuild_pt = |pt: &mut i686_pt::Builder,
+                      old_pt_gpa: u64,
+                      extra_flags: u32,
+                      phys_map: &std::collections::HashMap<u64, usize>|
+     -> u32 {
+        let new_pt_offset = pt.bytes.len();
+        pt.bytes.resize(new_pt_offset + page_size, 0);
+        let new_pt_gpa = (pd_base_gpa + new_pt_offset) as u32;
+        for pti in 0..1024usize {
+            let pte = read_u32(old_pt_gpa + pti as u64 * 4);
+            if (pte & PAGE_PRESENT as u32) == 0 {
+                continue;
+            }
+            let old_frame = (pte & ADDR_MASK) as u64;
+            let Some(&new_gpa) = phys_map.get(&old_frame) else {
+                continue;
+            };
+            let mut flags = (pte & 0xFFF) | extra_flags;
+            // Mark writable or already-CoW pages as CoW (read-only + AVL bit).
+            if (flags & RW_FLAGS & !PTE_COW) != 0 || (flags & PTE_COW) != 0 {
+                flags = (flags & !(hyperlight_common::vmem::i686_guest::PAGE_RW as u32)) | PTE_COW;
+            }
+            let off = new_pt_offset + pti * 4;
+            pt.bytes[off..off + 4].copy_from_slice(&((new_gpa as u32) | flags).to_le_bytes());
+        }
+        new_pt_gpa
+    };
+
+    // Resolve a VA through a PD to its physical frame.
+    let resolve_through_pd = |pd_gpa: u64, va: u64| -> u64 {
+        let pdi = (va >> 22) & 0x3FF;
+        let pde = read_u32(pd_gpa + pdi * 4);
+        if (pde & PAGE_PRESENT as u32) == 0 {
+            return va;
+        }
+        let pti = (va >> 12) & 0x3FF;
+        let pte = read_u32((pde & ADDR_MASK) as u64 + pti * 4);
+        if (pte & PAGE_PRESENT as u32) == 0 {
+            return va;
+        }
+        (pte & ADDR_MASK) as u64
+    };
+
+    // Build kernel page tables (lower 256 PD entries) from the first root.
+    let first_root = root_pt_gpas.first().copied().ok_or_else(|| {
+        crate::new_error!("compact_i686_snapshot called with no page directory roots")
+    })?;
+    let mut kernel_pdes = [0u32; 256];
+    for (pdi, kernel_pde) in kernel_pdes.iter_mut().enumerate() {
+        let pde = read_u32(first_root + pdi as u64 * 4);
+        if (pde & PAGE_PRESENT as u32) == 0 {
+            continue;
+        }
+        let new_pt_gpa = rebuild_pt(&mut pt, (pde & ADDR_MASK) as u64, 0, phys_seen);
+        *kernel_pde = (pde & 0xFFF) | new_pt_gpa;
+    }
+
+    // Fill in per-process PDs: kernel half (shared) + user half (per-process).
+    for (root_idx, &root) in root_pt_gpas.iter().enumerate() {
+        let pd_offset = root_idx * page_size;
+        // Copy kernel PDEs (lower 256 entries) into this PD.
+        for (pdi, &kpde) in kernel_pdes.iter().enumerate() {
+            if kpde != 0 {
+                pt.bytes[pd_offset + pdi * 4..pd_offset + pdi * 4 + 4]
+                    .copy_from_slice(&kpde.to_le_bytes());
+            }
+        }
+        // Rebuild user PDEs (upper 256 entries).
+        for pdi in 256..1024usize {
+            let pde = read_u32(root + pdi as u64 * 4);
+            if (pde & PAGE_PRESENT as u32) == 0 {
+                continue;
+            }
+            let user = PAGE_USER as u32;
+            let pt_gpa_raw = (pde & ADDR_MASK) as u64;
+            let pt_gpa = resolve_through_pd(first_root, pt_gpa_raw);
+            let new_pt_gpa = rebuild_pt(&mut pt, pt_gpa, user, phys_seen);
+            let fixed_pde = (pde & 0xFFF) | new_pt_gpa | user;
+            pt.bytes[pd_offset + pdi * 4..pd_offset + pdi * 4 + 4]
+                .copy_from_slice(&fixed_pde.to_le_bytes());
+        }
+    }
+
+    // Map scratch and snapshot identity regions into every PD.
+    for ri in 0..n_roots {
+        let pd_off = ri * page_size;
+        pt.map_range(
+            pd_off,
+            scratch_gpa,
+            scratch_gpa,
+            scratch_size as u64,
+            RW_FLAGS,
+        );
+
+        let snapshot_end = SandboxMemoryLayout::BASE_ADDRESS + snapshot_memory.len();
+        let snapshot_pages = (snapshot_end - SandboxMemoryLayout::BASE_ADDRESS) / page_size;
+        for pi in 0..snapshot_pages {
+            let gpa = (SandboxMemoryLayout::BASE_ADDRESS + pi * page_size) as u64;
+            let pdi = ((gpa >> 22) & 0x3FF) as usize;
+            let pti = ((gpa >> 12) & 0x3FF) as usize;
+            let pt_off = pt.ensure_pt(pd_off, pdi, RW_FLAGS);
+            let pte_off = pt_off + pti * 4;
+            if pt.read_u32(pte_off) & PAGE_PRESENT as u32 == 0 {
+                pt.bytes[pte_off..pte_off + 4]
+                    .copy_from_slice(&((gpa as u32) | RW_FLAGS).to_le_bytes());
+            }
+        }
+    }
+
+    Ok((snapshot_memory, pt.into_bytes()))
+}
+
 fn filtered_mappings<'a>(
     snap: &'a [u8],
     scratch: &'a [u8],
     regions: &[MemoryRegion],
     layout: SandboxMemoryLayout,
-    root_pt: u64,
+    root_pts: &[u64],
+    #[cfg(feature = "i686-guest")] cow_map: &std::collections::HashMap<u64, u64>,
 ) -> Vec<(Mapping, &'a [u8])> {
-    let op = SharedMemoryPageTableBuffer::new(snap, scratch, layout, root_pt);
-    unsafe {
-        hyperlight_common::vmem::virt_to_phys(&op, 0, hyperlight_common::layout::MAX_GVA as u64)
-    }
-    .filter_map(move |mapping| {
-        // the scratch map doesn't count
-        if mapping.virt_base >= scratch_base_gva(layout.get_scratch_size()) {
-            return None;
+    #[cfg(not(feature = "i686-guest"))]
+    let mappings_iter: Vec<Mapping> = {
+        let Some(&root_pt) = root_pts.first() else {
+            return Vec::new();
+        };
+        let op = SharedMemoryPageTableBuffer::new(snap, scratch, layout, root_pt);
+        unsafe {
+            hyperlight_common::vmem::virt_to_phys(&op, 0, hyperlight_common::layout::MAX_GVA as u64)
         }
-        // neither does the mapping of the snapshot's own page tables
-        #[cfg(not(feature = "i686-guest"))]
-        if mapping.virt_base >= hyperlight_common::layout::SNAPSHOT_PT_GVA_MIN as u64
-            && mapping.virt_base <= hyperlight_common::layout::SNAPSHOT_PT_GVA_MAX as u64
-        {
-            return None;
+        .collect()
+    };
+
+    #[cfg(feature = "i686-guest")]
+    let mappings_iter: Vec<Mapping> = {
+        use std::collections::HashSet;
+        let mut mappings = Vec::new();
+        let mut seen_phys = HashSet::new();
+
+        let scratch_base_gva_val =
+            hyperlight_common::layout::scratch_base_gva(layout.get_scratch_size());
+        for &root_pt in root_pts {
+            let op = SharedMemoryPageTableBuffer::new(snap, scratch, layout, root_pt)
+                .with_cow_map(cow_map);
+            let root_mappings =
+                unsafe { hyperlight_common::vmem::i686_guest::virt_to_phys_all(&op) };
+            for m in root_mappings {
+                // Skip mappings whose VA is in the scratch region - these
+                // are identity-mapped helpers and would poison seen_phys for
+                // legitimate user mappings that share the same scratch PAs.
+                if m.virt_base >= scratch_base_gva_val {
+                    continue;
+                }
+                if seen_phys.insert(m.phys_base) {
+                    mappings.push(m);
+                }
+            }
         }
-        // todo: is it useful to warn if we can't resolve this?
-        let contents = unsafe { guest_page(snap, scratch, regions, layout, mapping.phys_base) }?;
-        Some((mapping, contents))
-    })
-    .collect()
+        mappings
+    };
+
+    mappings_iter
+        .into_iter()
+        .filter_map(move |mapping| {
+            // the scratch map doesn't count
+            if mapping.virt_base >= scratch_base_gva(layout.get_scratch_size()) {
+                return None;
+            }
+            // neither does the mapping of the snapshot's own page tables
+            #[cfg(not(feature = "i686-guest"))]
+            if mapping.virt_base >= hyperlight_common::layout::SNAPSHOT_PT_GVA_MIN as u64
+                && mapping.virt_base <= hyperlight_common::layout::SNAPSHOT_PT_GVA_MAX as u64
+            {
+                return None;
+            }
+            let contents =
+                unsafe { guest_page(snap, scratch, regions, layout, mapping.phys_base) }?;
+            Some((mapping, contents))
+        })
+        .collect()
 }
 
 /// Find the contents of the page which starts at gpa in guest physical
@@ -293,6 +735,7 @@ unsafe fn guest_page<'a>(
     Some(&resolved.as_ref()[..PAGE_SIZE])
 }
 
+#[cfg(not(feature = "i686-guest"))]
 fn map_specials(pt_buf: &GuestPageTableBuffer, scratch_size: usize) {
     // Map the scratch region
     let mapping = Mapping {
@@ -406,6 +849,12 @@ impl Snapshot {
             layout.set_pt_size(pt_bytes.len())?;
             memory.extend(&pt_bytes);
         };
+        #[cfg(feature = "i686-guest")]
+        {
+            let pt_bytes = build_initial_i686_page_tables(&layout)?;
+            layout.set_pt_size(pt_bytes.len())?;
+            memory.extend(&pt_bytes);
+        };
 
         let exn_stack_top_gva = hyperlight_common::layout::MAX_GVA as u64
             - hyperlight_common::layout::SCRATCH_TOP_EXN_STACK_OFFSET
@@ -423,6 +872,8 @@ impl Snapshot {
             hash,
             stack_top_gva: exn_stack_top_gva,
             sregs: None,
+            #[cfg(feature = "i686-guest")]
+            separate_pt_bytes: Vec::new(),
             entrypoint: NextAction::Initialise(load_addr + entrypoint_va - base_va),
         })
     }
@@ -443,7 +894,7 @@ impl Snapshot {
         mut layout: SandboxMemoryLayout,
         load_info: LoadInfo,
         regions: Vec<MemoryRegion>,
-        root_pt_gpa: u64,
+        root_pt_gpas: &[u64],
         stack_top_gva: u64,
         sregs: CommonSpecialRegisters,
         entrypoint: NextAction,
@@ -452,54 +903,96 @@ impl Snapshot {
         let mut phys_seen = HashMap::<u64, usize>::new();
         let memory = shared_mem.with_contents(|snap_c| {
             scratch_mem.with_contents(|scratch_c| {
-                // Pass 1: count how many pages need to live
-                let live_pages =
-                    filtered_mappings(snap_c, scratch_c, &regions, layout, root_pt_gpa);
+                // Build CoW resolution map (i686 only): maps original GPAs
+                // to their CoW'd scratch GPAs so the PT walker can read the
+                // actual page table data instead of stale snapshot copies.
+                #[cfg(feature = "i686-guest")]
+                let cow_map = {
+                    let kernel_root = root_pt_gpas.first().copied().ok_or_else(|| {
+                        crate::new_error!("snapshot requires at least one page directory root")
+                    })?;
+                    build_cow_map(snap_c, scratch_c, layout, kernel_root)
+                };
 
-                // Pass 2: copy them, and map them
+                // Pass 1: collect live pages
+                let live_pages = filtered_mappings(
+                    snap_c,
+                    scratch_c,
+                    &regions,
+                    layout,
+                    root_pt_gpas,
+                    #[cfg(feature = "i686-guest")]
+                    &cow_map,
+                );
+
+                // Pass 2: copy live pages and build new page tables
                 // TODO: Look for opportunities to hugepage map
-                let pt_buf = GuestPageTableBuffer::new(layout.get_pt_base_gpa() as usize);
-                let mut snapshot_memory: Vec<u8> = Vec::new();
-                for (mapping, contents) in live_pages {
-                    let kind = match mapping.kind {
-                        MappingKind::Cow(cm) => MappingKind::Cow(cm),
-                        MappingKind::Basic(bm) if bm.writable => MappingKind::Cow(CowMapping {
-                            readable: bm.readable,
-                            executable: bm.executable,
-                        }),
-                        MappingKind::Basic(bm) => MappingKind::Basic(BasicMapping {
-                            readable: bm.readable,
-                            writable: false,
-                            executable: bm.executable,
-                        }),
-                        MappingKind::Unmapped => continue,
-                    };
-                    let new_gpa = phys_seen.entry(mapping.phys_base).or_insert_with(|| {
-                        let new_offset = snapshot_memory.len();
-                        snapshot_memory.extend(contents);
-                        new_offset + SandboxMemoryLayout::BASE_ADDRESS
-                    });
-                    let mapping = Mapping {
-                        phys_base: *new_gpa as u64,
-                        virt_base: mapping.virt_base,
-                        len: PAGE_SIZE as u64,
-                        kind,
-                    };
-                    unsafe { vmem::map(&pt_buf, mapping) };
-                }
-                // Phase 3: Map the special mappings
-                map_specials(&pt_buf, layout.get_scratch_size());
-                let pt_bytes = pt_buf.into_bytes();
-                layout.set_pt_size(pt_bytes.len())?;
-                snapshot_memory.extend(&pt_bytes);
-                Ok::<Vec<u8>, crate::HyperlightError>(snapshot_memory)
+                #[cfg(not(feature = "i686-guest"))]
+                let (snapshot_memory, pt_bytes) = {
+                    let mut snapshot_memory: Vec<u8> = Vec::new();
+                    let pt_buf = GuestPageTableBuffer::new(layout.get_pt_base_gpa() as usize);
+                    for (mapping, contents) in live_pages {
+                        let kind = match mapping.kind {
+                            MappingKind::Cow(cm) => MappingKind::Cow(cm),
+                            MappingKind::Basic(bm) if bm.writable => MappingKind::Cow(CowMapping {
+                                readable: bm.readable,
+                                executable: bm.executable,
+                            }),
+                            MappingKind::Basic(bm) => MappingKind::Basic(BasicMapping {
+                                readable: bm.readable,
+                                writable: false,
+                                executable: bm.executable,
+                            }),
+                            MappingKind::Unmapped => continue,
+                        };
+                        let new_gpa = phys_seen.entry(mapping.phys_base).or_insert_with(|| {
+                            let new_offset = snapshot_memory.len();
+                            snapshot_memory.extend(contents);
+                            new_offset + SandboxMemoryLayout::BASE_ADDRESS
+                        });
+                        let mapping = Mapping {
+                            phys_base: *new_gpa as u64,
+                            virt_base: mapping.virt_base,
+                            len: PAGE_SIZE as u64,
+                            kind,
+                        };
+                        unsafe { vmem::map(&pt_buf, mapping) };
+                    }
+                    map_specials(&pt_buf, layout.get_scratch_size());
+                    let pt_data = pt_buf.into_bytes();
+                    layout.set_pt_size(pt_data.len())?;
+                    snapshot_memory.extend(&pt_data);
+                    (snapshot_memory, Vec::new())
+                };
+
+                #[cfg(feature = "i686-guest")]
+                let (snapshot_memory, pt_bytes) = {
+                    let (mem, pt) = compact_i686_snapshot(
+                        snap_c,
+                        scratch_c,
+                        layout,
+                        live_pages,
+                        root_pt_gpas,
+                        &cow_map,
+                        &mut phys_seen,
+                    )?;
+                    layout.set_pt_size(pt.len())?;
+                    (mem, pt)
+                };
+
+                Ok::<(Vec<u8>, Vec<u8>), crate::HyperlightError>((snapshot_memory, pt_bytes))
             })
         })???;
+        let (memory, separate_pt_bytes) = memory;
         layout.set_snapshot_size(memory.len());
 
-        // We do not need the original regions anymore, as any uses of
-        // them in the guest have been incorporated into the snapshot
-        // properly.
+        // For i686, keep the regions so the RAMFS and other map_file_cow
+        // mappings are accessible after restore. For x86_64, we do not
+        // need the original regions anymore, as any uses of them in the
+        // guest have been incorporated into the snapshot properly.
+        #[cfg(feature = "i686-guest")]
+        let regions = regions;
+        #[cfg(not(feature = "i686-guest"))]
         let regions = Vec::new();
 
         let hash = hash(&memory, &regions)?;
@@ -512,6 +1005,8 @@ impl Snapshot {
             hash,
             stack_top_gva,
             sregs: Some(sregs),
+            #[cfg(feature = "i686-guest")]
+            separate_pt_bytes,
             entrypoint,
         })
     }
@@ -558,6 +1053,11 @@ impl Snapshot {
         self.sregs.as_ref()
     }
 
+    #[cfg(feature = "i686-guest")]
+    pub(crate) fn separate_pt_bytes(&self) -> &[u8] {
+        &self.separate_pt_bytes
+    }
+
     pub(crate) fn entrypoint(&self) -> NextAction {
         self.entrypoint
     }
@@ -570,6 +1070,7 @@ impl PartialEq for Snapshot {
 }
 
 #[cfg(test)]
+#[cfg(not(feature = "i686-guest"))]
 mod tests {
     use hyperlight_common::vmem::{self, BasicMapping, Mapping, MappingKind, PAGE_SIZE};
 
@@ -638,7 +1139,7 @@ mod tests {
             mgr.layout,
             LoadInfo::dummy(),
             Vec::new(),
-            pt_base,
+            &[pt_base],
             0,
             default_sregs(),
             super::NextAction::None,
@@ -654,7 +1155,7 @@ mod tests {
             mgr.layout,
             LoadInfo::dummy(),
             Vec::new(),
-            pt_base,
+            &[pt_base],
             0,
             default_sregs(),
             super::NextAction::None,

--- a/src/hyperlight_host/src/sandbox/snapshot.rs
+++ b/src/hyperlight_host/src/sandbox/snapshot.rs
@@ -589,15 +589,14 @@ impl Snapshot {
         debug_assert!(guest_visible_size.is_multiple_of(PAGE_SIZE));
         layout.set_snapshot_size(guest_visible_size);
 
-        // On amd64 we currently don't persist the embedder-provided
-        // regions (`map_file_cow` etc.) into the snapshot — the
-        // existing behaviour predates this PR and mirrors what the old
-        // non-relocated path did. On i686 we do keep them: Nanvix uses
-        // `map_file_cow` regions for its ramfs image, which must
-        // survive into the snapshot identity so that restore produces
-        // the same guest state.
-        #[cfg(not(feature = "i686-guest"))]
-        let regions = Vec::new();
+        // Drop the embedder-provided regions: post-compaction every
+        // VA that used to map into a `map_file_cow` region has been
+        // rewritten to point at the new copy inside the snapshot blob
+        // (see the `guest_page` walk above). Re-mapping the originals
+        // on restore is unnecessary for the translation to work and
+        // actively risks corrupting the snapshot if the new snapshot
+        // PAs overlap the old region PAs.
+        let regions: Vec<MemoryRegion> = Vec::new();
 
         let hash = hash(&memory, &regions)?;
         Ok(Self {

--- a/src/hyperlight_host/src/sandbox/snapshot.rs
+++ b/src/hyperlight_host/src/sandbox/snapshot.rs
@@ -578,6 +578,13 @@ impl Snapshot {
         debug_assert!(guest_visible_size.is_multiple_of(PAGE_SIZE));
         layout.set_snapshot_size(guest_visible_size);
 
+        // On amd64 we currently don't persist the embedder-provided
+        // regions (`map_file_cow` etc.) into the snapshot — the
+        // existing behaviour predates this PR and mirrors what the old
+        // non-relocated path did. On i686 we do keep them: Nanvix uses
+        // `map_file_cow` regions for its ramfs image, which must
+        // survive into the snapshot identity so that restore produces
+        // the same guest state.
         #[cfg(not(feature = "i686-guest"))]
         let regions = Vec::new();
 

--- a/src/hyperlight_host/src/sandbox/snapshot.rs
+++ b/src/hyperlight_host/src/sandbox/snapshot.rs
@@ -78,15 +78,6 @@ pub struct Snapshot {
     /// The memory regions that were mapped when this snapshot was
     /// taken (excluding initial sandbox regions)
     regions: Vec<MemoryRegion>,
-    /// Separate PT storage for i686 snapshots. On x86_64, PTs are
-    /// appended to `memory` and the snapshot region's GPA range grows
-    /// to include them. On i686, that would cause the snapshot KVM
-    /// memory slot to overlap with map_file_cow regions (e.g. RAMFS)
-    /// placed at GPAs just above the original snapshot end. Storing
-    /// PTs separately avoids the conflict; they are copied directly
-    /// to scratch during restore.
-    #[cfg(feature = "i686-guest")]
-    separate_pt_bytes: Vec<u8>,
     /// Extra debug information about the binary in this snapshot,
     /// from when the binary was first loaded into the snapshot.
     ///
@@ -595,8 +586,6 @@ impl Snapshot {
             hash,
             stack_top_gva: exn_stack_top_gva,
             sregs: None,
-            #[cfg(feature = "i686-guest")]
-            separate_pt_bytes: Vec::new(),
             entrypoint: NextAction::Initialise(load_addr + entrypoint_va - base_va),
         })
     }
@@ -748,37 +737,32 @@ impl Snapshot {
                 // Phase 5: finalize PT bytes.
                 let pt_data = pt_buf.into_bytes();
                 layout.set_pt_size(pt_data.len())?;
-
-                #[cfg(feature = "i686-guest")]
-                {
-                    Ok::<_, crate::HyperlightError>((snapshot_memory, pt_data.into_vec()))
-                }
-                #[cfg(not(feature = "i686-guest"))]
-                {
-                    snapshot_memory.extend(&pt_data);
-                    Ok::<_, crate::HyperlightError>(snapshot_memory)
-                }
+                snapshot_memory.extend(&pt_data);
+                Ok::<_, crate::HyperlightError>(snapshot_memory)
             })
         })???;
-        #[cfg(feature = "i686-guest")]
-        let (memory, separate_pt_bytes) = memory;
-        layout.set_snapshot_size(memory.len());
+        // Only map the data portion into guest PA space. The PT tail
+        // must stay out of the KVM slot to avoid overlapping with
+        // map_file_cow regions that sit right after the snapshot.
+        let guest_visible_size = memory.len() - layout.get_pt_size();
+        debug_assert!(guest_visible_size.is_multiple_of(PAGE_SIZE));
+        layout.set_snapshot_size(guest_visible_size);
 
         #[cfg(not(feature = "i686-guest"))]
         let regions = Vec::new();
 
         let hash = hash(&memory, &regions)?;
+        let rom =
+            ReadonlySharedMemory::from_bytes_with_mapped_size(&memory, guest_visible_size)?;
         Ok(Self {
             sandbox_id,
             layout,
-            memory: ReadonlySharedMemory::from_bytes(&memory)?,
+            memory: rom,
             regions,
             load_info,
             hash,
             stack_top_gva,
             sregs: Some(sregs),
-            #[cfg(feature = "i686-guest")]
-            separate_pt_bytes,
             entrypoint,
         })
     }
@@ -823,11 +807,6 @@ impl Snapshot {
     /// use `root_pt_gpa()` instead since page tables are relocated during snapshot.
     pub(crate) fn sregs(&self) -> Option<&CommonSpecialRegisters> {
         self.sregs.as_ref()
-    }
-
-    #[cfg(feature = "i686-guest")]
-    pub(crate) fn separate_pt_bytes(&self) -> &[u8] {
-        &self.separate_pt_bytes
     }
 
     pub(crate) fn entrypoint(&self) -> NextAction {

--- a/src/hyperlight_host/src/sandbox/snapshot.rs
+++ b/src/hyperlight_host/src/sandbox/snapshot.rs
@@ -14,13 +14,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::sync::atomic::{AtomicU64, Ordering};
 
 use hyperlight_common::layout::{scratch_base_gpa, scratch_base_gva};
 use hyperlight_common::vmem;
 use hyperlight_common::vmem::{
-    BasicMapping, CowMapping, Mapping, MappingKind, PAGE_SIZE, TableOps,
+    BasicMapping, CowMapping, Mapping, MappingKind, PAGE_SIZE, SpaceAwareMapping, SpaceId,
+    TableOps,
 };
 use tracing::{Span, instrument};
 
@@ -242,43 +243,23 @@ impl<'a> core::convert::AsRef<SharedMemoryPageTableBuffer<'a>> for SharedMemoryP
         self
     }
 }
-fn filtered_mappings<'a>(
-    snap: &'a [u8],
-    scratch: &'a [u8],
-    regions: &[MemoryRegion],
-    layout: SandboxMemoryLayout,
-    root_pts: &[u64],
-) -> Vec<(usize, Mapping, &'a [u8])> {
-    let mut result = Vec::new();
-    let scratch_gva = scratch_base_gva(layout.get_scratch_size());
-
-    for (root_idx, &root_pt) in root_pts.iter().enumerate() {
-        let op = SharedMemoryPageTableBuffer::new(snap, scratch, layout, root_pt);
-
-        let iter = unsafe { vmem::virt_to_phys(&op, 0, hyperlight_common::layout::MAX_GVA as u64) };
-
-        for m in iter {
-            // the scratch map doesn't count
-            if m.virt_base >= scratch_gva {
-                continue;
-            }
-            // neither does the mapping of the snapshot's own page tables
-            #[cfg(not(feature = "i686-guest"))]
-            if m.virt_base >= hyperlight_common::layout::SNAPSHOT_PT_GVA_MIN as u64
-                && m.virt_base <= hyperlight_common::layout::SNAPSHOT_PT_GVA_MAX as u64
-            {
-                continue;
-            }
-
-            if let Some(contents) =
-                unsafe { guest_page(snap, scratch, regions, layout, m.phys_base) }
-            {
-                result.push((root_idx, m, contents));
-            }
-        }
+/// Return true if `virt_base` is a VA we must not preserve into the
+/// rebuilt snapshot page tables: it is either part of the scratch
+/// region (re-mapped freshly by `map_specials`) or, on amd64, part of
+/// the self-map of the snapshot's own page tables.
+fn skip_virt(virt_base: u64, scratch_gva: u64) -> bool {
+    if virt_base >= scratch_gva {
+        return true;
     }
-
-    result
+    #[cfg(not(feature = "i686-guest"))]
+    if virt_base >= hyperlight_common::layout::SNAPSHOT_PT_GVA_MIN as u64
+        && virt_base <= hyperlight_common::layout::SNAPSHOT_PT_GVA_MAX as u64
+    {
+        return true;
+    }
+    #[cfg(feature = "i686-guest")]
+    let _ = virt_base;
+    false
 }
 
 /// Find the contents of the page which starts at gpa in guest physical
@@ -456,16 +437,38 @@ impl Snapshot {
         entrypoint: NextAction,
     ) -> Result<Self> {
         let mut phys_seen = HashMap::<u64, usize>::new();
+        let scratch_gva = scratch_base_gva(layout.get_scratch_size());
         let memory = shared_mem.with_contents(|snap_c| {
             scratch_mem.with_contents(|scratch_c| {
-                // Phase 1: walk every PT root and collect live pages,
-                // tagged with which root they belong to (for per-process
-                // PD isolation on i686).
-                let live_pages =
-                    filtered_mappings(snap_c, scratch_c, &regions, layout, root_pt_gpas);
+                // Phase 1: walk every PT root together. This detects
+                // aliased intermediate tables (e.g. Nanvix's kernel-
+                // half PTs, which multiple process PDs share by
+                // pointing at the same PT page). The walker emits
+                // `ThisSpace(leaf)` for private leaves and
+                // `AnotherSpace(ref)` for sub-trees that were already
+                // seen via an earlier root. Results are returned in
+                // `root_pt_gpas` order — which is also the topological
+                // order of the `AnotherSpace` references — so
+                // processing in iteration order is safe.
+                let op = SharedMemoryPageTableBuffer::new(
+                    snap_c,
+                    scratch_c,
+                    layout,
+                    root_pt_gpas.first().copied().unwrap_or(0),
+                );
+                let walk = unsafe {
+                    vmem::walk_va_spaces(
+                        &op,
+                        root_pt_gpas,
+                        0,
+                        hyperlight_common::layout::MAX_GVA as u64,
+                    )
+                };
 
-                // Phase 2: compact live pages into a dense snapshot blob
-                // and build new page tables with compacted GPAs.
+                // Phase 2: rebuild each space's page tables, compacting
+                // `ThisSpace` leaves into a dense snapshot blob and
+                // linking `AnotherSpace` entries to already-built
+                // spaces' tables.
                 // TODO: Look for opportunities to hugepage map
                 let mut snapshot_memory: Vec<u8> = Vec::new();
                 let pt_buf = GuestPageTableBuffer::new(layout.get_pt_base_gpa() as usize);
@@ -473,38 +476,76 @@ impl Snapshot {
                     unsafe { pt_buf.alloc_table() };
                 }
 
-                for (_root_idx, mapping, contents) in live_pages {
-                    // Convert a snapshot mapping kind for compaction: writable
-                    // pages become CoW, read-only pages stay read-only.
-                    let kind = match mapping.kind {
-                        MappingKind::Cow(cm) => MappingKind::Cow(cm),
-                        MappingKind::Basic(bm) if bm.writable => MappingKind::Cow(CowMapping {
-                            readable: bm.readable,
-                            executable: bm.executable,
-                        }),
-                        MappingKind::Basic(bm) => MappingKind::Basic(BasicMapping {
-                            readable: bm.readable,
-                            writable: false,
-                            executable: bm.executable,
-                        }),
-                        MappingKind::Unmapped => continue,
-                    };
-                    let new_gpa = phys_seen.entry(mapping.phys_base).or_insert_with(|| {
-                        let new_offset = snapshot_memory.len();
-                        snapshot_memory.extend(contents);
-                        new_offset + SandboxMemoryLayout::BASE_ADDRESS
-                    });
+                let mut built_roots: BTreeMap<SpaceId, u64> = BTreeMap::new();
+                for (root_idx, (space_id, mappings)) in walk.into_iter().enumerate() {
+                    pt_buf.set_root_offset(root_idx * PAGE_SIZE);
+                    built_roots.insert(
+                        space_id,
+                        (layout.get_pt_base_gpa() as usize + root_idx * PAGE_SIZE) as u64,
+                    );
 
-                    pt_buf.set_root_offset(_root_idx * PAGE_SIZE);
+                    for sam in mappings {
+                        match sam {
+                            SpaceAwareMapping::ThisSpace(mapping) => {
+                                // Drop the scratch region and (on
+                                // amd64) the snapshot's own PT
+                                // self-map; both are re-mapped
+                                // freshly by `map_specials`.
+                                if skip_virt(mapping.virt_base, scratch_gva) {
+                                    continue;
+                                }
+                                let Some(contents) = (unsafe {
+                                    guest_page(snap_c, scratch_c, &regions, layout, mapping.phys_base)
+                                }) else {
+                                    continue;
+                                };
 
-                    let mapping = Mapping {
-                        phys_base: *new_gpa as u64,
-                        virt_base: mapping.virt_base,
-                        len: PAGE_SIZE as u64,
-                        kind,
-                        user_accessible: mapping.user_accessible,
-                    };
-                    unsafe { vmem::map(&pt_buf, mapping) };
+                                // Writable pages become CoW in the
+                                // rebuilt snapshot; read-only pages
+                                // stay read-only.
+                                let kind = match mapping.kind {
+                                    MappingKind::Cow(cm) => MappingKind::Cow(cm),
+                                    MappingKind::Basic(bm) if bm.writable => {
+                                        MappingKind::Cow(CowMapping {
+                                            readable: bm.readable,
+                                            executable: bm.executable,
+                                        })
+                                    }
+                                    MappingKind::Basic(bm) => MappingKind::Basic(BasicMapping {
+                                        readable: bm.readable,
+                                        writable: false,
+                                        executable: bm.executable,
+                                    }),
+                                    MappingKind::Unmapped => continue,
+                                };
+                                let new_gpa =
+                                    phys_seen.entry(mapping.phys_base).or_insert_with(|| {
+                                        let new_offset = snapshot_memory.len();
+                                        snapshot_memory.extend(contents);
+                                        new_offset + SandboxMemoryLayout::BASE_ADDRESS
+                                    });
+
+                                let compacted = Mapping {
+                                    phys_base: *new_gpa as u64,
+                                    virt_base: mapping.virt_base,
+                                    len: PAGE_SIZE as u64,
+                                    kind,
+                                    user_accessible: mapping.user_accessible,
+                                };
+                                unsafe { vmem::map(&pt_buf, compacted) };
+                            }
+                            SpaceAwareMapping::AnotherSpace(ref_map) => {
+                                // Link to the owning space's already-
+                                // rebuilt intermediate table — this
+                                // is what preserves Nanvix's
+                                // kernel-half-shared invariant across
+                                // process PDs after relocation.
+                                unsafe {
+                                    vmem::space_aware_map(&pt_buf, ref_map, &built_roots);
+                                }
+                            }
+                        }
+                    }
                 }
 
                 // Phase 3: Map the scratch region into each root.

--- a/src/hyperlight_host/src/sandbox/snapshot.rs
+++ b/src/hyperlight_host/src/sandbox/snapshot.rs
@@ -484,17 +484,19 @@ impl Snapshot {
                 // TODO: Look for opportunities to hugepage map
                 let mut snapshot_memory: Vec<u8> = Vec::new();
                 let pt_buf = GuestPageTableBuffer::new(layout.get_pt_base_gpa() as usize);
+                // Allocate one root table per space and remember the
+                // addresses returned by `alloc_table` instead of
+                // assuming the buffer's physical layout.
+                let mut root_addrs: Vec<u64> = Vec::with_capacity(root_pt_gpas.len());
+                root_addrs.push(pt_buf.initial_root());
                 for _ in 1..root_pt_gpas.len() {
-                    unsafe { pt_buf.alloc_table() };
+                    root_addrs.push(unsafe { pt_buf.alloc_table() });
                 }
 
                 let mut built_roots: BTreeMap<SpaceId, u64> = BTreeMap::new();
                 for (root_idx, (space_id, mappings)) in walk.into_iter().enumerate() {
-                    pt_buf.set_root_offset(root_idx * PAGE_SIZE);
-                    built_roots.insert(
-                        space_id,
-                        (layout.get_pt_base_gpa() as usize + root_idx * PAGE_SIZE) as u64,
-                    );
+                    pt_buf.set_root(root_addrs[root_idx]);
+                    built_roots.insert(space_id, root_addrs[root_idx]);
 
                     for sam in mappings {
                         match sam {
@@ -567,11 +569,11 @@ impl Snapshot {
                 }
 
                 // Phase 3: Map the scratch region into each root.
-                for root_idx in 0..root_pt_gpas.len() {
-                    pt_buf.set_root_offset(root_idx * PAGE_SIZE);
+                for &root_addr in &root_addrs {
+                    pt_buf.set_root(root_addr);
                     map_specials(&pt_buf, layout.get_scratch_size());
                 }
-                pt_buf.set_root_offset(0);
+                pt_buf.set_root(pt_buf.initial_root());
 
                 // Phase 4: finalize PT bytes.
                 let pt_data = pt_buf.into_bytes();

--- a/src/hyperlight_host/src/sandbox/snapshot.rs
+++ b/src/hyperlight_host/src/sandbox/snapshot.rs
@@ -84,6 +84,16 @@ pub struct Snapshot {
     /// outside the main snapshot memory to avoid overlap with map_file_cow.
     #[cfg(feature = "i686-guest")]
     separate_pt_bytes: Vec<u8>,
+    /// Number of per-process page-directory roots captured in this
+    /// snapshot. After restore the PD-root count and the compacted
+    /// root GPAs are re-populated in the scratch bookkeeping area
+    /// (`SCRATCH_TOP_PD_ROOTS_{COUNT,ARRAY}_OFFSET`) so a subsequent
+    /// `snapshot()` call observes a non-zero count. Root GPAs are
+    /// deterministic: root `i` lands at
+    /// `layout.get_pt_base_gpa() + i * PAGE_SIZE` (see
+    /// `compact_i686_snapshot`).
+    #[cfg(feature = "i686-guest")]
+    n_pd_roots: usize,
     /// Extra debug information about the binary in this snapshot,
     /// from when the binary was first loaded into the snapshot.
     ///
@@ -259,7 +269,9 @@ impl<'a> hyperlight_common::vmem::TableReadOps for SharedMemoryPageTableBuffer<'
             };
             #[allow(clippy::unwrap_used)]
             let n: [u8; 4] = pte_bytes.try_into().unwrap();
-            u32::from_ne_bytes(n) as u64
+            // Page-table entries are little-endian by arch spec;
+            // use `from_le_bytes` so host endianness doesn't leak in.
+            u32::from_le_bytes(n) as u64
         }
         #[cfg(not(feature = "i686-guest"))]
         {
@@ -874,6 +886,8 @@ impl Snapshot {
             sregs: None,
             #[cfg(feature = "i686-guest")]
             separate_pt_bytes: Vec::new(),
+            #[cfg(feature = "i686-guest")]
+            n_pd_roots: 0,
             entrypoint: NextAction::Initialise(load_addr + entrypoint_va - base_va),
         })
     }
@@ -1007,6 +1021,8 @@ impl Snapshot {
             sregs: Some(sregs),
             #[cfg(feature = "i686-guest")]
             separate_pt_bytes,
+            #[cfg(feature = "i686-guest")]
+            n_pd_roots: root_pt_gpas.len(),
             entrypoint,
         })
     }
@@ -1056,6 +1072,15 @@ impl Snapshot {
     #[cfg(feature = "i686-guest")]
     pub(crate) fn separate_pt_bytes(&self) -> &[u8] {
         &self.separate_pt_bytes
+    }
+
+    /// Number of per-process page-directory roots captured in this
+    /// snapshot. Used by `restore_snapshot` to rewrite the scratch
+    /// PD-roots bookkeeping so a later `snapshot()` call doesn't
+    /// observe a stale zero count.
+    #[cfg(feature = "i686-guest")]
+    pub(crate) fn n_pd_roots(&self) -> usize {
+        self.n_pd_roots
     }
 
     pub(crate) fn entrypoint(&self) -> NextAction {

--- a/src/hyperlight_host/src/sandbox/snapshot.rs
+++ b/src/hyperlight_host/src/sandbox/snapshot.rs
@@ -120,6 +120,10 @@ impl hyperlight_common::vmem::TableReadOps for Snapshot {
         let addr = addr as usize;
         let pte_size = core::mem::size_of::<vmem::PageTableEntry>();
         let Some(pte_bytes) = self.memory.as_slice().get(addr..addr + pte_size) else {
+            // Attacker-controlled data pointed out-of-bounds. We'll
+            // default to returning 0 in this case, which, for most
+            // architectures (including x86-64 and arm64, the ones we
+            // care about presently) will be a not-present entry.
             return 0;
         };
         let mut buf = [0u8; 8];
@@ -190,7 +194,6 @@ pub(crate) struct SharedMemoryPageTableBuffer<'a> {
     layout: SandboxMemoryLayout,
     root: u64,
 }
-
 impl<'a> SharedMemoryPageTableBuffer<'a> {
     pub(crate) fn new(
         snap: &'a [u8],
@@ -215,6 +218,10 @@ impl<'a> hyperlight_common::vmem::TableReadOps for SharedMemoryPageTableBuffer<'
         let memoff = access_gpa(self.snap, self.scratch, self.layout, addr);
         let pte_size = core::mem::size_of::<vmem::PageTableEntry>();
         let Some(pte_bytes) = memoff.and_then(|(mem, off)| mem.get(off..off + pte_size)) else {
+            // Attacker-controlled data pointed out-of-bounds. We'll
+            // default to returning 0 in this case, which, for most
+            // architectures (including x86-64 and arm64, the ones we
+            // care about presently) will be a not-present entry.
             return 0;
         };
         let mut buf = [0u8; 8];
@@ -285,9 +292,11 @@ fn filtered_mappings<'a>(
         let iter = unsafe { vmem::virt_to_phys(&op, 0, hyperlight_common::layout::MAX_GVA as u64) };
 
         for m in iter {
+            // the scratch map doesn't count
             if m.virt_base >= scratch_gva {
                 continue;
             }
+            // neither does the mapping of the snapshot's own page tables
             #[cfg(not(feature = "i686-guest"))]
             if m.virt_base >= hyperlight_common::layout::SNAPSHOT_PT_GVA_MIN as u64
                 && m.virt_base <= hyperlight_common::layout::SNAPSHOT_PT_GVA_MAX as u64

--- a/src/hyperlight_host/src/sandbox/snapshot.rs
+++ b/src/hyperlight_host/src/sandbox/snapshot.rs
@@ -14,27 +14,30 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+use std::collections::HashMap;
 use std::sync::atomic::{AtomicU64, Ordering};
 
-use hyperlight_common::layout::scratch_base_gva;
+use hyperlight_common::layout::{scratch_base_gpa, scratch_base_gva};
 use hyperlight_common::vmem;
-#[cfg(feature = "i686-guest")]
-use hyperlight_common::vmem::TableOps;
-use hyperlight_common::vmem::{BasicMapping, CowMapping, Mapping, MappingKind, PAGE_SIZE};
+use hyperlight_common::vmem::{
+    BasicMapping, CowMapping, Mapping, MappingKind, PAGE_SIZE, TableOps,
+};
 use tracing::{Span, instrument};
 
 use crate::HyperlightError::MemoryRegionSizeMismatch;
 use crate::Result;
 use crate::hypervisor::regs::CommonSpecialRegisters;
-use crate::mem::exe::LoadInfo;
+use crate::mem::exe::{ExeInfo, LoadInfo};
 use crate::mem::layout::SandboxMemoryLayout;
-use crate::mem::memory_region::MemoryRegion;
+use crate::mem::memory_region::{GuestMemoryRegion, MemoryRegion, MemoryRegionFlags};
 use crate::mem::mgr::{GuestPageTableBuffer, SnapshotSharedMemory};
 use crate::mem::shared_mem::{ReadonlySharedMemory, SharedMemory};
 use crate::sandbox::SandboxConfiguration;
 use crate::sandbox::uninitialized::{GuestBinary, GuestEnvironment};
 
 pub(super) static SANDBOX_CONFIGURATION_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+const PTE_SIZE: usize = size_of::<vmem::PageTableEntry>();
 
 /// Presently, a snapshot can be of a preinitialised sandbox, which
 /// still needs an initialise function called in order to determine
@@ -118,17 +121,14 @@ impl hyperlight_common::vmem::TableReadOps for Snapshot {
     }
     unsafe fn read_entry(&self, addr: u64) -> vmem::PageTableEntry {
         let addr = addr as usize;
-        let pte_size = core::mem::size_of::<vmem::PageTableEntry>();
-        let Some(pte_bytes) = self.memory.as_slice().get(addr..addr + pte_size) else {
+        let Some(pte_bytes) = self.memory.as_slice().get(addr..addr + PTE_SIZE) else {
             // Attacker-controlled data pointed out-of-bounds. We'll
             // default to returning 0 in this case, which, for most
             // architectures (including x86-64 and arm64, the ones we
             // care about presently) will be a not-present entry.
             return 0;
         };
-        let mut buf = [0u8; 8];
-        buf[..pte_size].copy_from_slice(pte_bytes);
-        vmem::PageTableEntry::from_le_bytes(buf[..pte_size].try_into().unwrap_or_default())
+        vmem::PageTableEntry::from_le_bytes(pte_bytes.try_into().unwrap())
     }
     #[allow(clippy::unnecessary_cast)]
     fn to_phys(addr: u64) -> vmem::PhysAddr {
@@ -216,17 +216,14 @@ impl<'a> hyperlight_common::vmem::TableReadOps for SharedMemoryPageTableBuffer<'
     }
     unsafe fn read_entry(&self, addr: u64) -> vmem::PageTableEntry {
         let memoff = access_gpa(self.snap, self.scratch, self.layout, addr);
-        let pte_size = core::mem::size_of::<vmem::PageTableEntry>();
-        let Some(pte_bytes) = memoff.and_then(|(mem, off)| mem.get(off..off + pte_size)) else {
+        let Some(pte_bytes) = memoff.and_then(|(mem, off)| mem.get(off..off + PTE_SIZE)) else {
             // Attacker-controlled data pointed out-of-bounds. We'll
             // default to returning 0 in this case, which, for most
             // architectures (including x86-64 and arm64, the ones we
             // care about presently) will be a not-present entry.
             return 0;
         };
-        let mut buf = [0u8; 8];
-        buf[..pte_size].copy_from_slice(pte_bytes);
-        vmem::PageTableEntry::from_le_bytes(buf[..pte_size].try_into().unwrap_or_default())
+        vmem::PageTableEntry::from_le_bytes(pte_bytes.try_into().unwrap())
     }
     #[allow(clippy::unnecessary_cast)]
     fn to_phys(addr: u64) -> vmem::PhysAddr {
@@ -245,34 +242,6 @@ impl<'a> core::convert::AsRef<SharedMemoryPageTableBuffer<'a>> for SharedMemoryP
         self
     }
 }
-
-/// On i686, PDE index where user-space begins. Kernel occupies PDEs
-/// 0..256 (VA 0x00000000..0x40000000), user-space occupies 256+.
-#[cfg(feature = "i686-guest")]
-const I686_USER_PDE_START: usize = 256;
-
-/// On i686, VA where user-space begins (derived from [`I686_USER_PDE_START`]).
-#[cfg(feature = "i686-guest")]
-const I686_USER_VA_START: u64 = (I686_USER_PDE_START as u64) << 22;
-
-/// Convert a snapshot mapping kind for compaction: writable pages
-/// become CoW, read-only pages stay read-only.
-fn compaction_kind(kind: &MappingKind) -> MappingKind {
-    match kind {
-        MappingKind::Cow(cm) => MappingKind::Cow(*cm),
-        MappingKind::Basic(bm) if bm.writable => MappingKind::Cow(CowMapping {
-            readable: bm.readable,
-            executable: bm.executable,
-        }),
-        MappingKind::Basic(bm) => MappingKind::Basic(BasicMapping {
-            readable: bm.readable,
-            writable: false,
-            executable: bm.executable,
-        }),
-        MappingKind::Unmapped => MappingKind::Unmapped,
-    }
-}
-
 fn filtered_mappings<'a>(
     snap: &'a [u8],
     scratch: &'a [u8],
@@ -280,12 +249,9 @@ fn filtered_mappings<'a>(
     layout: SandboxMemoryLayout,
     root_pts: &[u64],
 ) -> Vec<(usize, Mapping, &'a [u8])> {
-    use std::collections::HashSet;
-    let mut all_mappings = Vec::new();
-    let mut seen_phys = HashSet::new();
+    let mut result = Vec::new();
     let scratch_gva = scratch_base_gva(layout.get_scratch_size());
 
-    #[cfg_attr(not(feature = "i686-guest"), allow(unused_variables))]
     for (root_idx, &root_pt) in root_pts.iter().enumerate() {
         let op = SharedMemoryPageTableBuffer::new(snap, scratch, layout, root_pt);
 
@@ -303,35 +269,16 @@ fn filtered_mappings<'a>(
             {
                 continue;
             }
-            // On i686, kernel pages (shared across roots) are only
-            // collected from root 0. User pages are collected per-root
-            // with their root index for per-process PD isolation.
-            #[cfg(feature = "i686-guest")]
-            let effective_root = if m.virt_base < I686_USER_VA_START {
-                if root_idx != 0 {
-                    continue;
-                }
-                0
-            } else {
-                root_idx
-            };
-            #[cfg(not(feature = "i686-guest"))]
-            let effective_root = 0;
 
-            if seen_phys.insert(m.phys_base) {
-                all_mappings.push((effective_root, m));
+            if let Some(contents) =
+                unsafe { guest_page(snap, scratch, regions, layout, m.phys_base) }
+            {
+                result.push((root_idx, m, contents));
             }
         }
     }
 
-    all_mappings
-        .into_iter()
-        .filter_map(move |(root_idx, mapping)| {
-            let contents =
-                unsafe { guest_page(snap, scratch, regions, layout, mapping.phys_base) }?;
-            Some((root_idx, mapping, contents))
-        })
-        .collect()
+    result
 }
 
 /// Find the contents of the page which starts at gpa in guest physical
@@ -357,6 +304,24 @@ unsafe fn guest_page<'a>(
     Some(&resolved.as_ref()[..PAGE_SIZE])
 }
 
+fn map_specials(pt_buf: &GuestPageTableBuffer, scratch_size: usize) {
+    // Map the scratch region
+    let mapping = Mapping {
+        phys_base: scratch_base_gpa(scratch_size),
+        virt_base: scratch_base_gva(scratch_size),
+        len: scratch_size as u64,
+        kind: MappingKind::Basic(BasicMapping {
+            readable: true,
+            writable: true,
+            // assume that the guest will map these pages elsewhere if
+            // it actually needs to execute from them
+            executable: false,
+        }),
+        user_accessible: false,
+    };
+    unsafe { vmem::map(pt_buf, mapping) };
+}
+
 impl Snapshot {
     /// Create a new snapshot from the guest binary identified by `env`. With the configuration
     /// specified in `cfg`.
@@ -369,7 +334,6 @@ impl Snapshot {
         bin.canonicalize()?;
         let blob = env.init_data;
 
-        use crate::mem::exe::ExeInfo;
         let exe_info = match bin {
             GuestBinary::FilePath(bin_path_str) => ExeInfo::from_file(&bin_path_str)?,
             GuestBinary::Buffer(buffer) => ExeInfo::from_buf(buffer)?,
@@ -413,63 +377,42 @@ impl Snapshot {
         blob.map(|x| layout.write_init_data(&mut memory, x.data))
             .transpose()?;
 
-        {
-            use hyperlight_common::layout::scratch_base_gpa;
+        // Set up page table entries for the snapshot
+        let pt_buf = GuestPageTableBuffer::new(layout.get_pt_base_gpa() as usize);
 
-            use crate::mem::memory_region::{GuestMemoryRegion, MemoryRegionFlags};
-            use crate::mem::mgr::GuestPageTableBuffer;
-
-            let pt_buf = GuestPageTableBuffer::new(layout.get_pt_base_gpa() as usize);
-
-            // Map snapshot memory regions (writable -> CoW, read-only -> Basic)
-            for rgn in layout.get_memory_regions_::<GuestMemoryRegion>(())?.iter() {
-                let readable = rgn.flags.contains(MemoryRegionFlags::READ);
-                let executable = rgn.flags.contains(MemoryRegionFlags::EXECUTE);
-                let writable = rgn.flags.contains(MemoryRegionFlags::WRITE);
-                let kind = if writable {
-                    MappingKind::Cow(CowMapping {
-                        readable,
-                        executable,
-                    })
-                } else {
-                    MappingKind::Basic(BasicMapping {
-                        readable,
-                        writable: false,
-                        executable,
-                    })
-                };
-                let mapping = Mapping {
-                    phys_base: rgn.guest_region.start as u64,
-                    virt_base: rgn.guest_region.start as u64,
-                    len: rgn.guest_region.len() as u64,
-                    kind,
-                    user_accessible: false,
-                };
-                unsafe {
-                    vmem::map(&pt_buf, mapping);
-                }
-            }
-
-            // Map the scratch region
-            let scratch_mapping = Mapping {
-                phys_base: scratch_base_gpa(layout.get_scratch_size()),
-                virt_base: scratch_base_gva(layout.get_scratch_size()),
-                len: layout.get_scratch_size() as u64,
-                kind: MappingKind::Basic(BasicMapping {
-                    readable: true,
-                    writable: true,
-                    executable: false,
-                }),
+        // 1. Map the (ideally readonly) pages of snapshot data
+        for rgn in layout.get_memory_regions_::<GuestMemoryRegion>(())?.iter() {
+            let readable = rgn.flags.contains(MemoryRegionFlags::READ);
+            let executable = rgn.flags.contains(MemoryRegionFlags::EXECUTE);
+            let writable = rgn.flags.contains(MemoryRegionFlags::WRITE);
+            let kind = if writable {
+                MappingKind::Cow(CowMapping {
+                    readable,
+                    executable,
+                })
+            } else {
+                MappingKind::Basic(BasicMapping {
+                    readable,
+                    writable: false,
+                    executable,
+                })
+            };
+            let mapping = Mapping {
+                phys_base: rgn.guest_region.start as u64,
+                virt_base: rgn.guest_region.start as u64,
+                len: rgn.guest_region.len() as u64,
+                kind,
                 user_accessible: false,
             };
-            unsafe {
-                vmem::map(&pt_buf, scratch_mapping);
-            }
+            unsafe { vmem::map(&pt_buf, mapping) };
+        }
 
-            let pt_bytes = pt_buf.into_bytes();
-            layout.set_pt_size(pt_bytes.len())?;
-            memory.extend(&pt_bytes);
-        };
+        // 2. Map the special mappings
+        map_specials(&pt_buf, layout.get_scratch_size());
+
+        let pt_bytes = pt_buf.into_bytes();
+        layout.set_pt_size(pt_bytes.len())?;
+        memory.extend(&pt_bytes);
 
         let exn_stack_top_gva = hyperlight_common::layout::MAX_GVA as u64
             - hyperlight_common::layout::SCRATCH_TOP_EXN_STACK_OFFSET
@@ -512,7 +455,6 @@ impl Snapshot {
         sregs: CommonSpecialRegisters,
         entrypoint: NextAction,
     ) -> Result<Self> {
-        use std::collections::HashMap;
         let mut phys_seen = HashMap::<u64, usize>::new();
         let memory = shared_mem.with_contents(|snap_c| {
             scratch_mem.with_contents(|scratch_c| {
@@ -527,76 +469,52 @@ impl Snapshot {
                 // TODO: Look for opportunities to hugepage map
                 let mut snapshot_memory: Vec<u8> = Vec::new();
                 let pt_buf = GuestPageTableBuffer::new(layout.get_pt_base_gpa() as usize);
-                #[cfg(feature = "i686-guest")]
                 for _ in 1..root_pt_gpas.len() {
                     unsafe { pt_buf.alloc_table() };
                 }
 
                 for (_root_idx, mapping, contents) in live_pages {
-                    let kind = compaction_kind(&mapping.kind);
-                    if matches!(kind, MappingKind::Unmapped) {
-                        continue;
-                    }
+                    // Convert a snapshot mapping kind for compaction: writable
+                    // pages become CoW, read-only pages stay read-only.
+                    let kind = match mapping.kind {
+                        MappingKind::Cow(cm) => MappingKind::Cow(cm),
+                        MappingKind::Basic(bm) if bm.writable => MappingKind::Cow(CowMapping {
+                            readable: bm.readable,
+                            executable: bm.executable,
+                        }),
+                        MappingKind::Basic(bm) => MappingKind::Basic(BasicMapping {
+                            readable: bm.readable,
+                            writable: false,
+                            executable: bm.executable,
+                        }),
+                        MappingKind::Unmapped => continue,
+                    };
                     let new_gpa = phys_seen.entry(mapping.phys_base).or_insert_with(|| {
                         let new_offset = snapshot_memory.len();
                         snapshot_memory.extend(contents);
                         new_offset + SandboxMemoryLayout::BASE_ADDRESS
                     });
 
-                    #[cfg(feature = "i686-guest")]
                     pt_buf.set_root_offset(_root_idx * PAGE_SIZE);
 
-                    let new_mapping = Mapping {
+                    let mapping = Mapping {
                         phys_base: *new_gpa as u64,
                         virt_base: mapping.virt_base,
                         len: PAGE_SIZE as u64,
                         kind,
                         user_accessible: mapping.user_accessible,
                     };
-                    unsafe {
-                        vmem::map(&pt_buf, new_mapping);
-                    }
+                    unsafe { vmem::map(&pt_buf, mapping) };
                 }
-                #[cfg(feature = "i686-guest")]
+
+                // Phase 3: Map the scratch region into each root.
+                for root_idx in 0..root_pt_gpas.len() {
+                    pt_buf.set_root_offset(root_idx * PAGE_SIZE);
+                    map_specials(&pt_buf, layout.get_scratch_size());
+                }
                 pt_buf.set_root_offset(0);
 
-                // Phase 3: map the scratch region into the page tables.
-                let scratch_gpa =
-                    hyperlight_common::layout::scratch_base_gpa(layout.get_scratch_size());
-                let scratch_gva = scratch_base_gva(layout.get_scratch_size());
-                let scratch_len = layout.get_scratch_size() as u64;
-                unsafe {
-                    vmem::map(
-                        &pt_buf,
-                        Mapping {
-                            phys_base: scratch_gpa,
-                            virt_base: scratch_gva,
-                            len: scratch_len,
-                            kind: MappingKind::Basic(BasicMapping {
-                                readable: true,
-                                writable: true,
-                                executable: false,
-                            }),
-                            user_accessible: false,
-                        },
-                    );
-                }
-
-                // Phase 4 (i686 only): replicate kernel PDEs and scratch
-                // into all other PD roots, then mark user PDEs with
-                // PAGE_USER for ring-3 accessibility.
-                #[cfg(feature = "i686-guest")]
-                unsafe {
-                    pt_buf.finalize_multi_root(
-                        root_pt_gpas.len(),
-                        I686_USER_PDE_START,
-                        scratch_gpa,
-                        scratch_gva,
-                        scratch_len,
-                    );
-                }
-
-                // Phase 5: finalize PT bytes.
+                // Phase 4: finalize PT bytes.
                 let pt_data = pt_buf.into_bytes();
                 layout.set_pt_size(pt_data.len())?;
                 snapshot_memory.extend(&pt_data);
@@ -614,11 +532,10 @@ impl Snapshot {
         let regions = Vec::new();
 
         let hash = hash(&memory, &regions)?;
-        let rom = ReadonlySharedMemory::from_bytes_with_mapped_size(&memory, guest_visible_size)?;
         Ok(Self {
             sandbox_id,
             layout,
-            memory: rom,
+            memory: ReadonlySharedMemory::from_bytes_with_mapped_size(&memory, guest_visible_size)?,
             regions,
             load_info,
             hash,
@@ -714,19 +631,7 @@ mod tests {
             user_accessible: false,
         };
         unsafe { vmem::map(&pt_buf, mapping) };
-        // Map the scratch region
-        let scratch_mapping = Mapping {
-            phys_base: hyperlight_common::layout::scratch_base_gpa(PAGE_SIZE),
-            virt_base: hyperlight_common::layout::scratch_base_gva(PAGE_SIZE),
-            len: PAGE_SIZE as u64,
-            kind: MappingKind::Basic(BasicMapping {
-                readable: true,
-                writable: true,
-                executable: false,
-            }),
-            user_accessible: false,
-        };
-        unsafe { vmem::map(&pt_buf, scratch_mapping) };
+        super::map_specials(&pt_buf, PAGE_SIZE);
         let pt_bytes = pt_buf.into_bytes();
 
         let mut snapshot_mem = vec![0u8; PAGE_SIZE + pt_bytes.len()];

--- a/src/hyperlight_host/src/sandbox/snapshot.rs
+++ b/src/hyperlight_host/src/sandbox/snapshot.rs
@@ -128,6 +128,8 @@ impl hyperlight_common::vmem::TableReadOps for Snapshot {
             // care about presently) will be a not-present entry.
             return 0;
         };
+        // The `get()` above ensures exactly PTE_SIZE bytes.
+        #[allow(clippy::unwrap_used)]
         vmem::PageTableEntry::from_le_bytes(pte_bytes.try_into().unwrap())
     }
     #[allow(clippy::unnecessary_cast)]
@@ -223,6 +225,8 @@ impl<'a> hyperlight_common::vmem::TableReadOps for SharedMemoryPageTableBuffer<'
             // care about presently) will be a not-present entry.
             return 0;
         };
+        // The `get()` above ensures exactly PTE_SIZE bytes.
+        #[allow(clippy::unwrap_used)]
         vmem::PageTableEntry::from_le_bytes(pte_bytes.try_into().unwrap())
     }
     #[allow(clippy::unnecessary_cast)]

--- a/src/hyperlight_host/src/sandbox/snapshot.rs
+++ b/src/hyperlight_host/src/sandbox/snapshot.rs
@@ -257,7 +257,7 @@ fn filtered_mappings<'a>(
             return None;
         }
         // neither does the mapping of the snapshot's own page tables
-        #[cfg(not(feature = "nanvix-unstable"))]
+        #[cfg(not(feature = "i686-guest"))]
         if mapping.virt_base >= hyperlight_common::layout::SNAPSHOT_PT_GVA_MIN as u64
             && mapping.virt_base <= hyperlight_common::layout::SNAPSHOT_PT_GVA_MAX as u64
         {
@@ -342,7 +342,7 @@ impl Snapshot {
         let guest_blob_size = blob.as_ref().map(|b| b.data.len()).unwrap_or(0);
         let guest_blob_mem_flags = blob.as_ref().map(|b| b.permissions);
 
-        #[cfg_attr(feature = "nanvix-unstable", allow(unused_mut))]
+        #[cfg_attr(feature = "i686-guest", allow(unused_mut))]
         let mut layout = crate::mem::layout::SandboxMemoryLayout::new(
             cfg,
             exe_info.loaded_size(),
@@ -351,7 +351,8 @@ impl Snapshot {
         )?;
 
         let load_addr = layout.get_guest_code_address() as u64;
-        let entrypoint_offset: u64 = exe_info.entrypoint().into();
+        let base_va = exe_info.base_va();
+        let entrypoint_va: u64 = exe_info.entrypoint().into();
 
         let mut memory = vec![0; layout.get_memory_size()?];
 
@@ -365,7 +366,7 @@ impl Snapshot {
         blob.map(|x| layout.write_init_data(&mut memory, x.data))
             .transpose()?;
 
-        #[cfg(not(feature = "nanvix-unstable"))]
+        #[cfg(not(feature = "i686-guest"))]
         {
             // Set up page table entries for the snapshot
             let pt_buf = GuestPageTableBuffer::new(layout.get_pt_base_gpa() as usize);
@@ -422,7 +423,7 @@ impl Snapshot {
             hash,
             stack_top_gva: exn_stack_top_gva,
             sregs: None,
-            entrypoint: NextAction::Initialise(load_addr + entrypoint_offset),
+            entrypoint: NextAction::Initialise(load_addr + entrypoint_va - base_va),
         })
     }
 

--- a/src/hyperlight_host/src/sandbox/snapshot.rs
+++ b/src/hyperlight_host/src/sandbox/snapshot.rs
@@ -16,12 +16,12 @@ limitations under the License.
 
 use std::sync::atomic::{AtomicU64, Ordering};
 
-#[cfg(not(feature = "i686-guest"))]
-use hyperlight_common::layout::scratch_base_gpa;
 use hyperlight_common::layout::scratch_base_gva;
 #[cfg(not(feature = "i686-guest"))]
-use hyperlight_common::vmem::{self, BasicMapping, CowMapping};
-use hyperlight_common::vmem::{Mapping, MappingKind, PAGE_SIZE};
+use hyperlight_common::vmem;
+#[cfg(feature = "i686-guest")]
+use hyperlight_common::vmem::TableOps;
+use hyperlight_common::vmem::{BasicMapping, CowMapping, Mapping, MappingKind, PAGE_SIZE};
 use tracing::{Span, instrument};
 
 use crate::HyperlightError::MemoryRegionSizeMismatch;
@@ -30,9 +30,7 @@ use crate::hypervisor::regs::CommonSpecialRegisters;
 use crate::mem::exe::LoadInfo;
 use crate::mem::layout::SandboxMemoryLayout;
 use crate::mem::memory_region::MemoryRegion;
-#[cfg(not(feature = "i686-guest"))]
-use crate::mem::mgr::GuestPageTableBuffer;
-use crate::mem::mgr::SnapshotSharedMemory;
+use crate::mem::mgr::{GuestPageTableBuffer, SnapshotSharedMemory};
 use crate::mem::shared_mem::{ReadonlySharedMemory, SharedMemory};
 use crate::sandbox::SandboxConfiguration;
 use crate::sandbox::uninitialized::{GuestBinary, GuestEnvironment};
@@ -80,20 +78,15 @@ pub struct Snapshot {
     /// The memory regions that were mapped when this snapshot was
     /// taken (excluding initial sandbox regions)
     regions: Vec<MemoryRegion>,
-    /// Separate PT storage for i686 snapshots where PTs are stored
-    /// outside the main snapshot memory to avoid overlap with map_file_cow.
+    /// Separate PT storage for i686 snapshots. On x86_64, PTs are
+    /// appended to `memory` and the snapshot region's GPA range grows
+    /// to include them. On i686, that would cause the snapshot KVM
+    /// memory slot to overlap with map_file_cow regions (e.g. RAMFS)
+    /// placed at GPAs just above the original snapshot end. Storing
+    /// PTs separately avoids the conflict; they are copied directly
+    /// to scratch during restore.
     #[cfg(feature = "i686-guest")]
     separate_pt_bytes: Vec<u8>,
-    /// Number of per-process page-directory roots captured in this
-    /// snapshot. After restore the PD-root count and the compacted
-    /// root GPAs are re-populated in the scratch bookkeeping area
-    /// (`SCRATCH_TOP_PD_ROOTS_{COUNT,ARRAY}_OFFSET`) so a subsequent
-    /// `snapshot()` call observes a non-zero count. Root GPAs are
-    /// deterministic: root `i` lands at
-    /// `layout.get_pt_base_gpa() + i * PAGE_SIZE` (see
-    /// `compact_i686_snapshot`).
-    #[cfg(feature = "i686-guest")]
-    n_pd_roots: usize,
     /// Extra debug information about the binary in this snapshot,
     /// from when the binary was first loaded into the snapshot.
     ///
@@ -321,338 +314,47 @@ fn build_cow_map(
     let scratch_end = scratch_base + layout.get_scratch_size() as u64;
     let mem_size = layout.get_memory_size()? as u64;
 
-    for pdi in 0..1024u64 {
-        let pde_addr = kernel_root + pdi * 4;
-        let pde = access_gpa(snap, scratch, layout, pde_addr)
-            .and_then(|(mem, off)| mem.get(off..off + 4))
-            .map(|b| u32::from_le_bytes([b[0], b[1], b[2], b[3]]))
-            .unwrap_or(0);
-        if (pde & 1) == 0 {
-            continue;
-        }
-        let pt_gpa = (pde & 0xFFFFF000) as u64;
-        for pti in 0..1024u64 {
-            let pte_addr = pt_gpa + pti * 4;
-            let pte = access_gpa(snap, scratch, layout, pte_addr)
-                .and_then(|(mem, off)| mem.get(off..off + 4))
-                .map(|b| u32::from_le_bytes([b[0], b[1], b[2], b[3]]))
-                .unwrap_or(0);
-            if (pte & 1) == 0 {
-                continue;
-            }
-            let frame_gpa = (pte & 0xFFFFF000) as u64;
-            let va = (pdi << 22) | (pti << 12);
-            if va < mem_size && frame_gpa >= scratch_base && frame_gpa < scratch_end {
-                cow_map.insert(va, frame_gpa);
-            }
+    let op = SharedMemoryPageTableBuffer::new(snap, scratch, layout, kernel_root);
+    let mappings = unsafe {
+        hyperlight_common::vmem::i686_guest::virt_to_phys(
+            &op,
+            0,
+            hyperlight_common::layout::MAX_GVA as u64,
+        )
+    };
+    for m in mappings {
+        if m.virt_base < mem_size && m.phys_base >= scratch_base && m.phys_base < scratch_end {
+            cow_map.insert(m.virt_base, m.phys_base);
         }
     }
     Ok(cow_map)
 }
 
-/// Helper for building i686 2-level page tables as a flat byte buffer.
-///
-/// The buffer stores one or more page directories (PDs) at the front,
-/// followed by page tables (PTs) that are allocated on demand. All
-/// entries use 4-byte i686 PTEs.
+/// On i686, PDE index where user-space begins. Kernel occupies PDEs
+/// 0..256 (VA 0x00000000..0x40000000), user-space occupies 256+.
 #[cfg(feature = "i686-guest")]
-mod i686_pt {
-    use hyperlight_common::vmem::i686_guest::{PAGE_ACCESSED, PAGE_AVL_COW, PAGE_PRESENT, PAGE_RW};
+const I686_USER_PDE_START: usize = 256;
 
-    const PTE_PRESENT: u32 = PAGE_PRESENT as u32;
-    const PTE_RW: u32 = PAGE_RW as u32;
-    const PTE_ACCESSED: u32 = PAGE_ACCESSED as u32;
-    pub(super) const PTE_COW: u32 = PAGE_AVL_COW as u32;
-    pub(super) const ADDR_MASK: u32 = 0xFFFFF000;
-    pub(super) const RW_FLAGS: u32 = PTE_PRESENT | PTE_RW | PTE_ACCESSED;
-    const PAGE_SIZE: usize = 4096;
-
-    pub(super) struct Builder {
-        pub bytes: Vec<u8>,
-        pd_base_gpa: usize,
-    }
-
-    impl Builder {
-        pub fn new(pd_base_gpa: usize) -> Self {
-            Self {
-                bytes: vec![0u8; PAGE_SIZE],
-                pd_base_gpa,
-            }
-        }
-
-        pub fn with_pds(pd_base_gpa: usize, num_pds: usize) -> Self {
-            Self {
-                bytes: vec![0u8; num_pds * PAGE_SIZE],
-                pd_base_gpa,
-            }
-        }
-
-        pub fn read_u32(&self, offset: usize) -> u32 {
-            let b = &self.bytes[offset..offset + 4];
-            u32::from_le_bytes([b[0], b[1], b[2], b[3]])
-        }
-
-        fn write_u32(&mut self, offset: usize, val: u32) {
-            self.bytes[offset..offset + 4].copy_from_slice(&val.to_le_bytes());
-        }
-
-        /// Ensures a page table exists for PDE index `pdi` within the PD
-        /// at byte offset `pd_offset`. Allocates a new PT page at the end
-        /// of the buffer if absent. Returns the byte offset of the PT.
-        pub fn ensure_pt(&mut self, pd_offset: usize, pdi: usize, pde_flags: u32) -> usize {
-            let pde_off = pd_offset + pdi * 4;
-            let pde = self.read_u32(pde_off);
-            if (pde & PTE_PRESENT) != 0 {
-                (pde & ADDR_MASK) as usize - self.pd_base_gpa
-            } else {
-                let pt_offset = self.bytes.len();
-                self.bytes.resize(pt_offset + PAGE_SIZE, 0);
-                let pt_gpa = (self.pd_base_gpa + pt_offset) as u32;
-                self.write_u32(pde_off, pt_gpa | pde_flags);
-                pt_offset
-            }
-        }
-
-        /// Maps a single 4K page within the PD at `pd_offset`.
-        pub fn map_page(&mut self, pd_offset: usize, va: u64, pa: u64, pte_flags: u32) {
-            let pdi = ((va as u32 >> 22) & 0x3FF) as usize;
-            let pti = ((va as u32 >> 12) & 0x3FF) as usize;
-            let pt_offset = self.ensure_pt(pd_offset, pdi, RW_FLAGS);
-            let pte_off = pt_offset + pti * 4;
-            self.write_u32(pte_off, (pa as u32) | pte_flags);
-        }
-
-        /// Maps a contiguous range of pages with uniform flags.
-        pub fn map_range(
-            &mut self,
-            pd_offset: usize,
-            va_start: u64,
-            pa_start: u64,
-            len: u64,
-            pte_flags: u32,
-        ) {
-            let mut va = va_start;
-            let mut pa = pa_start;
-            let end = va_start + len;
-            while va < end {
-                self.map_page(pd_offset, va, pa, pte_flags);
-                va += PAGE_SIZE as u64;
-                pa += PAGE_SIZE as u64;
-            }
-        }
-
-        pub fn into_bytes(self) -> Vec<u8> {
-            self.bytes
-        }
-    }
-}
-
-/// Build initial i686 page tables for a freshly loaded guest binary.
-/// Maps snapshot regions (with CoW flags for writable pages) and the scratch region.
+/// On i686, VA where user-space begins (derived from [`I686_USER_PDE_START`]).
 #[cfg(feature = "i686-guest")]
-fn build_initial_i686_page_tables(
-    layout: &crate::mem::layout::SandboxMemoryLayout,
-) -> crate::Result<Vec<u8>> {
-    use i686_pt::{PTE_COW, RW_FLAGS};
+const I686_USER_VA_START: u64 = (I686_USER_PDE_START as u64) << 22;
 
-    use crate::mem::memory_region::{GuestMemoryRegion, MemoryRegionFlags};
-
-    let pd_base_gpa = layout.get_pt_base_gpa() as usize;
-    let mut pt = i686_pt::Builder::new(pd_base_gpa);
-
-    let ro_flags = hyperlight_common::vmem::i686_guest::PAGE_PRESENT as u32
-        | hyperlight_common::vmem::i686_guest::PAGE_ACCESSED as u32;
-
-    // 1. Map snapshot memory regions
-    for rgn in layout.get_memory_regions_::<GuestMemoryRegion>(())?.iter() {
-        let flags = if rgn.flags.contains(MemoryRegionFlags::WRITE) {
-            ro_flags | PTE_COW
-        } else {
-            ro_flags
-        };
-        pt.map_range(
-            0,
-            rgn.guest_region.start as u64,
-            rgn.guest_region.start as u64,
-            rgn.guest_region.len() as u64,
-            flags,
-        );
+/// Convert a snapshot mapping kind for compaction: writable pages
+/// become CoW, read-only pages stay read-only.
+fn compaction_kind(kind: &MappingKind) -> MappingKind {
+    match kind {
+        MappingKind::Cow(cm) => MappingKind::Cow(*cm),
+        MappingKind::Basic(bm) if bm.writable => MappingKind::Cow(CowMapping {
+            readable: bm.readable,
+            executable: bm.executable,
+        }),
+        MappingKind::Basic(bm) => MappingKind::Basic(BasicMapping {
+            readable: bm.readable,
+            writable: false,
+            executable: bm.executable,
+        }),
+        MappingKind::Unmapped => MappingKind::Unmapped,
     }
-
-    // 2. Map scratch region (writable, not CoW)
-    let scratch_size = layout.get_scratch_size();
-    let scratch_gpa = hyperlight_common::layout::scratch_base_gpa(scratch_size);
-    let scratch_gva = hyperlight_common::layout::scratch_base_gva(scratch_size);
-    pt.map_range(0, scratch_gva, scratch_gpa, scratch_size as u64, RW_FLAGS);
-
-    Ok(pt.into_bytes())
-}
-
-/// Compact an i686 snapshot: densely pack live pages and rebuild
-/// per-process page tables with updated GPAs.
-///
-/// Returns `(snapshot_memory, pt_bytes)`.
-#[cfg(feature = "i686-guest")]
-fn compact_i686_snapshot(
-    snap: &[u8],
-    scratch: &[u8],
-    layout: SandboxMemoryLayout,
-    live_pages: Vec<(Mapping, &[u8])>,
-    root_pt_gpas: &[u64],
-    cow_map: &std::collections::HashMap<u64, u64>,
-    phys_seen: &mut std::collections::HashMap<u64, usize>,
-) -> crate::Result<(Vec<u8>, Vec<u8>)> {
-    use hyperlight_common::vmem::i686_guest::{PAGE_PRESENT, PAGE_USER};
-    use i686_pt::{ADDR_MASK, PTE_COW, RW_FLAGS};
-
-    let page_size: usize = 4096;
-
-    // Phase 1: pack live pages densely into a new snapshot buffer.
-    let mut snapshot_memory: Vec<u8> = Vec::new();
-    for (mapping, contents) in live_pages {
-        if matches!(mapping.kind, MappingKind::Unmapped) {
-            continue;
-        }
-        phys_seen.entry(mapping.phys_base).or_insert_with(|| {
-            let new_offset = snapshot_memory.len();
-            snapshot_memory.extend(contents);
-            new_offset + SandboxMemoryLayout::BASE_ADDRESS
-        });
-    }
-
-    // Phase 2: build per-process page tables with compacted GPAs.
-    let pd_base_gpa = layout.get_pt_base_gpa() as usize;
-    let n_roots = root_pt_gpas.len().max(1);
-    let mut pt = i686_pt::Builder::with_pds(pd_base_gpa, n_roots);
-
-    let scratch_size = layout.get_scratch_size();
-    let scratch_gpa = hyperlight_common::layout::scratch_base_gpa(scratch_size);
-
-    // Helper: read a u32 from guest memory, resolving CoW redirections.
-    let read_u32 = |gpa: u64| -> u32 {
-        let resolved = {
-            let page = gpa & 0xFFFFF000;
-            cow_map
-                .get(&page)
-                .map_or(gpa, |&scratch| scratch + (gpa & 0xFFF))
-        };
-        access_gpa(snap, scratch, layout, resolved)
-            .and_then(|(mem, off)| mem.get(off..off + 4))
-            .map(|b| u32::from_le_bytes([b[0], b[1], b[2], b[3]]))
-            .unwrap_or(0)
-    };
-
-    // Rebuild a single page table with remapped frame GPAs.
-    let rebuild_pt = |pt: &mut i686_pt::Builder,
-                      old_pt_gpa: u64,
-                      extra_flags: u32,
-                      phys_map: &std::collections::HashMap<u64, usize>|
-     -> u32 {
-        let new_pt_offset = pt.bytes.len();
-        pt.bytes.resize(new_pt_offset + page_size, 0);
-        let new_pt_gpa = (pd_base_gpa + new_pt_offset) as u32;
-        for pti in 0..1024usize {
-            let pte = read_u32(old_pt_gpa + pti as u64 * 4);
-            if (pte & PAGE_PRESENT as u32) == 0 {
-                continue;
-            }
-            let old_frame = (pte & ADDR_MASK) as u64;
-            let Some(&new_gpa) = phys_map.get(&old_frame) else {
-                continue;
-            };
-            let mut flags = (pte & 0xFFF) | extra_flags;
-            // Mark writable or already-CoW pages as CoW (read-only + AVL bit).
-            if (flags & RW_FLAGS & !PTE_COW) != 0 || (flags & PTE_COW) != 0 {
-                flags = (flags & !(hyperlight_common::vmem::i686_guest::PAGE_RW as u32)) | PTE_COW;
-            }
-            let off = new_pt_offset + pti * 4;
-            pt.bytes[off..off + 4].copy_from_slice(&((new_gpa as u32) | flags).to_le_bytes());
-        }
-        new_pt_gpa
-    };
-
-    // Resolve a VA through a PD to its physical frame.
-    let resolve_through_pd = |pd_gpa: u64, va: u64| -> u64 {
-        let pdi = (va >> 22) & 0x3FF;
-        let pde = read_u32(pd_gpa + pdi * 4);
-        if (pde & PAGE_PRESENT as u32) == 0 {
-            return va;
-        }
-        let pti = (va >> 12) & 0x3FF;
-        let pte = read_u32((pde & ADDR_MASK) as u64 + pti * 4);
-        if (pte & PAGE_PRESENT as u32) == 0 {
-            return va;
-        }
-        (pte & ADDR_MASK) as u64
-    };
-
-    // Build kernel page tables (lower 256 PD entries) from the first root.
-    let first_root = root_pt_gpas.first().copied().ok_or_else(|| {
-        crate::new_error!("compact_i686_snapshot called with no page directory roots")
-    })?;
-    let mut kernel_pdes = [0u32; 256];
-    for (pdi, kernel_pde) in kernel_pdes.iter_mut().enumerate() {
-        let pde = read_u32(first_root + pdi as u64 * 4);
-        if (pde & PAGE_PRESENT as u32) == 0 {
-            continue;
-        }
-        let new_pt_gpa = rebuild_pt(&mut pt, (pde & ADDR_MASK) as u64, 0, phys_seen);
-        *kernel_pde = (pde & 0xFFF) | new_pt_gpa;
-    }
-
-    // Fill in per-process PDs: kernel half (shared) + user half (per-process).
-    for (root_idx, &root) in root_pt_gpas.iter().enumerate() {
-        let pd_offset = root_idx * page_size;
-        // Copy kernel PDEs (lower 256 entries) into this PD.
-        for (pdi, &kpde) in kernel_pdes.iter().enumerate() {
-            if kpde != 0 {
-                pt.bytes[pd_offset + pdi * 4..pd_offset + pdi * 4 + 4]
-                    .copy_from_slice(&kpde.to_le_bytes());
-            }
-        }
-        // Rebuild user PDEs (upper 256 entries).
-        for pdi in 256..1024usize {
-            let pde = read_u32(root + pdi as u64 * 4);
-            if (pde & PAGE_PRESENT as u32) == 0 {
-                continue;
-            }
-            let user = PAGE_USER as u32;
-            let pt_gpa_raw = (pde & ADDR_MASK) as u64;
-            let pt_gpa = resolve_through_pd(first_root, pt_gpa_raw);
-            let new_pt_gpa = rebuild_pt(&mut pt, pt_gpa, user, phys_seen);
-            let fixed_pde = (pde & 0xFFF) | new_pt_gpa | user;
-            pt.bytes[pd_offset + pdi * 4..pd_offset + pdi * 4 + 4]
-                .copy_from_slice(&fixed_pde.to_le_bytes());
-        }
-    }
-
-    // Map scratch and snapshot identity regions into every PD.
-    for ri in 0..n_roots {
-        let pd_off = ri * page_size;
-        pt.map_range(
-            pd_off,
-            scratch_gpa,
-            scratch_gpa,
-            scratch_size as u64,
-            RW_FLAGS,
-        );
-
-        let snapshot_end = SandboxMemoryLayout::BASE_ADDRESS + snapshot_memory.len();
-        let snapshot_pages = (snapshot_end - SandboxMemoryLayout::BASE_ADDRESS) / page_size;
-        for pi in 0..snapshot_pages {
-            let gpa = (SandboxMemoryLayout::BASE_ADDRESS + pi * page_size) as u64;
-            let pdi = ((gpa >> 22) & 0x3FF) as usize;
-            let pti = ((gpa >> 12) & 0x3FF) as usize;
-            let pt_off = pt.ensure_pt(pd_off, pdi, RW_FLAGS);
-            let pte_off = pt_off + pti * 4;
-            if pt.read_u32(pte_off) & PAGE_PRESENT as u32 == 0 {
-                pt.bytes[pte_off..pte_off + 4]
-                    .copy_from_slice(&((gpa as u32) | RW_FLAGS).to_le_bytes());
-            }
-        }
-    }
-
-    Ok((snapshot_memory, pt.into_bytes()))
 }
 
 fn filtered_mappings<'a>(
@@ -662,64 +364,70 @@ fn filtered_mappings<'a>(
     layout: SandboxMemoryLayout,
     root_pts: &[u64],
     #[cfg(feature = "i686-guest")] cow_map: &std::collections::HashMap<u64, u64>,
-) -> Vec<(Mapping, &'a [u8])> {
-    #[cfg(not(feature = "i686-guest"))]
-    let mappings_iter: Vec<Mapping> = {
-        let Some(&root_pt) = root_pts.first() else {
-            return Vec::new();
-        };
+) -> Vec<(usize, Mapping, &'a [u8])> {
+    use std::collections::HashSet;
+    let mut all_mappings = Vec::new();
+    let mut seen_phys = HashSet::new();
+    let scratch_gva = scratch_base_gva(layout.get_scratch_size());
+
+    #[cfg_attr(not(feature = "i686-guest"), allow(unused_variables))]
+    for (root_idx, &root_pt) in root_pts.iter().enumerate() {
+        #[cfg(feature = "i686-guest")]
+        let op =
+            SharedMemoryPageTableBuffer::new(snap, scratch, layout, root_pt).with_cow_map(cow_map);
+        #[cfg(not(feature = "i686-guest"))]
         let op = SharedMemoryPageTableBuffer::new(snap, scratch, layout, root_pt);
-        unsafe {
+
+        #[cfg(not(feature = "i686-guest"))]
+        let iter = unsafe {
             hyperlight_common::vmem::virt_to_phys(&op, 0, hyperlight_common::layout::MAX_GVA as u64)
-        }
-        .collect()
-    };
+        };
+        #[cfg(feature = "i686-guest")]
+        let iter = unsafe {
+            hyperlight_common::vmem::i686_guest::virt_to_phys(
+                &op,
+                0,
+                hyperlight_common::layout::MAX_GVA as u64,
+            )
+        };
 
-    #[cfg(feature = "i686-guest")]
-    let mappings_iter: Vec<Mapping> = {
-        use std::collections::HashSet;
-        let mut mappings = Vec::new();
-        let mut seen_phys = HashSet::new();
-
-        let scratch_base_gva_val =
-            hyperlight_common::layout::scratch_base_gva(layout.get_scratch_size());
-        for &root_pt in root_pts {
-            let op = SharedMemoryPageTableBuffer::new(snap, scratch, layout, root_pt)
-                .with_cow_map(cow_map);
-            let root_mappings =
-                unsafe { hyperlight_common::vmem::i686_guest::virt_to_phys_all(&op) };
-            for m in root_mappings {
-                // Skip mappings whose VA is in the scratch region - these
-                // are identity-mapped helpers and would poison seen_phys for
-                // legitimate user mappings that share the same scratch PAs.
-                if m.virt_base >= scratch_base_gva_val {
+        for m in iter {
+            if m.virt_base >= scratch_gva {
+                continue;
+            }
+            #[cfg(not(feature = "i686-guest"))]
+            if m.virt_base >= hyperlight_common::layout::SNAPSHOT_PT_GVA_MIN as u64
+                && m.virt_base <= hyperlight_common::layout::SNAPSHOT_PT_GVA_MAX as u64
+            {
+                continue;
+            }
+            // On i686, kernel pages (shared across roots) are only
+            // collected from root 0. User pages are collected per-root
+            // with their root index for per-process PD isolation.
+            #[cfg(feature = "i686-guest")]
+            let effective_root = if m.virt_base < I686_USER_VA_START {
+                if root_idx != 0 {
                     continue;
                 }
-                if seen_phys.insert(m.phys_base) {
-                    mappings.push(m);
-                }
+                0
+            } else {
+                root_idx
+            };
+            #[cfg(not(feature = "i686-guest"))]
+            let effective_root = 0;
+
+            if seen_phys.insert(m.phys_base) {
+                all_mappings.push((effective_root, m));
             }
         }
-        mappings
-    };
+    }
 
-    mappings_iter
+    all_mappings
         .into_iter()
-        .filter_map(move |mapping| {
-            // the scratch map doesn't count
-            if mapping.virt_base >= scratch_base_gva(layout.get_scratch_size()) {
-                return None;
-            }
-            // neither does the mapping of the snapshot's own page tables
-            #[cfg(not(feature = "i686-guest"))]
-            if mapping.virt_base >= hyperlight_common::layout::SNAPSHOT_PT_GVA_MIN as u64
-                && mapping.virt_base <= hyperlight_common::layout::SNAPSHOT_PT_GVA_MAX as u64
-            {
-                return None;
-            }
+        .filter_map(move |(root_idx, mapping)| {
             let contents =
                 unsafe { guest_page(snap, scratch, regions, layout, mapping.phys_base) }?;
-            Some((mapping, contents))
+            Some((root_idx, mapping, contents))
         })
         .collect()
 }
@@ -745,24 +453,6 @@ unsafe fn guest_page<'a>(
         return None;
     }
     Some(&resolved.as_ref()[..PAGE_SIZE])
-}
-
-#[cfg(not(feature = "i686-guest"))]
-fn map_specials(pt_buf: &GuestPageTableBuffer, scratch_size: usize) {
-    // Map the scratch region
-    let mapping = Mapping {
-        phys_base: scratch_base_gpa(scratch_size),
-        virt_base: scratch_base_gva(scratch_size),
-        len: scratch_size as u64,
-        kind: MappingKind::Basic(BasicMapping {
-            readable: true,
-            writable: true,
-            // assume that the guest will map these pages elsewhere if
-            // it actually needs to execute from them
-            executable: false,
-        }),
-    };
-    unsafe { vmem::map(pt_buf, mapping) };
 }
 
 impl Snapshot {
@@ -822,13 +512,20 @@ impl Snapshot {
             .transpose()?;
 
         #[cfg(not(feature = "i686-guest"))]
+        use hyperlight_common::vmem;
+
         {
-            // Set up page table entries for the snapshot
-            let pt_buf = GuestPageTableBuffer::new(layout.get_pt_base_gpa() as usize);
+            use hyperlight_common::layout::scratch_base_gpa;
 
             use crate::mem::memory_region::{GuestMemoryRegion, MemoryRegionFlags};
+            use crate::mem::mgr::GuestPageTableBuffer;
 
-            // 1. Map the (ideally readonly) pages of snapshot data
+            #[cfg(not(feature = "i686-guest"))]
+            let pt_buf = GuestPageTableBuffer::<8>::new(layout.get_pt_base_gpa() as usize);
+            #[cfg(feature = "i686-guest")]
+            let pt_buf = GuestPageTableBuffer::<4>::new(layout.get_pt_base_gpa() as usize);
+
+            // Map snapshot memory regions (writable -> CoW, read-only -> Basic)
             for rgn in layout.get_memory_regions_::<GuestMemoryRegion>(())?.iter() {
                 let readable = rgn.flags.contains(MemoryRegionFlags::READ);
                 let executable = rgn.flags.contains(MemoryRegionFlags::EXECUTE);
@@ -851,19 +548,33 @@ impl Snapshot {
                     len: rgn.guest_region.len() as u64,
                     kind,
                 };
-                unsafe { vmem::map(&pt_buf, mapping) };
+                unsafe {
+                    #[cfg(not(feature = "i686-guest"))]
+                    vmem::map(&pt_buf, mapping);
+                    #[cfg(feature = "i686-guest")]
+                    hyperlight_common::vmem::i686_guest::map(&pt_buf, mapping);
+                }
             }
 
-            // 2. Map the special mappings
-            map_specials(&pt_buf, layout.get_scratch_size());
+            // Map the scratch region
+            let scratch_mapping = Mapping {
+                phys_base: scratch_base_gpa(layout.get_scratch_size()),
+                virt_base: scratch_base_gva(layout.get_scratch_size()),
+                len: layout.get_scratch_size() as u64,
+                kind: MappingKind::Basic(BasicMapping {
+                    readable: true,
+                    writable: true,
+                    executable: false,
+                }),
+            };
+            unsafe {
+                #[cfg(not(feature = "i686-guest"))]
+                vmem::map(&pt_buf, scratch_mapping);
+                #[cfg(feature = "i686-guest")]
+                hyperlight_common::vmem::i686_guest::map(&pt_buf, scratch_mapping);
+            }
 
             let pt_bytes = pt_buf.into_bytes();
-            layout.set_pt_size(pt_bytes.len())?;
-            memory.extend(&pt_bytes);
-        };
-        #[cfg(feature = "i686-guest")]
-        {
-            let pt_bytes = build_initial_i686_page_tables(&layout)?;
             layout.set_pt_size(pt_bytes.len())?;
             memory.extend(&pt_bytes);
         };
@@ -886,8 +597,6 @@ impl Snapshot {
             sregs: None,
             #[cfg(feature = "i686-guest")]
             separate_pt_bytes: Vec::new(),
-            #[cfg(feature = "i686-guest")]
-            n_pd_roots: 0,
             entrypoint: NextAction::Initialise(load_addr + entrypoint_va - base_va),
         })
     }
@@ -917,9 +626,9 @@ impl Snapshot {
         let mut phys_seen = HashMap::<u64, usize>::new();
         let memory = shared_mem.with_contents(|snap_c| {
             scratch_mem.with_contents(|scratch_c| {
-                // Build CoW resolution map (i686 only): maps original GPAs
-                // to their CoW'd scratch GPAs so the PT walker can read the
-                // actual page table data instead of stale snapshot copies.
+                // Phase 0 (i686 only): build a CoW resolution map so the
+                // PT walker reads CoW'd pages from scratch, not stale
+                // snapshot copies.
                 #[cfg(feature = "i686-guest")]
                 let cow_map = {
                     let kernel_root = root_pt_gpas.first().copied().ok_or_else(|| {
@@ -928,7 +637,9 @@ impl Snapshot {
                     build_cow_map(snap_c, scratch_c, layout, kernel_root)?
                 };
 
-                // Pass 1: collect live pages
+                // Phase 1: walk every PT root and collect live pages,
+                // tagged with which root they belong to (for per-process
+                // PD isolation on i686).
                 let live_pages = filtered_mappings(
                     snap_c,
                     scratch_c,
@@ -939,76 +650,120 @@ impl Snapshot {
                     &cow_map,
                 );
 
-                // Pass 2: copy live pages and build new page tables
+                // Phase 2: compact live pages into a dense snapshot blob
+                // and build new page tables with compacted GPAs.
                 // TODO: Look for opportunities to hugepage map
+                let mut snapshot_memory: Vec<u8> = Vec::new();
                 #[cfg(not(feature = "i686-guest"))]
-                let (snapshot_memory, pt_bytes) = {
-                    let mut snapshot_memory: Vec<u8> = Vec::new();
-                    let pt_buf = GuestPageTableBuffer::new(layout.get_pt_base_gpa() as usize);
-                    for (mapping, contents) in live_pages {
-                        let kind = match mapping.kind {
-                            MappingKind::Cow(cm) => MappingKind::Cow(cm),
-                            MappingKind::Basic(bm) if bm.writable => MappingKind::Cow(CowMapping {
-                                readable: bm.readable,
-                                executable: bm.executable,
-                            }),
-                            MappingKind::Basic(bm) => MappingKind::Basic(BasicMapping {
-                                readable: bm.readable,
-                                writable: false,
-                                executable: bm.executable,
-                            }),
-                            MappingKind::Unmapped => continue,
-                        };
-                        let new_gpa = phys_seen.entry(mapping.phys_base).or_insert_with(|| {
-                            let new_offset = snapshot_memory.len();
-                            snapshot_memory.extend(contents);
-                            new_offset + SandboxMemoryLayout::BASE_ADDRESS
-                        });
-                        let mapping = Mapping {
-                            phys_base: *new_gpa as u64,
-                            virt_base: mapping.virt_base,
-                            len: PAGE_SIZE as u64,
-                            kind,
-                        };
-                        unsafe { vmem::map(&pt_buf, mapping) };
+                let pt_buf = GuestPageTableBuffer::<8>::new(layout.get_pt_base_gpa() as usize);
+                #[cfg(feature = "i686-guest")]
+                let pt_buf = {
+                    let buf = GuestPageTableBuffer::<4>::new(layout.get_pt_base_gpa() as usize);
+                    for _ in 1..root_pt_gpas.len() {
+                        unsafe { buf.alloc_table() };
                     }
-                    map_specials(&pt_buf, layout.get_scratch_size());
-                    let pt_data = pt_buf.into_bytes();
-                    layout.set_pt_size(pt_data.len())?;
-                    snapshot_memory.extend(&pt_data);
-                    (snapshot_memory, Vec::new())
+                    buf
                 };
+
+                for (_root_idx, mapping, contents) in live_pages {
+                    let kind = compaction_kind(&mapping.kind);
+                    if matches!(kind, MappingKind::Unmapped) {
+                        continue;
+                    }
+                    let new_gpa = phys_seen.entry(mapping.phys_base).or_insert_with(|| {
+                        let new_offset = snapshot_memory.len();
+                        snapshot_memory.extend(contents);
+                        new_offset + SandboxMemoryLayout::BASE_ADDRESS
+                    });
+
+                    #[cfg(feature = "i686-guest")]
+                    pt_buf.set_root_offset(_root_idx * PAGE_SIZE);
+
+                    let new_mapping = Mapping {
+                        phys_base: *new_gpa as u64,
+                        virt_base: mapping.virt_base,
+                        len: PAGE_SIZE as u64,
+                        kind,
+                    };
+                    unsafe {
+                        #[cfg(not(feature = "i686-guest"))]
+                        vmem::map(&pt_buf, new_mapping);
+                        #[cfg(feature = "i686-guest")]
+                        hyperlight_common::vmem::i686_guest::map(&pt_buf, new_mapping);
+                    }
+                }
+                #[cfg(feature = "i686-guest")]
+                pt_buf.set_root_offset(0);
+
+                // Phase 3: map the scratch region into the page tables.
+                let scratch_gpa =
+                    hyperlight_common::layout::scratch_base_gpa(layout.get_scratch_size());
+                let scratch_gva = scratch_base_gva(layout.get_scratch_size());
+                let scratch_len = layout.get_scratch_size() as u64;
+                unsafe {
+                    #[cfg(not(feature = "i686-guest"))]
+                    vmem::map(
+                        &pt_buf,
+                        Mapping {
+                            phys_base: scratch_gpa,
+                            virt_base: scratch_gva,
+                            len: scratch_len,
+                            kind: MappingKind::Basic(BasicMapping {
+                                readable: true,
+                                writable: true,
+                                executable: false,
+                            }),
+                        },
+                    );
+                    #[cfg(feature = "i686-guest")]
+                    hyperlight_common::vmem::i686_guest::map(
+                        &pt_buf,
+                        Mapping {
+                            phys_base: scratch_gpa,
+                            virt_base: scratch_gva,
+                            len: scratch_len,
+                            kind: MappingKind::Basic(BasicMapping {
+                                readable: true,
+                                writable: true,
+                                executable: false,
+                            }),
+                        },
+                    );
+                }
+
+                // Phase 4 (i686 only): replicate kernel PDEs and scratch
+                // into all other PD roots, then mark user PDEs with
+                // PAGE_USER for ring-3 accessibility.
+                #[cfg(feature = "i686-guest")]
+                unsafe {
+                    pt_buf.finalize_multi_root(
+                        root_pt_gpas.len(),
+                        I686_USER_PDE_START,
+                        scratch_gpa,
+                        scratch_gva,
+                        scratch_len,
+                    );
+                }
+
+                // Phase 5: finalize PT bytes.
+                let pt_data = pt_buf.into_bytes();
+                layout.set_pt_size(pt_data.len())?;
 
                 #[cfg(feature = "i686-guest")]
-                let (snapshot_memory, pt_bytes) = {
-                    let (mem, pt) = compact_i686_snapshot(
-                        snap_c,
-                        scratch_c,
-                        layout,
-                        live_pages,
-                        root_pt_gpas,
-                        &cow_map,
-                        &mut phys_seen,
-                    )?;
-                    layout.set_pt_size(pt.len())?;
-                    (mem, pt)
-                };
-
-                Ok::<(Vec<u8>, Vec<u8>), crate::HyperlightError>((snapshot_memory, pt_bytes))
+                {
+                    Ok::<_, crate::HyperlightError>((snapshot_memory, pt_data.into_vec()))
+                }
+                #[cfg(not(feature = "i686-guest"))]
+                {
+                    snapshot_memory.extend(&pt_data);
+                    Ok::<_, crate::HyperlightError>(snapshot_memory)
+                }
             })
         })???;
         #[cfg(feature = "i686-guest")]
         let (memory, separate_pt_bytes) = memory;
-        #[cfg(not(feature = "i686-guest"))]
-        let (memory, _) = memory;
         layout.set_snapshot_size(memory.len());
 
-        // For i686, keep the regions so the RAMFS and other map_file_cow
-        // mappings are accessible after restore. For x86_64, we do not
-        // need the original regions anymore, as any uses of them in the
-        // guest have been incorporated into the snapshot properly.
-        #[cfg(feature = "i686-guest")]
-        let regions = regions;
         #[cfg(not(feature = "i686-guest"))]
         let regions = Vec::new();
 
@@ -1024,8 +779,6 @@ impl Snapshot {
             sregs: Some(sregs),
             #[cfg(feature = "i686-guest")]
             separate_pt_bytes,
-            #[cfg(feature = "i686-guest")]
-            n_pd_roots: root_pt_gpas.len(),
             entrypoint,
         })
     }
@@ -1077,15 +830,6 @@ impl Snapshot {
         &self.separate_pt_bytes
     }
 
-    /// Number of per-process page-directory roots captured in this
-    /// snapshot. Used by `restore_snapshot` to rewrite the scratch
-    /// PD-roots bookkeeping so a later `snapshot()` call doesn't
-    /// observe a stale zero count.
-    #[cfg(feature = "i686-guest")]
-    pub(crate) fn n_pd_roots(&self) -> usize {
-        self.n_pd_roots
-    }
-
     pub(crate) fn entrypoint(&self) -> NextAction {
         self.entrypoint
     }
@@ -1117,7 +861,7 @@ mod tests {
     const SIMPLE_PT_BASE: usize = PAGE_SIZE + SandboxMemoryLayout::BASE_ADDRESS;
 
     fn make_simple_pt_mem(contents: &[u8]) -> SnapshotSharedMemory<ExclusiveSharedMemory> {
-        let pt_buf = GuestPageTableBuffer::new(SIMPLE_PT_BASE);
+        let pt_buf = GuestPageTableBuffer::<8>::new(SIMPLE_PT_BASE);
         let mapping = Mapping {
             phys_base: SandboxMemoryLayout::BASE_ADDRESS as u64,
             virt_base: SandboxMemoryLayout::BASE_ADDRESS as u64,
@@ -1129,7 +873,18 @@ mod tests {
             }),
         };
         unsafe { vmem::map(&pt_buf, mapping) };
-        super::map_specials(&pt_buf, PAGE_SIZE);
+        // Map the scratch region
+        let scratch_mapping = Mapping {
+            phys_base: hyperlight_common::layout::scratch_base_gpa(PAGE_SIZE),
+            virt_base: hyperlight_common::layout::scratch_base_gva(PAGE_SIZE),
+            len: PAGE_SIZE as u64,
+            kind: MappingKind::Basic(BasicMapping {
+                readable: true,
+                writable: true,
+                executable: false,
+            }),
+        };
+        unsafe { vmem::map(&pt_buf, scratch_mapping) };
         let pt_bytes = pt_buf.into_bytes();
 
         let mut snapshot_mem = vec![0u8; PAGE_SIZE + pt_bytes.len()];
@@ -1206,338 +961,139 @@ mod tests {
 
 #[cfg(test)]
 #[cfg(feature = "i686-guest")]
-mod tests {
-    use std::collections::HashMap;
+mod i686_tests {
+    use hyperlight_common::vmem::{
+        BasicMapping, CowMapping, Mapping, MappingKind, PAGE_SIZE, i686_guest,
+    };
 
-    use hyperlight_common::vmem::i686_guest::{PAGE_ACCESSED, PAGE_PRESENT, PAGE_RW};
-    use hyperlight_common::vmem::{BasicMapping, Mapping, MappingKind};
+    use crate::mem::mgr::GuestPageTableBuffer;
 
-    use super::i686_pt::{self, ADDR_MASK, PTE_COW, RW_FLAGS};
-    use crate::mem::layout::SandboxMemoryLayout;
-    use crate::mem::memory_region::{GuestMemoryRegion, MemoryRegionFlags};
-    use crate::sandbox::SandboxConfiguration;
-
-    const PAGE_SIZE: usize = 4096;
-
-    struct TestEnv {
-        layout: SandboxMemoryLayout,
-        snap: Vec<u8>,
-        scratch: Vec<u8>,
-        pt_base: u64,
-    }
-
-    fn make_env(pt_bytes: &[u8]) -> TestEnv {
-        let mut cfg = SandboxConfiguration::default();
-        cfg.set_heap_size(PAGE_SIZE as u64);
-        let layout = SandboxMemoryLayout::new(cfg, PAGE_SIZE, PAGE_SIZE, None).unwrap();
-        let scratch_size = layout.get_scratch_size();
-        let snapshot_size = layout.get_memory_size().unwrap();
-        let snap = vec![0u8; snapshot_size];
-        let mut scratch = vec![0u8; scratch_size];
-
-        let pt_scratch_offset = layout.get_pt_base_scratch_offset();
-        assert!(pt_scratch_offset + pt_bytes.len() <= scratch.len(),);
-
-        scratch[pt_scratch_offset..pt_scratch_offset + pt_bytes.len()].copy_from_slice(pt_bytes);
-
-        TestEnv {
-            snap,
-            scratch,
-            layout,
-            pt_base: layout.get_pt_base_gpa(),
-        }
-    }
-
-    /// Decode a PTE from raw page table bytes at the given VA.
-    fn read_pte(pt_bytes: &[u8], pt_base_gpa: usize, va: u64) -> u32 {
-        let pdi = ((va >> 22) & 0x3FF) as usize;
-        let pti = ((va >> 12) & 0x3FF) as usize;
-        let pde = u32::from_le_bytes(pt_bytes[pdi * 4..pdi * 4 + 4].try_into().unwrap());
-        assert_ne!(
-            pde & PAGE_PRESENT as u32,
-            0,
-            "PDE for VA {va:#x} not present"
-        );
-        let pt_offset = (pde & ADDR_MASK) as usize - pt_base_gpa;
-        u32::from_le_bytes(
-            pt_bytes[pt_offset + pti * 4..pt_offset + pti * 4 + 4]
-                .try_into()
-                .unwrap(),
-        )
-    }
+    const PT_BASE: usize = 0x10_0000;
 
     #[test]
-    fn builder_map_page_writes_pde_and_pte() {
-        let pd_base = 0x10_0000;
-        let mut b = i686_pt::Builder::new(pd_base);
-        let va = 0x0040_0000u64; // PD index 1, PT index 0
-        let pa = 0x0020_0000u64;
-        b.map_page(0, va, pa, RW_FLAGS);
-
-        let pde = b.read_u32(4);
-        assert_ne!(pde & PAGE_PRESENT as u32, 0, "PDE should be present");
-        assert_eq!((pde & ADDR_MASK) as usize, pd_base + PAGE_SIZE);
-
-        let pte = b.read_u32(PAGE_SIZE); // PT index 0
-        assert_eq!(pte & ADDR_MASK, pa as u32);
-        assert_eq!(pte & 0xFFF, RW_FLAGS);
-
-        // Map a second page in the same 4MB region - PT must be reused
-        b.map_page(0, 0x0040_1000, 0x20_1000, RW_FLAGS);
-        assert_eq!(b.bytes.len(), 2 * PAGE_SIZE, "PT should be reused");
-        let pte1 = b.read_u32(PAGE_SIZE + 4);
-        assert_eq!(pte1 & ADDR_MASK, 0x20_1000);
-    }
-
-    #[test]
-    fn builder_map_range_crosses_pde_boundary() {
-        let pd_base = 0x10_0000;
-        let mut b = i686_pt::Builder::new(pd_base);
-        // Last page of PD[0] to first page of PD[1]
-        let va_start = 0x003F_F000u64;
-        let pa_start = 0x5_0000u64;
-        b.map_range(0, va_start, pa_start, 2 * PAGE_SIZE as u64, RW_FLAGS);
-
-        assert_eq!(b.bytes.len(), 3 * PAGE_SIZE, "should allocate 2 PTs");
-
-        // Verify PTE contents across the boundary
-        let pt0_offset = (b.read_u32(0) & ADDR_MASK) as usize - pd_base;
-        let pte_last = b.read_u32(pt0_offset + 0x3FF * 4); // last entry in PT[0]
-        assert_eq!(pte_last & ADDR_MASK, pa_start as u32);
-
-        let pt1_offset = (b.read_u32(4) & ADDR_MASK) as usize - pd_base;
-        let pte_first = b.read_u32(pt1_offset); // first entry in PT[1]
-        assert_eq!(pte_first & ADDR_MASK, (pa_start + PAGE_SIZE as u64) as u32);
-    }
-
-    #[test]
-    fn builder_cow_flags_preserved_pde_stays_rw() {
-        let pd_base = 0x10_0000;
-        let mut b = i686_pt::Builder::new(pd_base);
-        let cow_flags = PAGE_PRESENT as u32 | PAGE_ACCESSED as u32 | PTE_COW;
-        b.map_page(0, 0x1000, 0x2000, cow_flags);
-
-        let pti = ((0x1000u64 >> 12) & 0x3FF) as usize;
-        let pte = b.read_u32(PAGE_SIZE + pti * 4);
-        assert_ne!(pte & PTE_COW, 0, "CoW bit should be set on PTE");
-        assert_eq!(pte & PAGE_RW as u32, 0, "RW should be clear for CoW PTE");
-
-        // PDE must remain RW so the CPU can walk the PT
-        let pde = b.read_u32(0);
-        assert_ne!(
-            pde & PAGE_RW as u32,
-            0,
-            "PDE must stay RW even for CoW PTEs"
-        );
-    }
-
-    #[test]
-    fn builder_multiple_pds_independent() {
-        let pd_base = 0x10_0000;
-        let mut b = i686_pt::Builder::with_pds(pd_base, 2);
-        b.map_page(0, 0x1000, 0xA000, RW_FLAGS);
-        b.map_page(PAGE_SIZE, 0x1000, 0xB000, RW_FLAGS);
-
-        // PTs start after the 2 PD pages
-        let pde0 = b.read_u32(0);
-        let pde1 = b.read_u32(PAGE_SIZE);
-        assert_eq!(
-            (pde0 & ADDR_MASK) as usize,
-            pd_base + 2 * PAGE_SIZE,
-            "PD[0] PT should be at first slot after PDs"
-        );
-        assert_eq!(
-            (pde1 & ADDR_MASK) as usize,
-            pd_base + 3 * PAGE_SIZE,
-            "PD[1] PT should be at second slot after PDs"
-        );
-
-        // Verify the PTEs point to the correct PAs
-        let pti = ((0x1000u64 >> 12) & 0x3FF) as usize;
-        let pte0 = b.read_u32(2 * PAGE_SIZE + pti * 4);
-        let pte1 = b.read_u32(3 * PAGE_SIZE + pti * 4);
-        assert_eq!(pte0 & ADDR_MASK, 0xA000);
-        assert_eq!(pte1 & ADDR_MASK, 0xB000);
-    }
-
-    #[test]
-    fn cow_map_finds_scratch_backed_pages() {
-        let cfg = SandboxConfiguration::default();
-        let scratch_size = cfg.get_scratch_size();
-        let scratch_base = hyperlight_common::layout::scratch_base_gpa(scratch_size);
-        let layout = SandboxMemoryLayout::new(cfg, PAGE_SIZE, PAGE_SIZE, None).unwrap();
-        let pt_base = layout.get_pt_base_gpa() as usize;
-
-        let mut b = i686_pt::Builder::new(pt_base);
-        let cow_frame = scratch_base + 0x5000;
-        let cow_va = 0x1000u64;
-        b.map_page(0, cow_va, cow_frame, RW_FLAGS);
-
-        let TestEnv {
-            snap,
-            scratch,
-            layout,
-            pt_base,
-        } = make_env(&b.into_bytes());
-        let cow_map = super::build_cow_map(&snap, &scratch, layout, pt_base).unwrap();
-
-        assert_eq!(cow_map.len(), 1);
-        assert_eq!(cow_map[&cow_va], cow_frame);
-    }
-
-    #[test]
-    fn cow_map_filtering() {
-        let cfg = SandboxConfiguration::default();
-        let scratch_size = cfg.get_scratch_size();
-        let scratch_base = hyperlight_common::layout::scratch_base_gpa(scratch_size);
-        let layout = SandboxMemoryLayout::new(cfg, PAGE_SIZE, PAGE_SIZE, None).unwrap();
-        let pt_base = layout.get_pt_base_gpa() as usize;
-        let mem_size = layout.get_memory_size().unwrap();
-
-        let mut b = i686_pt::Builder::new(pt_base);
-        b.map_page(
-            0,
-            0x1000,
-            SandboxMemoryLayout::BASE_ADDRESS as u64,
-            RW_FLAGS,
-        );
-        let far_va = (mem_size as u64).next_multiple_of(0x0040_0000);
-        b.map_page(0, far_va, scratch_base + 0x1000, RW_FLAGS);
-
-        let TestEnv {
-            snap,
-            scratch,
-            layout,
-            pt_base,
-        } = make_env(&b.into_bytes());
-        let cow_map = super::build_cow_map(&snap, &scratch, layout, pt_base).unwrap();
-
-        assert!(
-            cow_map.is_empty(),
-            "neither non-scratch nor beyond-mem-size VAs should appear"
-        );
-    }
-
-    #[test]
-    fn cow_map_empty_pd() {
-        let cfg = SandboxConfiguration::default();
-        let layout = SandboxMemoryLayout::new(cfg, PAGE_SIZE, PAGE_SIZE, None).unwrap();
-        let pt_base = layout.get_pt_base_gpa() as usize;
-        let b = i686_pt::Builder::new(pt_base);
-
-        let TestEnv {
-            snap,
-            scratch,
-            layout,
-            pt_base,
-        } = make_env(&b.into_bytes());
-        let cow_map = super::build_cow_map(&snap, &scratch, layout, pt_base).unwrap();
-
-        assert!(cow_map.is_empty());
-    }
-
-    #[test]
-    fn initial_pt_scratch_rw_and_region_flags() {
-        let cfg = SandboxConfiguration::default();
-        let layout = SandboxMemoryLayout::new(cfg, PAGE_SIZE, PAGE_SIZE, None).unwrap();
-
-        let pt_bytes = super::build_initial_i686_page_tables(&layout).unwrap();
-        let pt_base = layout.get_pt_base_gpa() as usize;
-
-        // Scratch must be mapped as RW without CoW
-        let scratch_size = layout.get_scratch_size();
-        let scratch_gva = hyperlight_common::layout::scratch_base_gva(scratch_size);
-        let scratch_pte = read_pte(&pt_bytes, pt_base, scratch_gva);
-        assert_ne!(scratch_pte & PAGE_PRESENT as u32, 0);
-        assert_ne!(scratch_pte & PAGE_RW as u32, 0, "scratch must be writable");
-        assert_eq!(scratch_pte & PTE_COW, 0, "scratch must not be CoW");
-
-        // Verify region permissions: writable -> CoW, read-only -> no CoW
-        let regions = layout.get_memory_regions_::<GuestMemoryRegion>(()).unwrap();
-
-        for rgn in &regions {
-            let is_writable = rgn.flags.contains(MemoryRegionFlags::WRITE);
-            let va = rgn.guest_region.start as u64;
-            let pte = read_pte(&pt_bytes, pt_base, va);
-            assert_ne!(pte & PAGE_PRESENT as u32, 0);
-            if is_writable {
-                assert_ne!(pte & PTE_COW, 0, "writable region at {va:#x} should be CoW");
-                assert_eq!(pte & PAGE_RW as u32, 0, "CoW at {va:#x} must clear RW");
-            } else {
-                assert_eq!(pte & PTE_COW, 0, "RO region at {va:#x} must not be CoW");
-            }
-        }
-    }
-
-    #[test]
-    fn compact_deduplicates_shared_physical_pages() {
-        let shared_phys = 0x2000u64;
-        let page_data = vec![0xAAu8; PAGE_SIZE];
-
-        let make_mapping = |virt_base: u64| Mapping {
-            phys_base: shared_phys,
-            virt_base,
+    fn map_single_page() {
+        let pt = GuestPageTableBuffer::<4>::new(PT_BASE);
+        let mapping = Mapping {
+            phys_base: 0x2000,
+            virt_base: 0x1000,
             len: PAGE_SIZE as u64,
             kind: MappingKind::Basic(BasicMapping {
                 readable: true,
                 writable: true,
-                executable: false,
+                executable: true,
             }),
         };
+        unsafe { i686_guest::map(&pt, mapping) };
 
-        let TestEnv {
-            snap,
-            scratch,
-            layout,
-            pt_base,
-        } = make_env(&[0u8; PAGE_SIZE]);
-
-        let cow_map = HashMap::new();
-        let mut phys_seen = HashMap::new();
-
-        let live_pages: Vec<(Mapping, &[u8])> = vec![
-            (make_mapping(0x1000), &page_data),
-            (make_mapping(0x5000), &page_data),
-        ];
-
-        let (snapshot_mem, _pt_bytes) = super::compact_i686_snapshot(
-            &snap,
-            &scratch,
-            layout,
-            live_pages,
-            &[pt_base],
-            &cow_map,
-            &mut phys_seen,
-        )
-        .unwrap();
-
-        assert_eq!(
-            snapshot_mem.len(),
-            PAGE_SIZE,
-            "shared physical page should be deduplicated"
-        );
+        let results: Vec<_> =
+            unsafe { i686_guest::virt_to_phys(&pt, 0x1000, PAGE_SIZE as u64) }.collect();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].phys_base, 0x2000);
+        assert_eq!(results[0].virt_base, 0x1000);
+        assert!(matches!(
+            results[0].kind,
+            MappingKind::Basic(BasicMapping { writable: true, .. })
+        ));
     }
 
     #[test]
-    fn compact_empty_roots_returns_error() {
-        let TestEnv {
-            snap,
-            scratch,
-            layout,
-            ..
-        } = make_env(&[0u8; PAGE_SIZE]);
-        let cow_map = HashMap::new();
-        let mut phys_seen = HashMap::new();
+    fn map_cow_page() {
+        let pt = GuestPageTableBuffer::<4>::new(PT_BASE);
+        let mapping = Mapping {
+            phys_base: 0x3000,
+            virt_base: 0x2000,
+            len: PAGE_SIZE as u64,
+            kind: MappingKind::Cow(CowMapping {
+                readable: true,
+                executable: true,
+            }),
+        };
+        unsafe { i686_guest::map(&pt, mapping) };
 
-        let result = super::compact_i686_snapshot(
-            &snap,
-            &scratch,
-            layout,
-            Vec::new(),
-            &[],
-            &cow_map,
-            &mut phys_seen,
-        );
-        assert!(result.is_err(), "empty root_pt_gpas should return an error");
+        let results: Vec<_> =
+            unsafe { i686_guest::virt_to_phys(&pt, 0x2000, PAGE_SIZE as u64) }.collect();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].phys_base, 0x3000);
+        assert!(matches!(results[0].kind, MappingKind::Cow(_)));
+    }
+
+    #[test]
+    fn map_multiple_pages_across_pd_boundary() {
+        let pt = GuestPageTableBuffer::<4>::new(PT_BASE);
+        // Map pages spanning a 4MB PD boundary (PD[0] -> PD[1])
+        let va_start = 0x003F_F000u64; // last page of PD[0]
+        let pa_start = 0x5000u64;
+        let mapping = Mapping {
+            phys_base: pa_start,
+            virt_base: va_start,
+            len: 2 * PAGE_SIZE as u64,
+            kind: MappingKind::Basic(BasicMapping {
+                readable: true,
+                writable: false,
+                executable: true,
+            }),
+        };
+        unsafe { i686_guest::map(&pt, mapping) };
+
+        let results: Vec<_> =
+            unsafe { i686_guest::virt_to_phys(&pt, va_start, 2 * PAGE_SIZE as u64) }.collect();
+        assert_eq!(results.len(), 2);
+        assert_eq!(results[0].phys_base, pa_start);
+        assert_eq!(results[0].virt_base, va_start);
+        assert_eq!(results[1].phys_base, pa_start + PAGE_SIZE as u64);
+        assert_eq!(results[1].virt_base, va_start + PAGE_SIZE as u64);
+    }
+
+    #[test]
+    fn virt_to_phys_unmapped_returns_empty() {
+        let pt = GuestPageTableBuffer::<4>::new(PT_BASE);
+        let results: Vec<_> =
+            unsafe { i686_guest::virt_to_phys(&pt, 0x1000, PAGE_SIZE as u64) }.collect();
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn map_reuses_existing_page_table() {
+        let pt = GuestPageTableBuffer::<4>::new(PT_BASE);
+        // Map two pages in the same 4MB region (same PD entry)
+        unsafe {
+            i686_guest::map(
+                &pt,
+                Mapping {
+                    phys_base: 0x1000,
+                    virt_base: 0x1000,
+                    len: PAGE_SIZE as u64,
+                    kind: MappingKind::Basic(BasicMapping {
+                        readable: true,
+                        writable: true,
+                        executable: true,
+                    }),
+                },
+            );
+            i686_guest::map(
+                &pt,
+                Mapping {
+                    phys_base: 0x5000,
+                    virt_base: 0x5000,
+                    len: PAGE_SIZE as u64,
+                    kind: MappingKind::Basic(BasicMapping {
+                        readable: true,
+                        writable: true,
+                        executable: true,
+                    }),
+                },
+            );
+        }
+        // Both should be visible
+        let r1: Vec<_> =
+            unsafe { i686_guest::virt_to_phys(&pt, 0x1000, PAGE_SIZE as u64) }.collect();
+        let r2: Vec<_> =
+            unsafe { i686_guest::virt_to_phys(&pt, 0x5000, PAGE_SIZE as u64) }.collect();
+        assert_eq!(r1.len(), 1);
+        assert_eq!(r2.len(), 1);
+        assert_eq!(r1[0].phys_base, 0x1000);
+        assert_eq!(r2[0].phys_base, 0x5000);
+        // Should have allocated: 1 PD (pre-existing) + 1 PT = 2 pages total
+        assert_eq!(pt.size(), 2 * PAGE_SIZE);
     }
 }

--- a/src/hyperlight_host/src/sandbox/snapshot.rs
+++ b/src/hyperlight_host/src/sandbox/snapshot.rs
@@ -189,10 +189,6 @@ pub(crate) struct SharedMemoryPageTableBuffer<'a> {
     scratch: &'a [u8],
     layout: SandboxMemoryLayout,
     root: u64,
-    /// CoW resolution map: maps snapshot GPAs to their CoW'd scratch GPAs.
-    /// Built by walking the kernel PD to find pages that were CoW'd during boot.
-    #[cfg(feature = "i686-guest")]
-    cow_map: Option<&'a std::collections::HashMap<u64, u64>>,
 }
 
 impl<'a> SharedMemoryPageTableBuffer<'a> {
@@ -207,15 +203,7 @@ impl<'a> SharedMemoryPageTableBuffer<'a> {
             scratch,
             layout,
             root,
-            #[cfg(feature = "i686-guest")]
-            cow_map: None,
         }
-    }
-
-    #[cfg(feature = "i686-guest")]
-    fn with_cow_map(mut self, cow_map: &'a std::collections::HashMap<u64, u64>) -> Self {
-        self.cow_map = Some(cow_map);
-        self
     }
 }
 impl<'a> hyperlight_common::vmem::TableReadOps for SharedMemoryPageTableBuffer<'a> {
@@ -224,20 +212,6 @@ impl<'a> hyperlight_common::vmem::TableReadOps for SharedMemoryPageTableBuffer<'
         addr + offset
     }
     unsafe fn read_entry(&self, addr: u64) -> vmem::PageTableEntry {
-        // For i686: if the GPA was CoW'd, read from the scratch copy instead.
-        #[cfg(feature = "i686-guest")]
-        let addr = {
-            let page_gpa = addr & 0xFFFFF000;
-            if let Some(map) = self.cow_map {
-                if let Some(&scratch_gpa) = map.get(&page_gpa) {
-                    scratch_gpa + (addr & 0xFFF)
-                } else {
-                    addr
-                }
-            } else {
-                addr
-            }
-        };
         let memoff = access_gpa(self.snap, self.scratch, self.layout, addr);
         let pte_size = core::mem::size_of::<vmem::PageTableEntry>();
         let Some(pte_bytes) = memoff.and_then(|(mem, off)| mem.get(off..off + pte_size)) else {
@@ -263,32 +237,6 @@ impl<'a> core::convert::AsRef<SharedMemoryPageTableBuffer<'a>> for SharedMemoryP
     fn as_ref(&self) -> &Self {
         self
     }
-}
-
-/// Build a CoW resolution map by walking a kernel PD.
-/// For each PTE that maps a VA in [0, MEMORY_SIZE) to a PA in scratch,
-/// record: original_gpa -> scratch_gpa.
-#[cfg(feature = "i686-guest")]
-fn build_cow_map(
-    snap: &[u8],
-    scratch: &[u8],
-    layout: SandboxMemoryLayout,
-    kernel_root: u64,
-) -> crate::Result<std::collections::HashMap<u64, u64>> {
-    use hyperlight_common::layout::scratch_base_gpa;
-    let mut cow_map = std::collections::HashMap::new();
-    let scratch_base = scratch_base_gpa(layout.get_scratch_size());
-    let scratch_end = scratch_base + layout.get_scratch_size() as u64;
-    let mem_size = layout.get_memory_size()? as u64;
-
-    let op = SharedMemoryPageTableBuffer::new(snap, scratch, layout, kernel_root);
-    let mappings = unsafe { vmem::virt_to_phys(&op, 0, hyperlight_common::layout::MAX_GVA as u64) };
-    for m in mappings {
-        if m.virt_base < mem_size && m.phys_base >= scratch_base && m.phys_base < scratch_end {
-            cow_map.insert(m.virt_base, m.phys_base);
-        }
-    }
-    Ok(cow_map)
 }
 
 /// On i686, PDE index where user-space begins. Kernel occupies PDEs
@@ -324,7 +272,6 @@ fn filtered_mappings<'a>(
     regions: &[MemoryRegion],
     layout: SandboxMemoryLayout,
     root_pts: &[u64],
-    #[cfg(feature = "i686-guest")] cow_map: &std::collections::HashMap<u64, u64>,
 ) -> Vec<(usize, Mapping, &'a [u8])> {
     use std::collections::HashSet;
     let mut all_mappings = Vec::new();
@@ -333,10 +280,6 @@ fn filtered_mappings<'a>(
 
     #[cfg_attr(not(feature = "i686-guest"), allow(unused_variables))]
     for (root_idx, &root_pt) in root_pts.iter().enumerate() {
-        #[cfg(feature = "i686-guest")]
-        let op =
-            SharedMemoryPageTableBuffer::new(snap, scratch, layout, root_pt).with_cow_map(cow_map);
-        #[cfg(not(feature = "i686-guest"))]
         let op = SharedMemoryPageTableBuffer::new(snap, scratch, layout, root_pt);
 
         let iter = unsafe { vmem::virt_to_phys(&op, 0, hyperlight_common::layout::MAX_GVA as u64) };
@@ -564,29 +507,11 @@ impl Snapshot {
         let mut phys_seen = HashMap::<u64, usize>::new();
         let memory = shared_mem.with_contents(|snap_c| {
             scratch_mem.with_contents(|scratch_c| {
-                // Phase 0 (i686 only): build a CoW resolution map so the
-                // PT walker reads CoW'd pages from scratch, not stale
-                // snapshot copies.
-                #[cfg(feature = "i686-guest")]
-                let cow_map = {
-                    let kernel_root = root_pt_gpas.first().copied().ok_or_else(|| {
-                        crate::new_error!("snapshot requires at least one page directory root")
-                    })?;
-                    build_cow_map(snap_c, scratch_c, layout, kernel_root)?
-                };
-
                 // Phase 1: walk every PT root and collect live pages,
                 // tagged with which root they belong to (for per-process
                 // PD isolation on i686).
-                let live_pages = filtered_mappings(
-                    snap_c,
-                    scratch_c,
-                    &regions,
-                    layout,
-                    root_pt_gpas,
-                    #[cfg(feature = "i686-guest")]
-                    &cow_map,
-                );
+                let live_pages =
+                    filtered_mappings(snap_c, scratch_c, &regions, layout, root_pt_gpas);
 
                 // Phase 2: compact live pages into a dense snapshot blob
                 // and build new page tables with compacted GPAs.

--- a/src/hyperlight_host/src/sandbox/uninitialized.rs
+++ b/src/hyperlight_host/src/sandbox/uninitialized.rs
@@ -31,7 +31,7 @@ use crate::func::{ParameterTuple, SupportedReturnType};
 use crate::log_build_details;
 use crate::mem::memory_region::{DEFAULT_GUEST_BLOB_MEM_FLAGS, MemoryRegionFlags};
 use crate::mem::mgr::SandboxMemoryManager;
-#[cfg(feature = "nanvix-unstable")]
+#[cfg(feature = "guest-counter")]
 use crate::mem::shared_mem::HostSharedMemory;
 use crate::mem::shared_mem::{ExclusiveSharedMemory, SharedMemory};
 use crate::sandbox::SandboxConfiguration;
@@ -76,26 +76,26 @@ pub(crate) struct SandboxRuntimeConfig {
 ///
 /// Only one `GuestCounter` may be created per sandbox; a second call to
 /// [`UninitializedSandbox::guest_counter()`] returns an error.
-#[cfg(feature = "nanvix-unstable")]
+#[cfg(feature = "guest-counter")]
 pub struct GuestCounter {
     inner: Mutex<GuestCounterInner>,
 }
 
-#[cfg(feature = "nanvix-unstable")]
+#[cfg(feature = "guest-counter")]
 struct GuestCounterInner {
     deferred_hshm: Arc<Mutex<Option<HostSharedMemory>>>,
     offset: usize,
     value: u64,
 }
 
-#[cfg(feature = "nanvix-unstable")]
+#[cfg(feature = "guest-counter")]
 impl core::fmt::Debug for GuestCounter {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("GuestCounter").finish_non_exhaustive()
     }
 }
 
-#[cfg(feature = "nanvix-unstable")]
+#[cfg(feature = "guest-counter")]
 impl GuestCounter {
     /// Increments the counter by one and writes it to guest memory.
     pub fn increment(&self) -> Result<()> {
@@ -174,12 +174,12 @@ pub struct UninitializedSandbox {
     /// view of scratch memory. Code that needs host-style volatile access
     /// before `evolve()` (e.g. `GuestCounter`) can clone this `Arc` and
     /// will see `Some` once `evolve()` completes.
-    #[cfg(feature = "nanvix-unstable")]
+    #[cfg(feature = "guest-counter")]
     pub(crate) deferred_hshm: Arc<Mutex<Option<HostSharedMemory>>>,
     /// Set to `true` once a [`GuestCounter`] has been handed out via
     /// [`guest_counter()`](Self::guest_counter). Prevents creating
     /// multiple counters that would have divergent cached values.
-    #[cfg(feature = "nanvix-unstable")]
+    #[cfg(feature = "guest-counter")]
     counter_taken: std::sync::atomic::AtomicBool,
     /// File mappings prepared by [`Self::map_file_cow`] that will be
     /// applied to the VM during [`Self::evolve`].
@@ -287,7 +287,7 @@ impl UninitializedSandbox {
     ///
     /// This method can only be called once; a second call returns an error
     /// because multiple counters would have divergent cached values.
-    #[cfg(feature = "nanvix-unstable")]
+    #[cfg(feature = "guest-counter")]
     pub fn guest_counter(&mut self) -> Result<GuestCounter> {
         use std::sync::atomic::Ordering;
 
@@ -376,9 +376,9 @@ impl UninitializedSandbox {
             rt_cfg,
             load_info: snapshot.load_info(),
             stack_top_gva: snapshot.stack_top_gva(),
-            #[cfg(feature = "nanvix-unstable")]
+            #[cfg(feature = "guest-counter")]
             deferred_hshm: Arc::new(Mutex::new(None)),
-            #[cfg(feature = "nanvix-unstable")]
+            #[cfg(feature = "guest-counter")]
             counter_taken: std::sync::atomic::AtomicBool::new(false),
             pending_file_mappings: Vec::new(),
         };
@@ -552,7 +552,7 @@ impl UninitializedSandbox {
     /// Populate the deferred `HostSharedMemory` slot without running
     /// the full `evolve()` pipeline. Used in tests where guest boot
     /// is not available.
-    #[cfg(all(test, feature = "nanvix-unstable"))]
+    #[cfg(all(test, feature = "guest-counter"))]
     fn simulate_build(&self) {
         let hshm = self.mgr.scratch_mem.as_host_shared_memory();
         #[allow(clippy::unwrap_used)]
@@ -1569,7 +1569,7 @@ mod tests {
         }
     }
 
-    #[cfg(feature = "nanvix-unstable")]
+    #[cfg(feature = "guest-counter")]
     mod guest_counter_tests {
         use hyperlight_testing::simple_guest_as_string;
 

--- a/src/hyperlight_host/src/sandbox/uninitialized_evolve.rs
+++ b/src/hyperlight_host/src/sandbox/uninitialized_evolve.rs
@@ -41,7 +41,7 @@ pub(super) fn evolve_impl_multi_use(u_sbox: UninitializedSandbox) -> Result<Mult
 
     // Publish the HostSharedMemory for scratch so any pre-existing
     // GuestCounter can begin issuing volatile writes.
-    #[cfg(feature = "nanvix-unstable")]
+    #[cfg(feature = "guest-counter")]
     {
         #[allow(clippy::unwrap_used)]
         // The mutex can only be poisoned if a previous lock holder


### PR DESCRIPTION
## Summary

The cleaned-up version of #1381: drops the dependencies on #1379 and #1380 so this PR can land on its own.

## Commits
- `refactor: replace nanvix-unstable with i686-guest and guest-counter features`
- `feat: i686 protected-mode boot and unified restore path`
- `feat: i686 page tables, snapshot compaction, and CoW support`
- `fixup: address PR #1381 review comments`

## What this adds

- **i686 guest support** on the x86_64 host: 32-bit protected-mode boot, unified restore path, 2-level page-table walking and snapshot compaction with CoW-resolved PTE reads.
- **Feature rename** — the prior `nanvix-unstable` gates split into `i686-guest` (PT walker, protected-mode boot, compaction) and `guest-counter` (scratch counter plumbing). No behavior change for consumers using the old feature flag; Cargo.toml / Justfile / build.rs updated to match.

## What it does *not* include (vs #1381)

- The NOBITS-section ELF-loader zero-fill (#1379).
- The PEB `file_mappings` removal (#1380).

Both can land separately; #1381 happened to stack on top of them.

## Review items from #1381 addressed here

- PTE decode uses `u32::from_le_bytes` (previously `from_ne_bytes`) — PTEs are little-endian by arch spec.
- `i686-guest` feature guarded with a `compile_error!` on targets that are neither `x86` (guest) nor `x86_64` (host).
- `restore_snapshot` rewrites the scratch PD-roots bookkeeping (`SCRATCH_TOP_PD_ROOTS_{COUNT,ARRAY}_OFFSET`) so a subsequent `snapshot()` doesn't see a stale zero count. `Snapshot` persists the root count; root GPAs are deterministic (`layout.get_pt_base_gpa() + i * PAGE_SIZE`).

## Verification

Built with `cargo check -p hyperlight-{common,host,guest} --features kvm,mshv3,executable_heap,i686-guest,guest-counter` — clean. End-to-end tested against [nanvix@e61306676](https://github.com/nanvix/nanvix/tree/hyperlight-end-to-end-dev): **Hello 5/5** with `NANVIX_REPEAT=4` through the restore+call loop.