### PR TITLE
Fix flaky gdb tests by detaching from inside the bp commands

### DIFF
--- a/src/hyperlight_host/examples/guest-debugging/main.rs
+++ b/src/hyperlight_host/examples/guest-debugging/main.rs
@@ -265,13 +265,12 @@ mod tests {
                     echo \"Stopped at hyperlight_main breakpoint\\n\"
                     backtrace
 
-                    continue
+                    set logging enabled off
+                    detach
+                    quit
                 end
 
                 continue
-
-                set logging enabled off
-                quit
             "
         );
 
@@ -311,16 +310,14 @@ mod tests {
                     break +2
                     commands 2
                         print $xmm1.v4_float
-                        continue
+                        set logging enabled off
+                        detach
+                        quit
                     end
                     continue
                 end
-                
 
                 continue
-
-                set logging enabled off
-                quit
             "
         );
 


### PR DESCRIPTION
Replace the racy 'inner continue, outer continue, quit' pattern with 'detach, quit' inside the breakpoint commands. After the previous inner continue, the inferior could exit and the gdb stub could close the remote before gdb dispatched the outer continue, producing 'Remote connection closed' and a non-zero exit. The new shape lets the host run the guest call to completion on its own after detach, with no pending remote work in gdb.

closes #1326