### PR TITLE
Add Ralph as maintainer

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -9,9 +9,9 @@
 | Jorge Prendes      | [@jprendes](https://github.com/jprendes)           |
 | Lucy Menon         | [@syntactically](https://github.com/syntactically) |
 | Ludvig Liljenberg  | [@ludfjig](https://github.com/ludfjig)             |
+| Ralph Squillace    | [@squillace](https://github.com/squillace)         |
 | Simon Davies       | [@simongdavies](https://github.com/simongdavies)   |
 | Tomasz Andrzejak   | [@andreiltd](https://github.com/andreiltd)         |
-| Ralph Squillace    | [@squillace](https://github.com/squillace)         |
 
 <!-- Note: Please maintain alphabetical order when adding new entries to the table. -->
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -11,6 +11,7 @@
 | Ludvig Liljenberg  | [@ludfjig](https://github.com/ludfjig)             |
 | Simon Davies       | [@simongdavies](https://github.com/simongdavies)   |
 | Tomasz Andrzejak   | [@andreiltd](https://github.com/andreiltd)         |
+| Ralph Squillace    | [@squillace](https://github.com/squillace)         |
 
 <!-- Note: Please maintain alphabetical order when adding new entries to the table. -->
 


### PR DESCRIPTION
This keeps https://github.com/cncf/foundation/pull/1388 to be in sync.  Ralph was one of the originals behind HL and often joins us at community meetings and has helped with issue triage and getting samples into working condition.