### PR TITLE
Use latest cargo-hyperlight in release workflow

### DIFF
--- a/.github/workflows/CreateRelease.yml
+++ b/.github/workflows/CreateRelease.yml
@@ -136,6 +136,9 @@ jobs:
           echo "HYPERLIGHT_VERSION=$version" >> $GITHUB_ENV
           echo "HYPERLIGHT_VERSION=$version"
 
+      - name: Install cargo-hyperlight
+        run: cargo install cargo-hyperlight --version 0.1.10 --locked --force
+
       - name: Build and archive guest library + header files
         run: |
           just tar-headers


### PR DESCRIPTION
To generate the header's tar and the lib tar, we use cargo-hyperlight.
With the libc changes we need to make sure we use the latest cargo-hyperlight.