### PR TITLE
feat(host): implement Registerable for MultiUseSandbox

### DIFF
--- a/src/hyperlight_host/src/func/host_functions.rs
+++ b/src/hyperlight_host/src/func/host_functions.rs
@@ -56,6 +56,46 @@ impl Registerable for UninitializedSandbox {
     }
 }
 
+/// Allow registering host functions on an already-evolved
+/// [`crate::MultiUseSandbox`].
+///
+/// The primary entry point for host-function registration is the
+/// `UninitializedSandbox` impl above — that's the lifecycle phase
+/// where the guest hasn't yet been allowed to issue host calls.
+/// There are, however, cases where a `MultiUseSandbox` is obtained
+/// without traversing the `Uninitialized → evolve()` path:
+///
+/// - Sandboxes loaded from a persisted snapshot.
+/// - Any future API that yields a `MultiUseSandbox` directly.
+///
+/// In those cases the caller never had a chance to call
+/// `register_host_function` on an `UninitializedSandbox`, so we
+/// expose the same trait implementation here for late registration.
+/// The guest's host-function dispatcher resolves by name at call
+/// time, so inserting into the registry after `evolve()` is
+/// semantically safe as long as the first host-function invocation
+/// happens after registration completes.
+impl Registerable for crate::MultiUseSandbox {
+    fn register_host_function<Args: ParameterTuple, Output: SupportedReturnType>(
+        &mut self,
+        name: &str,
+        hf: impl Into<HostFunction<Output, Args>>,
+    ) -> Result<()> {
+        let mut hfs = self
+            .host_funcs
+            .try_lock()
+            .map_err(|e| new_error!("Error locking at {}:{}: {}", file!(), line!(), e))?;
+
+        let entry = FunctionEntry {
+            function: hf.into().into(),
+            parameter_types: Args::TYPE,
+            return_type: Output::TYPE,
+        };
+
+        (*hfs).register_host_function(name.to_string(), entry)
+    }
+}
+
 /// A representation of a host function.
 /// This is a thin wrapper around a `Fn(Args) -> Result<Output>`.
 #[derive(Clone)]

--- a/src/hyperlight_host/src/sandbox/initialized_multi_use.rs
+++ b/src/hyperlight_host/src/sandbox/initialized_multi_use.rs
@@ -86,7 +86,7 @@ pub struct MultiUseSandbox {
     id: u64,
     /// Whether this sandbox is poisoned
     poisoned: bool,
-    pub(super) host_funcs: Arc<Mutex<FunctionRegistry>>,
+    pub(crate) host_funcs: Arc<Mutex<FunctionRegistry>>,
     pub(crate) mem_mgr: SandboxMemoryManager<HostSharedMemory>,
     vm: HyperlightVm,
     #[cfg(gdb)]


### PR DESCRIPTION
## Summary

Extends the `Registerable` trait impl to `MultiUseSandbox` so host functions can be registered on a sandbox after `evolve()`. Today the only impl is on `UninitializedSandbox`, which works fine for the standard `Uninitialized → evolve() → MultiUse` flow — but not for paths that yield a `MultiUseSandbox` directly. Examples: sandboxes loaded from a persisted snapshot (the snapshot-to-disk work lands one such path), and any future API with the same shape.

Without this, those callers have to reach into internal state or maintain a parallel registry, which isn't a stable story. With it, late registration becomes a one-liner that mirrors the existing `UninitializedSandbox` impl exactly.

## Semantics

The guest's host-function dispatcher resolves by name at call time. Inserting into the registry after `evolve()` is safe as long as the first host-call invocation happens after registration completes. The typical usage pattern is the same as today for the pre-evolve path:

```rust
let mut sbox = MultiUseSandbox::from_snapshot(s)?;
sbox.register_host_function("__dispatch", |payload: Vec<u8>| { ... })?;
sbox.call::<(), _>("run", args)?;
```

## Changes

- New `impl Registerable for MultiUseSandbox` next to the existing `UninitializedSandbox` impl in `src/func/host_functions.rs`. Body is a verbatim copy of the existing impl — same error handling, same lock acquisition, same `FunctionEntry` construction.
- Visibility of `MultiUseSandbox.host_funcs` nudged from `pub(super)` to `pub(crate)` so the impl in `src/func/` can reach it. No external API change.

## Tested

`cargo check` + `cargo test -p hyperlight-host` locally on Linux. No behaviour change for any existing caller.