### PR TITLE
Remove disallowed-macros lint

### DIFF
--- a/src/hyperlight_common/clippy.toml
+++ b/src/hyperlight_common/clippy.toml
@@ -1,5 +1,0 @@
-disallowed-macros = [
-    { path = "std::assert", reason = "no asserts in release builds" },
-    { path = "std::assert_eq", reason = "no asserts in release builds" },
-    { path = "std::assert_ne", reason = "no asserts in release builds" },
-]

--- a/src/hyperlight_common/src/clippy.toml
+++ b/src/hyperlight_common/src/clippy.toml
@@ -1,5 +1,0 @@
-disallowed-macros = [
-    { path = "std::assert", reason = "no asserts in release builds" },
-    { path = "std::assert_eq", reason = "no asserts in release builds" },
-    { path = "std::assert_ne", reason = "no asserts in release builds" },
-]

--- a/src/hyperlight_common/src/lib.rs
+++ b/src/hyperlight_common/src/lib.rs
@@ -17,16 +17,6 @@ limitations under the License.
 #![cfg_attr(not(any(test, debug_assertions)), warn(clippy::panic))]
 #![cfg_attr(not(any(test, debug_assertions)), warn(clippy::expect_used))]
 #![cfg_attr(not(any(test, debug_assertions)), warn(clippy::unwrap_used))]
-// clippy.toml disallows assert!/assert_eq!/assert_ne! via disallowed-macros.
-// That lint is active by default, so we suppress it globally here, then
-// selectively re-enable it for release host builds (feature = "std").
-// Guest targets (no std) are allowed asserts — panics are contained in the
-// micro-VM and cannot crash the host. Tests and debug builds are also allowed.
-#![allow(clippy::disallowed_macros)]
-#![cfg_attr(
-    not(any(test, debug_assertions, not(feature = "std"))),
-    warn(clippy::disallowed_macros)
-)]
 // We use Arbitrary during fuzzing, which requires std
 #![cfg_attr(not(feature = "fuzzing"), no_std)]
 

