### PR TITLE
fix(ci): pin cargo-hyperlight version

### DIFF
--- a/.github/workflows/RustNightly.yml
+++ b/.github/workflows/RustNightly.yml
@@ -77,6 +77,11 @@ jobs:
             src/tests/rust_guests/dummyguest -> target
             src/tests/rust_guests/witguest -> target
 
+      - name: Install cargo-hyperlight
+        uses: taiki-e/install-action@5939f3337e40968c39aa70f5ecb1417a92fb25a0 # v2.75.15
+        with:
+          tool: cargo-hyperlight@0.1.8
+
       - name: Build and move Rust guests
         run: |
           just build-rust-guests ${{ matrix.config }}

--- a/.github/workflows/dep_code_checks.yml
+++ b/.github/workflows/dep_code_checks.yml
@@ -73,6 +73,11 @@ jobs:
       - name: fmt
         run: just fmt-check
 
+      - name: Install cargo-hyperlight
+        uses: taiki-e/install-action@5939f3337e40968c39aa70f5ecb1417a92fb25a0 # v2.75.15
+        with:
+          tool: cargo-hyperlight@0.1.8
+
       - name: clippy exhaustive check (debug)
         run: just clippy-exhaustive debug
 


### PR DESCRIPTION
Make sure we use stable version of cargo-hyperlight across all CI workflows.