### PR TITLE
fix(ci): force install cargo-hyperlight

### DIFF
--- a/.github/workflows/RustNightly.yml
+++ b/.github/workflows/RustNightly.yml
@@ -78,9 +78,7 @@ jobs:
             src/tests/rust_guests/witguest -> target
 
       - name: Install cargo-hyperlight
-        uses: taiki-e/install-action@cf525cb33f51aca27cd6fa02034117ab963ff9f1 # v2.75.22
-        with:
-          tool: cargo-hyperlight@0.1.9
+        run: cargo install cargo-hyperlight --version 0.1.9 --locked --force
 
       - name: Build and move Rust guests
         run: |

--- a/.github/workflows/dep_build_guests.yml
+++ b/.github/workflows/dep_build_guests.yml
@@ -68,9 +68,7 @@ jobs:
             src/tests/rust_guests/witguest -> target
 
       - name: Install cargo-hyperlight
-        uses: taiki-e/install-action@cf525cb33f51aca27cd6fa02034117ab963ff9f1 # v2.75.22
-        with:
-          tool: cargo-hyperlight@0.1.9
+        run: cargo install cargo-hyperlight --version 0.1.9 --locked --force
 
       - name: Build Rust guests
         run: |

--- a/.github/workflows/dep_code_checks.yml
+++ b/.github/workflows/dep_code_checks.yml
@@ -74,9 +74,7 @@ jobs:
         run: just fmt-check
 
       - name: Install cargo-hyperlight
-        uses: taiki-e/install-action@cf525cb33f51aca27cd6fa02034117ab963ff9f1 # v2.75.22
-        with:
-          tool: cargo-hyperlight@0.1.9
+        run: cargo install cargo-hyperlight --version 0.1.9 --locked --force
 
       - name: clippy exhaustive check (debug)
         run: just clippy-exhaustive debug
@@ -147,9 +145,7 @@ jobs:
         run: just fmt-check
 
       - name: Install cargo-hyperlight
-        uses: taiki-e/install-action@cf525cb33f51aca27cd6fa02034117ab963ff9f1 # v2.75.22
-        with:
-          tool: cargo-hyperlight@0.1.9
+        run: cargo install cargo-hyperlight --version 0.1.9 --locked --force
 
       - name: clippy (debug)
         run: |


### PR DESCRIPTION
It looks like taiki action fails to pin the version of `cargo-hyperlight`. For example, check this workflow:

https://github.com/hyperlight-dev/hyperlight/actions/runs/24995100212/job/73189927877?pr=1419

