### PR TITLE
Add hyperlight-libc to CI publishing

### DIFF
--- a/.github/workflows/CargoPublish.yml
+++ b/.github/workflows/CargoPublish.yml
@@ -69,6 +69,7 @@ jobs:
             fi
           }
           
+          needs_publish hyperlight-libc
           needs_publish hyperlight-common
           needs_publish hyperlight-guest
           needs_publish hyperlight-guest-macro
@@ -81,6 +82,13 @@ jobs:
       - name: Authenticate with crates.io
         uses: rust-lang/crates-io-auth-action@v1
         id: crates-io-auth
+
+      - name: Publish hyperlight-libc
+        continue-on-error: ${{ inputs.dry_run }}
+        run: cargo publish --manifest-path ./src/hyperlight_libc/Cargo.toml ${{ inputs.dry_run && '--dry-run' || '' }}
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.crates-io-auth.outputs.token }}
+        if: env.PUBLISH_HYPERLIGHT_LIBC != 'false'
         
       - name: Publish hyperlight-common
         continue-on-error: ${{ inputs.dry_run }}

--- a/src/hyperlight_libc/Cargo.toml
+++ b/src/hyperlight_libc/Cargo.toml
@@ -1,4 +1,3 @@
-
 [package]
 name = "hyperlight-libc"
 links = "c"

--- a/src/hyperlight_libc/Cargo.toml
+++ b/src/hyperlight_libc/Cargo.toml
@@ -7,7 +7,7 @@ rust-version.workspace = true
 license.workspace = true
 homepage.workspace = true
 repository.workspace = true
-readme.workspace = true
+readme = "README.md"
 description = """
 This crate provides picolibc for Hyperlight guests.
 It builds the picolibc library and generates bindings to the libc types and functions.


### PR DESCRIPTION
This PR adds the `hyperlight-libc` to the CI publishing workflow.