--- a/src/hyperlight_common/src/version_note.rs
+++ b/src/hyperlight_common/src/version_note.rs
@@ -90,7 +90,6 @@ impl<const NAME_SZ: usize, const DESC_SZ: usize> ElfNote<NAME_SZ, DESC_SZ> {
     ///
     /// Panics at compile time if `NAME_SZ` or `DESC_SZ` don't match
     /// `padded_name_size(name.len() + 1)` or `padded_desc_size(desc.len() + 1)`.
-    #[allow(clippy::disallowed_macros)] // These asserts are evaluated at compile time only (const fn).
     pub const fn new(name: &str, desc: &str, n_type: u32) -> Self {
         // NAME_SZ and DESC_SZ must match the padded sizes.
         assert!(

--- a/src/hyperlight_host/benches/benchmarks.rs
+++ b/src/hyperlight_host/benches/benchmarks.rs
@@ -14,11 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#![expect(
-    clippy::disallowed_macros,
-    reason = "This is a benchmark file, so using disallowed macros is fine here."
-)]
-
 use std::sync::{Arc, Barrier, Mutex};
 use std::thread;
 use std::time::{Duration, Instant};

--- a/src/hyperlight_host/clippy.toml
+++ b/src/hyperlight_host/clippy.toml
@@ -1,5 +1,0 @@
-disallowed-macros = [
-    { path = "std::assert", reason = "no asserts in release builds" },
-    { path = "std::assert_eq", reason = "no asserts in release builds" },
-    { path = "std::assert_ne", reason = "no asserts in release builds" },
-]

--- a/src/hyperlight_host/examples/crashdump/main.rs
+++ b/src/hyperlight_host/examples/crashdump/main.rs
@@ -71,8 +71,6 @@ limitations under the License.
 //!
 //! Core dump files are named `hl_core_<timestamp>.elf`.
 
-#![allow(clippy::disallowed_macros)]
-
 #[cfg(all(crashdump, target_os = "linux"))]
 use std::io::Write;
 

--- a/src/hyperlight_host/examples/guest-debugging/main.rs
+++ b/src/hyperlight_host/examples/guest-debugging/main.rs
@@ -13,7 +13,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-#![allow(clippy::disallowed_macros)]
 use std::thread;
 
 use hyperlight_host::sandbox::SandboxConfiguration;

--- a/src/hyperlight_host/examples/hello-world/main.rs
+++ b/src/hyperlight_host/examples/hello-world/main.rs
@@ -13,7 +13,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-#![allow(clippy::disallowed_macros)]
 use std::thread;
 
 use hyperlight_host::{MultiUseSandbox, UninitializedSandbox};

--- a/src/hyperlight_host/examples/logging/main.rs
+++ b/src/hyperlight_host/examples/logging/main.rs
@@ -13,7 +13,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-#![allow(clippy::disallowed_macros)]
 extern crate hyperlight_host;
 
 use std::sync::{Arc, Barrier};

--- a/src/hyperlight_host/examples/map-file-cow-test/main.rs
+++ b/src/hyperlight_host/examples/map-file-cow-test/main.rs
@@ -28,7 +28,6 @@ limitations under the License.
 // Run:
 //   cargo run --release --example map-file-cow-test
 
-#![allow(clippy::disallowed_macros)]
 use std::path::Path;
 
 use hyperlight_host::sandbox::SandboxConfiguration;

--- a/src/hyperlight_host/examples/metrics/main.rs
+++ b/src/hyperlight_host/examples/metrics/main.rs
@@ -13,7 +13,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-#![allow(clippy::disallowed_macros)]
 extern crate hyperlight_host;
 use std::sync::{Arc, Barrier};
 use std::thread::{JoinHandle, spawn};

--- a/src/hyperlight_host/examples/tracing-chrome/main.rs
+++ b/src/hyperlight_host/examples/tracing-chrome/main.rs
@@ -13,7 +13,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-#![allow(clippy::disallowed_macros)]
 use hyperlight_host::sandbox::uninitialized::UninitializedSandbox;
 use hyperlight_host::{GuestBinary, Result};
 use hyperlight_testing::simple_guest_as_string;

--- a/src/hyperlight_host/examples/tracing-otlp/main.rs
+++ b/src/hyperlight_host/examples/tracing-otlp/main.rs
@@ -13,8 +13,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-#![allow(clippy::disallowed_macros)]
-//use opentelemetry_sdk::resource::ResourceBuilder;
 use opentelemetry_sdk::trace::SdkTracerProvider;
 use tracing::{Level, span};
 use tracing_opentelemetry::OpenTelemetryLayer;

--- a/src/hyperlight_host/examples/tracing/main.rs
+++ b/src/hyperlight_host/examples/tracing/main.rs
@@ -13,7 +13,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-#![allow(clippy::disallowed_macros)]
 use tracing::{Level, span};
 extern crate hyperlight_host;
 use std::sync::{Arc, Barrier};

--- a/src/hyperlight_host/src/hypervisor/regs/x86_64/special_regs.rs
+++ b/src/hyperlight_host/src/hypervisor/regs/x86_64/special_regs.rs
@@ -251,7 +251,6 @@ impl From<&CommonSpecialRegisters> for kvm_sregs {
 pub(crate) struct Align16<T>(pub(crate) T);
 
 #[cfg(target_os = "windows")]
-#[allow(clippy::disallowed_macros)] // compile time
 const _: () = {
     assert!(
         std::mem::size_of::<Align16<WHV_REGISTER_VALUE>>()

--- a/src/hyperlight_host/src/lib.rs
+++ b/src/hyperlight_host/src/lib.rs
@@ -38,7 +38,6 @@ limitations under the License.
 #![cfg_attr(not(any(test, debug_assertions)), warn(clippy::panic))]
 #![cfg_attr(not(any(test, debug_assertions)), warn(clippy::expect_used))]
 #![cfg_attr(not(any(test, debug_assertions)), warn(clippy::unwrap_used))]
-#![cfg_attr(any(test, debug_assertions), allow(clippy::disallowed_macros))]
 
 #[cfg(feature = "build-metadata")]
 use std::sync::Once;

--- a/src/hyperlight_host/tests/integration_test.rs
+++ b/src/hyperlight_host/tests/integration_test.rs
@@ -13,7 +13,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-#![allow(clippy::disallowed_macros)]
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Barrier};
 use std::thread;

--- a/src/hyperlight_host/tests/sandbox_host_tests.rs
+++ b/src/hyperlight_host/tests/sandbox_host_tests.rs
@@ -13,7 +13,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-#![allow(clippy::disallowed_macros)]
 use core::f64;
 use std::sync::mpsc::channel;
 use std::sync::{Arc, Mutex};

--- a/src/hyperlight_host/tests/wit_test.rs
+++ b/src/hyperlight_host/tests/wit_test.rs
@@ -13,7 +13,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
  */
-#![allow(clippy::disallowed_macros)]
 
 use std::sync::{Arc, Mutex};
 


### PR DESCRIPTION
Using the `disallowed-macros` lint to detect the use of `assert!` flags up the use of `debug-assert!` , use of assert in const expressions etc. This leads to more and more annotations in code to allow the valid use of asserts, rather than continually expand this this PR removes the lint in favour of detecting use of assert in release code via PR reviews