### PR TITLE
Save/load snapshot from disk (oci format)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Prerelease] - Unreleased
 
+### Added
+* `Snapshot::save`, `Snapshot::load`, and `Snapshot::checked_load` for persisting and loading sandbox snapshots as OCI Image Layout directories by @ludfjig in https://github.com/hyperlight-dev/hyperlight/pull/1465. Note that Hyperlight is at version 0.x, so a snapshot taken on one version may not load on another version.
+
 ### Changed
 * **Breaking:** `MultiUseSandbox::map_file_cow` and `UninitializedSandbox::map_file_cow` no longer take a label argument. The APIs now accept only `(file_path, guest_base)`.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -531,6 +531,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
+name = "const_format"
+version = "0.2.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4481a617ad9a412be3b97c5d403fef8ed023103368908b9c50af598ff467cc1e"
+dependencies = [
+ "const_format_proc_macros",
+ "konst",
+]
+
+[[package]]
+name = "const_format_proc_macros"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d57c2eccfb16dbac1f4e61e206105db5820c9d26c3c472bc17c774259ef7744"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
+]
+
+[[package]]
 name = "constant_time_eq"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -731,6 +752,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "derive_arbitrary"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -738,6 +794,37 @@ checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
 dependencies = [
  "proc-macro2",
  "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
+dependencies = [
+ "derive_builder_core",
  "syn",
 ]
 
@@ -1161,6 +1248,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "getset"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cf0fc11e47561d47397154977bc219f4cf809b2974facc3ccb3b89e2436f912"
+dependencies = [
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "gimli"
 version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1364,6 +1463,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "http"
@@ -1594,6 +1699,7 @@ dependencies = [
  "gdbstub",
  "gdbstub_arch",
  "goblin",
+ "hex",
  "hyperlight-common",
  "hyperlight-component-macro",
  "hyperlight-guest-tracing",
@@ -1609,6 +1715,7 @@ dependencies = [
  "metrics-util",
  "mshv-bindings",
  "mshv-ioctls",
+ "oci-spec",
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry-semantic-conventions",
@@ -1621,6 +1728,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serial_test",
+ "sha2",
  "signal-hook-registry",
  "tempfile",
  "termcolor",
@@ -1799,6 +1907,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1920,6 +2034,21 @@ dependencies = [
  "once_cell",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "konst"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "128133ed7824fcd73d6e7b17957c5eb7bacb885649bd8c69708b2331a10bcefb"
+dependencies = [
+ "konst_macro_rules",
+]
+
+[[package]]
+name = "konst_macro_rules"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4933f3f57a8e9d9da04db23fb153356ecaf00cbd14aee46279c33dc80925c37"
 
 [[package]]
 name = "kurbo"
@@ -2333,6 +2462,23 @@ dependencies = [
  "flate2",
  "memchr",
  "ruzstd",
+]
+
+[[package]]
+name = "oci-spec"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc3da52b83ce3258fbf29f66ac784b279453c2ac3c22c5805371b921ede0d308"
+dependencies = [
+ "const_format",
+ "derive_builder",
+ "getset",
+ "regex",
+ "serde",
+ "serde_json",
+ "strum",
+ "strum_macros",
+ "thiserror",
 ]
 
 [[package]]
@@ -2775,6 +2921,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
  "toml_edit",
+]
+
+[[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -3428,6 +3596,24 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+
+[[package]]
+name = "strum_macros"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "syn"

--- a/docs/snapshot-oci-format.md
+++ b/docs/snapshot-oci-format.md
@@ -1,0 +1,119 @@
+# Hyperlight snapshot on-disk format
+
+Hyperlight serialises a `Snapshot` to disk as an [OCI Image Layout]
+directory. `Snapshot::save` writes one. `Snapshot::load` and
+`Snapshot::checked_load` read one back.
+
+Only a snapshot taken after the guest has run can be persisted. Such a
+snapshot carries the captured vCPU registers needed to resume a call.
+`Snapshot::save` rejects a pre-init snapshot.
+
+[OCI Image Layout]: https://github.com/opencontainers/image-spec/blob/main/image-layout.md
+
+## Directory layout
+
+```text
+path/
+  oci-layout                          {"imageLayoutVersion":"1.0.0"}
+  index.json                          one manifest descriptor per tag,
+                                      tagged via the OCI standard
+                                      `org.opencontainers.image.ref.name`
+                                      annotation
+  blobs/sha256/
+    <manifest-digest>                 OCI image manifest JSON
+    <config-digest>                   Hyperlight config JSON
+    <snapshot-digest>                 raw memory bytes
+                                      (`memory_size` bytes)
+```
+
+Three blob kinds per tag:
+
+* **manifest** (`application/vnd.oci.image.manifest.v1+json`). Tiny JSON
+  pointer record selected via `index.json`. References one config and
+  one layer by digest.
+* **config** (`application/vnd.hyperlight.snapshot.config.v1+json`). The
+  snapshot descriptor: arch, hypervisor, ABI version, resume address
+  and captured registers, memory layout, registered host functions,
+  snapshot generation counter. Loaded eagerly and fully parsed.
+* **layer / memory** (`application/vnd.hyperlight.snapshot.memory.v1`).
+  The raw guest memory image, exactly `memory_size` bytes. mmap'd on
+  restore.
+
+Blob filenames are the sha256 of the blob bytes, so identical blobs
+across tags are stored once.
+
+## What is one snapshot
+
+A single saved `Snapshot` consists of exactly:
+
+* one entry in `index.json`, carrying the `tag` as
+  `org.opencontainers.image.ref.name`, plus advisory
+  `dev.hyperlight.snapshot.arch` and
+  `dev.hyperlight.snapshot.hypervisor` annotations that mirror the
+  config blob for tooling visibility,
+* one **manifest** blob (referenced by that index entry),
+* one **config** blob (referenced by the manifest's `config` field),
+* one **layer** blob (the only entry in the manifest's `layers`
+  array, holding the raw memory image).
+
+Saving two snapshots under different tags into the same `path`
+produces two index entries and two manifests. Configs and layers are
+deduplicated by content, so identical bytes are stored once and
+referenced by both manifests.
+
+Saving the same tag a second time replaces that tag's index entry
+and writes a fresh manifest. The previous manifest, and any of its
+config or layer blobs that no other tag references, become orphans
+in `blobs/sha256/`.
+
+## Write semantics
+
+`Snapshot::save(path, tag)` opens or creates the OCI layout at
+`path` and writes one snapshot under `tag`, an [`OciTag`] whose
+grammar is validated when it is parsed. It returns the manifest
+descriptor digest as an [`OciDigest`], a content address that selects
+the written manifest on a later load. The parent directory of `path`
+must exist. `path` itself is created if absent. An existing
+layout at `path` is preserved: other tags are kept, and a tag equal
+to `tag` is replaced.
+
+[`OciTag`]: https://docs.rs/hyperlight-host/latest/hyperlight_host/sandbox/snapshot/struct.OciTag.html
+[`OciDigest`]: https://docs.rs/hyperlight-host/latest/hyperlight_host/sandbox/snapshot/struct.OciDigest.html
+
+`index.json` is rewritten via a tmp file plus `rename`, the commit
+point for the whole operation. Concurrent readers observe either the
+prior layout or the new one, never a partial write. Power-loss
+durability is the caller's responsibility: add `fsync` on the file
+and parent directory if a crash must not lose a committed tag.
+
+Replaced tags leave orphan blobs behind. To compact, remove the
+directory and re-save. Concurrent writers to the same `path` are
+unsupported.
+
+This mirrors the merge behaviour of `containers/image` (skopeo,
+podman), `go-containerregistry` (crane), and `regclient`.
+
+## Read semantics
+
+`Snapshot::load(path, reference)` reads a snapshot. It does not check
+the manifest, config, or snapshot blobs against their sha256 digests.
+`reference` is an
+[`OciReference`], either a tag that matches the
+`org.opencontainers.image.ref.name` annotation or the manifest
+digest returned by `save`. `Snapshot::checked_load` adds the digest
+check on those three blobs, catching accidental corruption on disk.
+Both run every other check (OCI structure, descriptor sizes, schema
+versions, arch / hypervisor / ABI tags, layout bounds, entrypoint
+bounds). The caller is responsible for trusting the source.
+
+A reference that matches no manifest, or a tag that matches more than
+one manifest in `index.json`, is rejected.
+
+[`OciReference`]: https://docs.rs/hyperlight-host/latest/hyperlight_host/sandbox/snapshot/enum.OciReference.html
+
+## Portability
+
+Snapshot images are bound to a specific CPU architecture and
+hypervisor. Both are recorded in the config blob and checked at load
+time, with mismatches rejected with a clear error. The hypervisor
+tag (`kvm`, `mshv`, `whp`) constrains the host OS.

--- a/src/hyperlight_host/Cargo.toml
+++ b/src/hyperlight_host/Cargo.toml
@@ -48,9 +48,14 @@ thiserror = "2.0.18"
 chrono = { version = "0.4", optional = true }
 anyhow = "1.0"
 metrics = "0.24.6"
+serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 elfcore = { version = "2.0", optional = true }
 uuid = { version = "1.23.3", features = ["v4"] }
+oci-spec = { version = "0.8", default-features = false, features = ["image"] }
+sha2 = "0.10"
+hex = "0.4"
+tempfile = "3.27.0"
 
 [target.'cfg(windows)'.dependencies]
 windows = { version = "0.62", features = [
@@ -82,10 +87,8 @@ mshv-ioctls = { version = "0.6", optional = true}
 [dev-dependencies]
 uuid = { version = "1.23.3", features = ["v4"] }
 signal-hook-registry = "1.4.8"
-serde = "1.0"
 iced-x86 = { version = "1.21", default-features = false, features = ["std", "code_asm"] }
 proptest = "1.11.0"
-tempfile = "3.27.0"
 crossbeam-queue = "0.3.12"
 tracing-serde = "0.2.0"
 serial_test = "3.5.0"

--- a/src/hyperlight_host/benches/benchmarks.rs
+++ b/src/hyperlight_host/benches/benchmarks.rs
@@ -153,6 +153,15 @@ fn sandbox_lifecycle_benchmark(c: &mut Criterion) {
         );
     }
 
+    // Isolates the cost of building a MultiUseSandbox from an
+    // already-resident Snapshot. The Snapshot is loaded outside the
+    // timed region.
+    for size in SandboxSize::all() {
+        group.bench_function(format!("sandbox_from_snapshot/{}", size.name()), |b| {
+            bench_sandbox_from_snapshot(b, size)
+        });
+    }
+
     group.finish();
 }
 
@@ -345,6 +354,28 @@ fn bench_snapshot_restore(b: &mut criterion::Bencher, size: SandboxSize) {
 
         total_duration
     });
+}
+
+fn bench_sandbox_from_snapshot(b: &mut criterion::Bencher, size: SandboxSize) {
+    use hyperlight_host::HostFunctions;
+    use hyperlight_host::sandbox::snapshot::{OciTag, Snapshot};
+
+    let dir = tempfile::tempdir().unwrap();
+    let snap_path = dir.path().join("bench");
+    let tag = OciTag::new("latest").unwrap();
+    {
+        let mut sbox = create_multiuse_sandbox_with_size(size);
+        let snapshot = sbox.snapshot().unwrap();
+        snapshot.save(&snap_path, &tag).unwrap();
+    }
+    let loaded = std::sync::Arc::new(Snapshot::checked_load(&snap_path, tag).unwrap());
+
+    // Drop is not included.
+    b.iter_batched(
+        || (),
+        |_| MultiUseSandbox::from_snapshot(loaded.clone(), HostFunctions::default(), None).unwrap(),
+        criterion::BatchSize::PerIteration,
+    );
 }
 
 fn snapshots_benchmark(c: &mut Criterion) {
@@ -551,6 +582,141 @@ fn shared_memory_benchmark(c: &mut Criterion) {
     group.finish();
 }
 
+// ============================================================================
+// Benchmark Category: Snapshot Files
+// ============================================================================
+
+fn snapshot_file_benchmark(c: &mut Criterion) {
+    use hyperlight_host::HostFunctions;
+    use hyperlight_host::sandbox::snapshot::{OciTag, Snapshot};
+
+    let mut group = c.benchmark_group("snapshot_files");
+
+    // Pre-create OCI snapshot images for all sizes.
+    let dirs: Vec<_> = SandboxSize::all()
+        .iter()
+        .map(|size| {
+            let dir = tempfile::tempdir().unwrap();
+            let snap_path = dir.path().join(size.name());
+            let snapshot = {
+                let mut sbox = create_multiuse_sandbox_with_size(*size);
+                sbox.snapshot().unwrap()
+            };
+            snapshot
+                .save(&snap_path, &OciTag::new("latest").unwrap())
+                .unwrap();
+            (dir, snapshot, snap_path)
+        })
+        .collect();
+
+    // Benchmark: save_snapshot. Wipe the layout between iterations
+    // so each save measures a fresh write rather than a tag-append.
+    for (i, size) in SandboxSize::all().iter().enumerate() {
+        let snap_dir = tempfile::tempdir().unwrap();
+        let path = snap_dir.path().join("bench");
+        let snapshot = &dirs[i].1;
+        group.bench_function(format!("save_snapshot/{}", size.name()), |b| {
+            b.iter_batched(
+                || {
+                    let _ = std::fs::remove_dir_all(&path);
+                },
+                |_| {
+                    snapshot
+                        .save(&path, &OciTag::new("latest").unwrap())
+                        .unwrap()
+                },
+                criterion::BatchSize::PerIteration,
+            );
+        });
+    }
+
+    // Benchmark: load_snapshot (parse manifest + config + mmap blob).
+    for (i, size) in SandboxSize::all().iter().enumerate() {
+        let snap_path = dirs[i].2.clone();
+        group.bench_function(format!("load_snapshot/{}", size.name()), |b| {
+            b.iter(|| {
+                let _ = Snapshot::checked_load(&snap_path, OciTag::new("latest").unwrap()).unwrap();
+            });
+        });
+    }
+
+    // Benchmark: load_snapshot_unchecked (skip blob digest verification).
+    for (i, size) in SandboxSize::all().iter().enumerate() {
+        let snap_path = dirs[i].2.clone();
+        group.bench_function(format!("load_snapshot_unverified/{}", size.name()), |b| {
+            b.iter(|| {
+                let _ = Snapshot::load(&snap_path, OciTag::new("latest").unwrap()).unwrap();
+            });
+        });
+    }
+
+    // Benchmark: cold_start_via_evolve (new + evolve + call). Drop is not included.
+    for size in SandboxSize::all() {
+        group.bench_function(format!("cold_start_via_evolve/{}", size.name()), |b| {
+            b.iter_batched(
+                || (),
+                |_| {
+                    let mut sbox = create_multiuse_sandbox_with_size(size);
+                    sbox.call::<String>("Echo", "hello\n".to_string()).unwrap();
+                    sbox
+                },
+                criterion::BatchSize::PerIteration,
+            );
+        });
+    }
+
+    // Benchmark: cold_start_via_snapshot (load + from_snapshot + call). Drop is not included.
+    for (i, size) in SandboxSize::all().iter().enumerate() {
+        let snap_path = dirs[i].2.clone();
+        group.bench_function(format!("cold_start_via_snapshot/{}", size.name()), |b| {
+            b.iter_batched(
+                || (),
+                |_| {
+                    let loaded =
+                        Snapshot::checked_load(&snap_path, OciTag::new("latest").unwrap()).unwrap();
+                    let mut sbox = MultiUseSandbox::from_snapshot(
+                        std::sync::Arc::new(loaded),
+                        HostFunctions::default(),
+                        None,
+                    )
+                    .unwrap();
+                    sbox.call::<String>("Echo", "hello\n".to_string()).unwrap();
+                    sbox
+                },
+                criterion::BatchSize::PerIteration,
+            );
+        });
+    }
+
+    // Benchmark: cold_start_via_snapshot_unverified (load unverified + from_snapshot + call). Drop is not included.
+    for (i, size) in SandboxSize::all().iter().enumerate() {
+        let snap_path = dirs[i].2.clone();
+        group.bench_function(
+            format!("cold_start_via_snapshot_unverified/{}", size.name()),
+            |b| {
+                b.iter_batched(
+                    || (),
+                    |_| {
+                        let loaded =
+                            Snapshot::load(&snap_path, OciTag::new("latest").unwrap()).unwrap();
+                        let mut sbox = MultiUseSandbox::from_snapshot(
+                            std::sync::Arc::new(loaded),
+                            HostFunctions::default(),
+                            None,
+                        )
+                        .unwrap();
+                        sbox.call::<String>("Echo", "hello\n".to_string()).unwrap();
+                        sbox
+                    },
+                    criterion::BatchSize::PerIteration,
+                );
+            },
+        );
+    }
+
+    group.finish();
+}
+
 criterion_group! {
     name = benches;
     config = Criterion::default();
@@ -561,6 +727,7 @@ criterion_group! {
         guest_call_benchmark_large_param,
         function_call_serialization_benchmark,
         sample_workloads_benchmark,
-        shared_memory_benchmark
+        shared_memory_benchmark,
+        snapshot_file_benchmark
 }
 criterion_main!(benches);

--- a/src/hyperlight_host/src/mem/shared_mem.rs
+++ b/src/hyperlight_host/src/mem/shared_mem.rs
@@ -1568,6 +1568,8 @@ impl ReadonlySharedMemory {
     fn map_file(file: &std::fs::File, len: usize) -> Result<Arc<HostMapping>> {
         use std::os::unix::io::AsRawFd;
 
+        #[cfg(mshv3)]
+        use libc::PROT_WRITE;
         use libc::{
             MAP_ANONYMOUS, MAP_FAILED, MAP_FIXED, MAP_NORESERVE, MAP_PRIVATE, PROT_NONE, PROT_READ,
             mmap, off_t, size_t,
@@ -1605,9 +1607,17 @@ impl ReadonlySharedMemory {
         };
 
         // 2. Overlay the file content on the middle slot with
-        //    `MAP_FIXED`. The guest maps these pages READ|EXECUTE,
-        //    so the host VMA is read-only. `MAP_PRIVATE` keeps the
-        //    mapping detached from the underlying file.
+        //    `MAP_FIXED`. `MAP_PRIVATE` keeps the mapping detached
+        //    from the underlying file.
+        //
+        //    MSHV's map_user_memory requires host-writable pages
+        //    (the kernel module calls `pin_user_pages(FOLL_PIN|FOLL_WRITE)`
+        //    on the region when it is mapped into the partition).
+        //    KVM accepts read-only host pages for read-only guest slots.
+        #[cfg(mshv3)]
+        let file_prot = PROT_READ | PROT_WRITE;
+        #[cfg(not(mshv3))]
+        let file_prot = PROT_READ;
         // SAFETY: `total_size = len + 2 * PAGE_SIZE_USIZE`, so
         // `base + PAGE_SIZE_USIZE` is in-bounds of the reservation.
         let usable_ptr = unsafe { (base as *mut u8).add(PAGE_SIZE_USIZE) };
@@ -1620,7 +1630,7 @@ impl ReadonlySharedMemory {
             mmap(
                 usable_ptr as *mut c_void,
                 len as size_t,
-                PROT_READ,
+                file_prot,
                 MAP_PRIVATE | MAP_FIXED | MAP_NORESERVE,
                 fd,
                 0 as off_t,

--- a/src/hyperlight_host/src/mem/shared_mem.rs
+++ b/src/hyperlight_host/src/mem/shared_mem.rs
@@ -1521,7 +1521,6 @@ impl ReadonlySharedMemory {
     /// The file's length must be a non-zero multiple of `PAGE_SIZE`.
     /// `guest_mapped_size` must be a non-zero multiple of `PAGE_SIZE`
     /// no greater than the file's length.
-    #[cfg_attr(not(test), expect(dead_code))]
     pub(crate) fn from_file(file: &std::fs::File, guest_mapped_size: usize) -> Result<Self> {
         let len: usize = file
             .metadata()

--- a/src/hyperlight_host/src/sandbox/initialized_multi_use.rs
+++ b/src/hyperlight_host/src/sandbox/initialized_multi_use.rs
@@ -160,6 +160,21 @@ impl MultiUseSandbox {
     /// # Ok(())
     /// # }
     /// ```
+    ///
+    /// From a snapshot loaded from disk:
+    ///
+    /// ```no_run
+    /// # use std::sync::Arc;
+    /// # use hyperlight_host::{HostFunctions, MultiUseSandbox};
+    /// # use hyperlight_host::sandbox::snapshot::{OciTag, Snapshot};
+    /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let tag = OciTag::new("latest")?;
+    /// let snapshot = Arc::new(Snapshot::load("./guest_snapshot", tag)?);
+    /// let mut sandbox = MultiUseSandbox::from_snapshot(snapshot, HostFunctions::default(), None)?;
+    /// let result: String = sandbox.call("Echo", "hello".to_string())?;
+    /// # Ok(())
+    /// # }
+    /// ```
     #[instrument(err(Debug), skip_all, parent = Span::current(), level = "Trace")]
     pub fn from_snapshot(
         snapshot: Arc<Snapshot>,

--- a/src/hyperlight_host/src/sandbox/snapshot/file/config.rs
+++ b/src/hyperlight_host/src/sandbox/snapshot/file/config.rs
@@ -1,0 +1,581 @@
+/*
+Copyright 2025 The Hyperlight Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use hyperlight_common::flatbuffer_wrappers::function_types::{ParameterType, ReturnType};
+use hyperlight_common::flatbuffer_wrappers::host_function_definition::HostFunctionDefinition;
+use hyperlight_common::vmem::PAGE_SIZE;
+use serde::{Deserialize, Serialize};
+
+use super::media_types::SNAPSHOT_ABI_VERSION;
+use crate::hypervisor::regs::{CommonSegmentRegister, CommonSpecialRegisters, CommonTableRegister};
+use crate::mem::layout::SandboxMemoryLayout;
+
+// --- Arch and hypervisor identifiers --------------------------------
+
+/// Guest architecture the snapshot was captured for. Checked on load
+/// against the running host.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub(super) enum Arch {
+    X86_64,
+    Aarch64,
+}
+
+impl Arch {
+    pub(super) fn current() -> Self {
+        #[cfg(target_arch = "x86_64")]
+        {
+            Self::X86_64
+        }
+        #[cfg(target_arch = "aarch64")]
+        {
+            Self::Aarch64
+        }
+    }
+
+    /// Lowercase token matching the config JSON serialization, used
+    /// for the advisory arch annotation on the manifest descriptor.
+    pub(super) fn as_str(&self) -> &'static str {
+        match self {
+            Self::X86_64 => "x86_64",
+            Self::Aarch64 => "aarch64",
+        }
+    }
+}
+
+/// Hypervisor backend the snapshot was captured under. Checked on
+/// load because vCPU register state is backend-specific.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub(super) enum Hypervisor {
+    Kvm,
+    Mshv,
+    Whp,
+}
+
+impl Hypervisor {
+    pub(super) fn current() -> Option<Self> {
+        #[allow(unused_imports)]
+        use crate::hypervisor::virtual_machine::HypervisorType;
+        use crate::hypervisor::virtual_machine::get_available_hypervisor;
+
+        match get_available_hypervisor() {
+            #[cfg(kvm)]
+            Some(HypervisorType::Kvm) => Some(Self::Kvm),
+            #[cfg(mshv3)]
+            Some(HypervisorType::Mshv) => Some(Self::Mshv),
+            #[cfg(target_os = "windows")]
+            Some(HypervisorType::Whp) => Some(Self::Whp),
+            None => None,
+        }
+    }
+
+    fn name(&self) -> &'static str {
+        match self {
+            Self::Kvm => "KVM",
+            Self::Mshv => "MSHV",
+            Self::Whp => "WHP",
+        }
+    }
+
+    /// Lowercase token matching the config JSON serialization, used
+    /// for the advisory hypervisor annotation on the manifest
+    /// descriptor.
+    pub(super) fn as_str(&self) -> &'static str {
+        match self {
+            Self::Kvm => "kvm",
+            Self::Mshv => "mshv",
+            Self::Whp => "whp",
+        }
+    }
+}
+
+// --- Config JSON shape ----------------------------------------------
+
+/// Top-level Hyperlight snapshot config JSON. Lives at
+/// `blobs/sha256/<config-digest>` with media type
+/// `application/vnd.hyperlight.snapshot.config.v1+json`.
+///
+/// In OCI terms this is the "image config" blob that the manifest's
+/// `config` descriptor points to. It describes the accompanying
+/// memory layer (the snapshot bytes) and everything the loader needs
+/// to reconstruct a runnable `Snapshot`.
+#[derive(Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(super) struct OciSnapshotConfig {
+    /// Hyperlight crate version that produced this config. Recorded
+    /// for diagnostics. Not checked on load.
+    pub(super) hyperlight_version: String,
+    pub(super) arch: Arch,
+    /// Memory blob ABI version. See `SNAPSHOT_ABI_VERSION`.
+    pub(super) abi_version: u32,
+    pub(super) hypervisor: Hypervisor,
+    /// Top of the guest stack, in guest virtual address space.
+    pub(super) stack_top_gva: u64,
+    /// Guest virtual address the loader resumes the paused call at.
+    pub(super) entrypoint_addr: u64,
+    /// Special registers captured from the paused vCPU, restored
+    /// verbatim when resuming the call.
+    pub(super) sregs: Sregs,
+    pub(super) layout: MemoryLayout,
+    /// Total size of the memory blob in bytes (including the guest
+    /// page-table tail, if any). Equal to `self.memory.mem_size()`.
+    pub(super) memory_size: u64,
+    /// Names and signatures of host functions registered when this
+    /// snapshot was taken. Validated against the loader's registry.
+    pub(super) host_functions: Vec<HostFunction>,
+    /// Generation counter for the snapshot. Restored verbatim into
+    /// the `Snapshot` so guest-visible bookkeeping at
+    /// `SCRATCH_TOP_SNAPSHOT_GENERATION_OFFSET` is continuous across
+    /// save/load.
+    pub(super) snapshot_generation: u64,
+}
+
+/// Sizes and permissions of the regions inside the snapshot blob,
+/// enough for the loader to rebuild a `SandboxMemoryLayout`.
+#[derive(Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(super) struct MemoryLayout {
+    pub(super) input_data_size: usize,
+    pub(super) output_data_size: usize,
+    pub(super) heap_size: usize,
+    pub(super) code_size: usize,
+    pub(super) init_data_size: usize,
+    /// Memory region flag bits. `None` means default permissions.
+    pub(super) init_data_permissions: Option<u32>,
+    pub(super) scratch_size: usize,
+    pub(super) snapshot_size: usize,
+    pub(super) pt_size: Option<usize>,
+}
+
+/// Name and signature of one host function registered when the
+/// snapshot was taken. The loader validates these against the
+/// registry of the sandbox it is restoring into.
+#[derive(Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(super) struct HostFunction {
+    function_name: String,
+    parameter_types: Vec<ParameterTypeRepr>,
+    return_type: ReturnTypeRepr,
+}
+
+/// JSON-friendly mirror of
+/// [`hyperlight_common::flatbuffer_wrappers::function_types::ParameterType`].
+/// Kept local so we don't have to plumb serde through `hyperlight_common`.
+/// The `match`es below are exhaustive: any new variant upstream forces
+/// an explicit decision here.
+#[derive(Serialize, Deserialize, Copy, Clone)]
+#[serde(rename_all = "snake_case")]
+enum ParameterTypeRepr {
+    Int,
+    UInt,
+    Long,
+    ULong,
+    Float,
+    Double,
+    String,
+    Bool,
+    VecBytes,
+}
+
+/// JSON-friendly mirror of
+/// [`hyperlight_common::flatbuffer_wrappers::function_types::ReturnType`].
+#[derive(Serialize, Deserialize, Copy, Clone)]
+#[serde(rename_all = "snake_case")]
+enum ReturnTypeRepr {
+    Int,
+    UInt,
+    Long,
+    ULong,
+    Float,
+    Double,
+    String,
+    Bool,
+    Void,
+    VecBytes,
+}
+
+impl From<&ParameterType> for ParameterTypeRepr {
+    fn from(p: &ParameterType) -> Self {
+        match p {
+            ParameterType::Int => Self::Int,
+            ParameterType::UInt => Self::UInt,
+            ParameterType::Long => Self::Long,
+            ParameterType::ULong => Self::ULong,
+            ParameterType::Float => Self::Float,
+            ParameterType::Double => Self::Double,
+            ParameterType::String => Self::String,
+            ParameterType::Bool => Self::Bool,
+            ParameterType::VecBytes => Self::VecBytes,
+        }
+    }
+}
+
+impl From<ParameterTypeRepr> for ParameterType {
+    fn from(r: ParameterTypeRepr) -> Self {
+        match r {
+            ParameterTypeRepr::Int => Self::Int,
+            ParameterTypeRepr::UInt => Self::UInt,
+            ParameterTypeRepr::Long => Self::Long,
+            ParameterTypeRepr::ULong => Self::ULong,
+            ParameterTypeRepr::Float => Self::Float,
+            ParameterTypeRepr::Double => Self::Double,
+            ParameterTypeRepr::String => Self::String,
+            ParameterTypeRepr::Bool => Self::Bool,
+            ParameterTypeRepr::VecBytes => Self::VecBytes,
+        }
+    }
+}
+
+impl From<&ReturnType> for ReturnTypeRepr {
+    fn from(r: &ReturnType) -> Self {
+        match r {
+            ReturnType::Int => Self::Int,
+            ReturnType::UInt => Self::UInt,
+            ReturnType::Long => Self::Long,
+            ReturnType::ULong => Self::ULong,
+            ReturnType::Float => Self::Float,
+            ReturnType::Double => Self::Double,
+            ReturnType::String => Self::String,
+            ReturnType::Bool => Self::Bool,
+            ReturnType::Void => Self::Void,
+            ReturnType::VecBytes => Self::VecBytes,
+        }
+    }
+}
+
+impl From<ReturnTypeRepr> for ReturnType {
+    fn from(r: ReturnTypeRepr) -> Self {
+        match r {
+            ReturnTypeRepr::Int => Self::Int,
+            ReturnTypeRepr::UInt => Self::UInt,
+            ReturnTypeRepr::Long => Self::Long,
+            ReturnTypeRepr::ULong => Self::ULong,
+            ReturnTypeRepr::Float => Self::Float,
+            ReturnTypeRepr::Double => Self::Double,
+            ReturnTypeRepr::String => Self::String,
+            ReturnTypeRepr::Bool => Self::Bool,
+            ReturnTypeRepr::Void => Self::Void,
+            ReturnTypeRepr::VecBytes => Self::VecBytes,
+        }
+    }
+}
+
+/// Captured x86_64 special registers for a paused vCPU. Round-trips
+/// to/from [`CommonSpecialRegisters`] and is restored verbatim when
+/// resuming a `Call` entrypoint.
+#[derive(Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(super) struct Sregs {
+    cs: SegmentRegister,
+    ds: SegmentRegister,
+    es: SegmentRegister,
+    fs: SegmentRegister,
+    gs: SegmentRegister,
+    ss: SegmentRegister,
+    tr: SegmentRegister,
+    ldt: SegmentRegister,
+    gdt: TableRegister,
+    idt: TableRegister,
+    cr0: u64,
+    cr2: u64,
+    // CR3 is recomputed at load from the reconstructed layout via
+    // `get_pt_base_gpa()`, so it is omitted to keep the config
+    // digest stable across re-snapshots of the same guest state.
+    cr4: u64,
+    cr8: u64,
+    efer: u64,
+    apic_base: u64,
+    interrupt_bitmap: [u64; 4],
+}
+
+/// Serde mirror of [`CommonSegmentRegister`].
+#[derive(Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct SegmentRegister {
+    base: u64,
+    limit: u32,
+    selector: u16,
+    type_: u8,
+    present: u8,
+    dpl: u8,
+    db: u8,
+    s: u8,
+    l: u8,
+    g: u8,
+    avl: u8,
+    unusable: u8,
+    padding: u8,
+}
+
+/// Serde mirror of [`CommonTableRegister`].
+#[derive(Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct TableRegister {
+    base: u64,
+    limit: u16,
+}
+
+// --- Conversions between repr and runtime types ---------------------
+
+impl From<&CommonSpecialRegisters> for Sregs {
+    fn from(s: &CommonSpecialRegisters) -> Self {
+        let seg = |r: &CommonSegmentRegister| SegmentRegister {
+            base: r.base,
+            limit: r.limit,
+            selector: r.selector,
+            type_: r.type_,
+            present: r.present,
+            dpl: r.dpl,
+            db: r.db,
+            s: r.s,
+            l: r.l,
+            g: r.g,
+            avl: r.avl,
+            unusable: r.unusable,
+            padding: r.padding,
+        };
+        let tab = |r: &CommonTableRegister| TableRegister {
+            base: r.base,
+            limit: r.limit,
+        };
+        Self {
+            cs: seg(&s.cs),
+            ds: seg(&s.ds),
+            es: seg(&s.es),
+            fs: seg(&s.fs),
+            gs: seg(&s.gs),
+            ss: seg(&s.ss),
+            tr: seg(&s.tr),
+            ldt: seg(&s.ldt),
+            gdt: tab(&s.gdt),
+            idt: tab(&s.idt),
+            cr0: s.cr0,
+            cr2: s.cr2,
+            cr4: s.cr4,
+            cr8: s.cr8,
+            efer: s.efer,
+            apic_base: s.apic_base,
+            interrupt_bitmap: s.interrupt_bitmap,
+        }
+    }
+}
+
+impl From<Sregs> for CommonSpecialRegisters {
+    fn from(r: Sregs) -> Self {
+        let seg = |s: SegmentRegister| CommonSegmentRegister {
+            base: s.base,
+            limit: s.limit,
+            selector: s.selector,
+            type_: s.type_,
+            present: s.present,
+            dpl: s.dpl,
+            db: s.db,
+            s: s.s,
+            l: s.l,
+            g: s.g,
+            avl: s.avl,
+            unusable: s.unusable,
+            padding: s.padding,
+        };
+        let tab = |t: TableRegister| CommonTableRegister {
+            base: t.base,
+            limit: t.limit,
+        };
+        Self {
+            cs: seg(r.cs),
+            ds: seg(r.ds),
+            es: seg(r.es),
+            fs: seg(r.fs),
+            gs: seg(r.gs),
+            ss: seg(r.ss),
+            tr: seg(r.tr),
+            ldt: seg(r.ldt),
+            gdt: tab(r.gdt),
+            idt: tab(r.idt),
+            cr0: r.cr0,
+            cr2: r.cr2,
+            cr3: 0,
+            cr4: r.cr4,
+            cr8: r.cr8,
+            efer: r.efer,
+            apic_base: r.apic_base,
+            interrupt_bitmap: r.interrupt_bitmap,
+        }
+    }
+}
+
+impl From<&HostFunctionDefinition> for HostFunction {
+    fn from(d: &HostFunctionDefinition) -> Self {
+        let parameter_types = d
+            .parameter_types
+            .as_ref()
+            .map(|v| v.iter().map(ParameterTypeRepr::from).collect())
+            .unwrap_or_default();
+        Self {
+            function_name: d.function_name.clone(),
+            parameter_types,
+            return_type: ReturnTypeRepr::from(&d.return_type),
+        }
+    }
+}
+
+impl From<HostFunction> for HostFunctionDefinition {
+    fn from(r: HostFunction) -> Self {
+        Self {
+            function_name: r.function_name,
+            parameter_types: Some(r.parameter_types.into_iter().map(Into::into).collect()),
+            return_type: r.return_type.into(),
+        }
+    }
+}
+
+impl OciSnapshotConfig {
+    pub(super) fn validate_for_load(&self) -> crate::Result<()> {
+        if self.arch != Arch::current() {
+            return Err(crate::new_error!(
+                "snapshot architecture mismatch: file is {:?}, current host is {:?} \
+                 (snapshot produced by hyperlight {})",
+                self.arch,
+                Arch::current(),
+                self.hyperlight_version
+            ));
+        }
+        if self.abi_version != SNAPSHOT_ABI_VERSION {
+            return Err(crate::new_error!(
+                "snapshot ABI version mismatch: file has version {}, this build expects {}. \
+                 The snapshot must be regenerated from the guest binary \
+                 (snapshot produced by hyperlight {}).",
+                self.abi_version,
+                SNAPSHOT_ABI_VERSION,
+                self.hyperlight_version
+            ));
+        }
+        let current_hv = Hypervisor::current()
+            .ok_or_else(|| crate::new_error!("no hypervisor available to load snapshot"))?;
+        if self.hypervisor != current_hv {
+            return Err(crate::new_error!(
+                "snapshot hypervisor mismatch: file was created on {} but the current hypervisor is {} \
+                 (snapshot produced by hyperlight {})",
+                self.hypervisor.name(),
+                current_hv.name(),
+                self.hyperlight_version
+            ));
+        }
+        // Bound memory size early so the subsequent file-size check
+        // does not have to deal with absurd values.
+        if self.memory_size == 0 || self.memory_size > SandboxMemoryLayout::MAX_MEMORY_SIZE as u64 {
+            return Err(crate::new_error!(
+                "snapshot memory_size ({}) is out of range",
+                self.memory_size
+            ));
+        }
+        if !(self.memory_size as usize).is_multiple_of(PAGE_SIZE) {
+            return Err(crate::new_error!(
+                "snapshot memory_size ({}) is not a multiple of PAGE_SIZE",
+                self.memory_size
+            ));
+        }
+        // `snapshot_size` is the guest-visible prefix of the blob,
+        // mapped at `BASE_ADDRESS`. `pt_size` is the page-table tail
+        // after it, present in the blob and host mapping but outside
+        // the guest mapping. They sum to `memory_size`.
+        if self.layout.snapshot_size == 0 {
+            return Err(crate::new_error!("snapshot snapshot_size must be nonzero"));
+        }
+        if !self.layout.snapshot_size.is_multiple_of(PAGE_SIZE) {
+            return Err(crate::new_error!(
+                "snapshot snapshot_size ({}) is not a multiple of PAGE_SIZE",
+                self.layout.snapshot_size
+            ));
+        }
+        let pt = self.layout.pt_size.unwrap_or(0);
+        if !pt.is_multiple_of(PAGE_SIZE) {
+            return Err(crate::new_error!(
+                "snapshot pt_size ({}) is not a multiple of PAGE_SIZE",
+                pt
+            ));
+        }
+        if (self.layout.snapshot_size as u64).saturating_add(pt as u64) != self.memory_size {
+            return Err(crate::new_error!(
+                "snapshot snapshot_size ({}) + pt_size ({}) does not equal memory_size ({})",
+                self.layout.snapshot_size,
+                pt,
+                self.memory_size
+            ));
+        }
+        // Cap each layout field at `MAX_MEMORY_SIZE` so the later
+        // size and offset sums in `SandboxMemoryLayout` cannot
+        // overflow `u64`. Whether the regions fit the snapshot is
+        // checked against `snapshot_size` in `load_inner`.
+        let max_region = SandboxMemoryLayout::MAX_MEMORY_SIZE;
+        for (name, value) in [
+            ("input_data_size", self.layout.input_data_size),
+            ("output_data_size", self.layout.output_data_size),
+            ("heap_size", self.layout.heap_size),
+            ("code_size", self.layout.code_size),
+            ("init_data_size", self.layout.init_data_size),
+            ("scratch_size", self.layout.scratch_size),
+        ] {
+            if value > max_region {
+                return Err(crate::new_error!(
+                    "snapshot layout field {} ({}) exceeds maximum allowed {}",
+                    name,
+                    value,
+                    max_region
+                ));
+            }
+        }
+
+        // Entrypoint address must point inside the guest snapshot
+        // region `[BASE_ADDRESS, BASE_ADDRESS + snapshot_size)`. The
+        // address is a GVA, bounded by the same range because guests
+        // identity-map the snapshot region at low VAs. A guest
+        // dispatching from a non-identity-mapped VA must relax this
+        // check.
+        let snap_lo = SandboxMemoryLayout::BASE_ADDRESS as u64;
+        let snap_hi = snap_lo
+            .checked_add(self.layout.snapshot_size as u64)
+            .ok_or_else(|| {
+                crate::new_error!(
+                    "snapshot layout overflow: BASE_ADDRESS + snapshot_size ({}) does not fit in u64",
+                    self.layout.snapshot_size
+                )
+            })?;
+        if self.entrypoint_addr < snap_lo || self.entrypoint_addr >= snap_hi {
+            return Err(crate::new_error!(
+                "snapshot entrypoint addr {:#x} is outside the snapshot region [{:#x}, {:#x})",
+                self.entrypoint_addr,
+                snap_lo,
+                snap_hi
+            ));
+        }
+
+        // `stack_top_gva` is restored into the guest stack pointer.
+        // Bound it to the architecture's addressable GVA range so a
+        // malformed config cannot install an out-of-range stack
+        // pointer. The range is `(0, MAX_GVA]`.
+        let max_gva = hyperlight_common::layout::MAX_GVA as u64;
+        if self.stack_top_gva == 0 || self.stack_top_gva > max_gva {
+            return Err(crate::new_error!(
+                "snapshot stack_top_gva {:#x} is outside the valid range (0, {:#x}]",
+                self.stack_top_gva,
+                max_gva
+            ));
+        }
+        Ok(())
+    }
+}

--- a/src/hyperlight_host/src/sandbox/snapshot/file/config.rs
+++ b/src/hyperlight_host/src/sandbox/snapshot/file/config.rs
@@ -579,3 +579,120 @@ impl OciSnapshotConfig {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use hyperlight_common::flatbuffer_wrappers::function_types::{ParameterType, ReturnType};
+
+    use super::*;
+
+    /// Build a `CommonSegmentRegister` whose every field holds a
+    /// distinct value, so a transposed field in the `Sregs`
+    /// conversion produces an inequality.
+    fn distinct_segment(start: u64) -> CommonSegmentRegister {
+        CommonSegmentRegister {
+            base: start,
+            limit: (start + 1) as u32,
+            selector: (start + 2) as u16,
+            type_: (start + 3) as u8,
+            present: (start + 4) as u8,
+            dpl: (start + 5) as u8,
+            db: (start + 6) as u8,
+            s: (start + 7) as u8,
+            l: (start + 8) as u8,
+            g: (start + 9) as u8,
+            avl: (start + 10) as u8,
+            unusable: (start + 11) as u8,
+            padding: (start + 12) as u8,
+        }
+    }
+
+    fn distinct_table(start: u64) -> CommonTableRegister {
+        CommonTableRegister {
+            base: start,
+            limit: (start + 1) as u16,
+        }
+    }
+
+    /// Special registers with a unique value in every field, including
+    /// a nonzero `cr3`.
+    fn distinct_sregs() -> CommonSpecialRegisters {
+        CommonSpecialRegisters {
+            cs: distinct_segment(10),
+            ds: distinct_segment(30),
+            es: distinct_segment(50),
+            fs: distinct_segment(70),
+            gs: distinct_segment(90),
+            ss: distinct_segment(110),
+            tr: distinct_segment(130),
+            ldt: distinct_segment(150),
+            gdt: distinct_table(170),
+            idt: distinct_table(180),
+            cr0: 200,
+            cr2: 201,
+            cr3: 202,
+            cr4: 203,
+            cr8: 204,
+            efer: 205,
+            apic_base: 206,
+            interrupt_bitmap: [207, 208, 209, 210],
+        }
+    }
+
+    /// Round-tripping special registers through the serde mirror
+    /// preserves every field. `cr3` is the sole exception: it is
+    /// omitted from the config and recomputed at load, so it returns
+    /// as zero.
+    #[test]
+    fn sregs_round_trip_preserves_all_fields_except_cr3() {
+        let original = distinct_sregs();
+        let restored: CommonSpecialRegisters = Sregs::from(&original).into();
+
+        let mut expected = original;
+        expected.cr3 = 0;
+        assert_eq!(restored, expected);
+    }
+
+    /// Every `ParameterType` survives the round-trip through its serde
+    /// mirror, guarding against a transposed variant in either match.
+    #[test]
+    fn parameter_type_repr_round_trips_every_variant() {
+        let variants = [
+            ParameterType::Int,
+            ParameterType::UInt,
+            ParameterType::Long,
+            ParameterType::ULong,
+            ParameterType::Float,
+            ParameterType::Double,
+            ParameterType::String,
+            ParameterType::Bool,
+            ParameterType::VecBytes,
+        ];
+        for p in variants {
+            let back: ParameterType = ParameterTypeRepr::from(&p).into();
+            assert_eq!(back, p, "parameter type {:?} did not round-trip", p);
+        }
+    }
+
+    /// Every `ReturnType` survives the round-trip through its serde
+    /// mirror, guarding against a transposed variant in either match.
+    #[test]
+    fn return_type_repr_round_trips_every_variant() {
+        let variants = [
+            ReturnType::Int,
+            ReturnType::UInt,
+            ReturnType::Long,
+            ReturnType::ULong,
+            ReturnType::Float,
+            ReturnType::Double,
+            ReturnType::String,
+            ReturnType::Bool,
+            ReturnType::Void,
+            ReturnType::VecBytes,
+        ];
+        for r in variants {
+            let back: ReturnType = ReturnTypeRepr::from(&r).into();
+            assert_eq!(back, r, "return type {:?} did not round-trip", r);
+        }
+    }
+}

--- a/src/hyperlight_host/src/sandbox/snapshot/file/digest.rs
+++ b/src/hyperlight_host/src/sandbox/snapshot/file/digest.rs
@@ -1,0 +1,117 @@
+/*
+Copyright 2025 The Hyperlight Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use std::io::{Read, Seek, SeekFrom};
+
+use oci_spec::image::Digest;
+use sha2::{Digest as _, Sha256};
+
+/// A `sha256:<hex>` digest as recorded in OCI manifests. The bare hex
+/// (without prefix) is also the blob's filename inside `blobs/sha256/`.
+#[derive(Clone)]
+pub(super) struct Digest256 {
+    /// Lowercase hex of the 32-byte sha256 output.
+    pub(super) hex: String,
+}
+
+impl Digest256 {
+    pub(super) fn from_bytes(bytes: &[u8]) -> Self {
+        let arr: [u8; 32] = Sha256::digest(bytes).into();
+        Self::from_digest_array(arr)
+    }
+
+    fn from_digest_array(arr: [u8; 32]) -> Self {
+        Self {
+            hex: hex::encode(arr),
+        }
+    }
+}
+
+/// Build an `oci_spec::image::Digest` from a [`Digest256`].
+pub(super) fn oci_digest(d: &Digest256) -> crate::Result<Digest> {
+    Digest::try_from(format!("sha256:{}", d.hex))
+        .map_err(|e| crate::new_error!("failed to construct OCI digest: {}", e))
+}
+
+pub(super) fn parse_oci_digest(digest: &Digest) -> crate::Result<String> {
+    let s = digest.as_ref();
+    let rest = s.strip_prefix("sha256:").ok_or_else(|| {
+        crate::new_error!(
+            "OCI descriptor digest {:?} is not a sha256 digest (only sha256 is supported)",
+            s
+        )
+    })?;
+    Ok(rest.to_string())
+}
+
+/// Compute sha256 of `bytes` and verify it equals `expected_hex`.
+/// Used to validate manifest and config blobs (small, in memory).
+pub(super) fn verify_blob_bytes(
+    label: &str,
+    bytes: &[u8],
+    expected_hex: &str,
+) -> crate::Result<()> {
+    let actual = Digest256::from_bytes(bytes);
+    if actual.hex != expected_hex {
+        return Err(crate::new_error!(
+            "{} blob digest mismatch: descriptor declares sha256:{}, file hashes to sha256:{}",
+            label,
+            expected_hex,
+            actual.hex
+        ));
+    }
+    Ok(())
+}
+
+/// Stream-hash an open file and verify its sha256 equals
+/// `expected_hex`.
+///
+/// Takes the same `File` handle the caller will subsequently `mmap`,
+/// not a path. Hashing one open and mapping another is open-then-
+/// replace TOCTOU bait. Seeks to start before and after so the
+/// caller's file position is unchanged.
+pub(super) fn verify_blob_file(
+    label: &str,
+    file: &mut std::fs::File,
+    expected_hex: &str,
+) -> crate::Result<()> {
+    file.seek(SeekFrom::Start(0))
+        .map_err(|e| crate::new_error!("failed to seek {} blob: {}", label, e))?;
+    let mut hasher = Sha256::new();
+    let mut buf = [0u8; 64 * 1024];
+    loop {
+        let n = file
+            .read(&mut buf)
+            .map_err(|e| crate::new_error!("failed to read {} blob: {}", label, e))?;
+        if n == 0 {
+            break;
+        }
+        hasher.update(&buf[..n]);
+    }
+    file.seek(SeekFrom::Start(0))
+        .map_err(|e| crate::new_error!("failed to rewind {} blob: {}", label, e))?;
+    let arr: [u8; 32] = hasher.finalize().into();
+    let actual = Digest256::from_digest_array(arr);
+    if actual.hex != expected_hex {
+        return Err(crate::new_error!(
+            "{} blob digest mismatch: descriptor declares sha256:{}, file hashes to sha256:{}",
+            label,
+            expected_hex,
+            actual.hex
+        ));
+    }
+    Ok(())
+}

--- a/src/hyperlight_host/src/sandbox/snapshot/file/fsutil.rs
+++ b/src/hyperlight_host/src/sandbox/snapshot/file/fsutil.rs
@@ -1,0 +1,157 @@
+/*
+Copyright 2025 The Hyperlight Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use std::io::{Read, Write};
+use std::path::Path;
+
+use tempfile::NamedTempFile;
+
+use super::digest::{Digest256, verify_blob_file};
+
+/// Replace `target` atomically: a reader either sees the old
+/// contents or the full new contents, never a partial write. A
+/// failure before commit leaves `target` untouched and removes the
+/// staging file.
+pub(super) fn replace_file_atomic(target: &Path, bytes: &[u8]) -> crate::Result<()> {
+    let parent = target.parent().ok_or_else(|| {
+        crate::new_error!("atomic write: target {:?} has no parent directory", target)
+    })?;
+    let mut tmp = NamedTempFile::new_in(parent).map_err(|e| {
+        crate::new_error!("atomic write: failed to create tmp in {:?}: {}", parent, e)
+    })?;
+    tmp.write_all(bytes).map_err(|e| {
+        crate::new_error!("atomic write: failed to write tmp {:?}: {}", tmp.path(), e)
+    })?;
+    tmp.as_file_mut().sync_all().map_err(|e| {
+        crate::new_error!("atomic write: failed to sync tmp {:?}: {}", tmp.path(), e)
+    })?;
+    tmp.persist(target).map_err(|e| {
+        crate::new_error!("atomic write: failed to persist tmp to {:?}: {}", target, e)
+    })?;
+    Ok(())
+}
+
+/// Write a content-addressed blob into `blobs_dir` unconditionally,
+/// via [`replace_file_atomic`]. Intended for small blobs (manifest,
+/// config) where the cost of an extra atomic write is negligible
+/// compared to the cost of reading and re-hashing the existing file.
+pub(super) fn put_blob(blobs_dir: &Path, digest: &Digest256, bytes: &[u8]) -> crate::Result<()> {
+    replace_file_atomic(&blobs_dir.join(&digest.hex), bytes)
+}
+
+/// Write a content-addressed blob into `blobs_dir`, reusing the
+/// existing file at `blobs_dir/<hex>` only if it is present, has the
+/// expected length, AND hashes to `digest`. A wrong-content file of
+/// the right length (corruption, partial copy, foreign tool) is
+/// overwritten.
+///
+/// Intended for the large snapshot blob, where the cost of one full
+/// re-hash of the existing file is far less than the cost of an
+/// unconditional rewrite.
+pub(super) fn put_blob_if_absent(
+    blobs_dir: &Path,
+    digest: &Digest256,
+    bytes: &[u8],
+) -> crate::Result<()> {
+    let target = blobs_dir.join(&digest.hex);
+    if let Ok(meta) = std::fs::symlink_metadata(&target)
+        && meta.is_file()
+        && meta.len() == bytes.len() as u64
+        && let Ok(mut file) = std::fs::File::open(&target)
+        && verify_blob_file("existing snapshot", &mut file, &digest.hex).is_ok()
+    {
+        return Ok(());
+    }
+    replace_file_atomic(&target, bytes)
+}
+
+/// Reject a path that is a symbolic link.
+///
+/// Blobs in an OCI layout are content-addressed regular files. A
+/// symlink in their place could redirect a read outside the layout
+/// directory, so refuse it before opening. A missing path passes
+/// this check so the caller's open reports the absence with one
+/// consistent error.
+#[cfg(not(unix))]
+pub(super) fn reject_symlink(path: &Path) -> crate::Result<()> {
+    let meta = match std::fs::symlink_metadata(path) {
+        Ok(meta) => meta,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(e) => return Err(crate::new_error!("failed to stat {:?}: {}", path, e)),
+    };
+    if meta.file_type().is_symlink() {
+        return Err(crate::new_error!(
+            "{:?} is a symbolic link; refusing to follow it",
+            path
+        ));
+    }
+    Ok(())
+}
+
+/// Open a blob file for reading without following a final-component
+/// symlink. A missing file maps to a fixed "not found" error whose
+/// text is the same on every platform, so callers and tests do not
+/// depend on the OS wording for a missing file.
+pub(super) fn open_no_follow(path: &Path) -> crate::Result<std::fs::File> {
+    // On unix, `O_NOFOLLOW` rejects a final-component symlink in the
+    // same syscall that opens the file, so there is no window between
+    // a stat and the open for the path to be swapped. On other
+    // platforms, a stat-then-open pre-check is the available option.
+    #[cfg(unix)]
+    let opened = {
+        use std::os::unix::fs::OpenOptionsExt;
+        std::fs::OpenOptions::new()
+            .read(true)
+            .custom_flags(libc::O_NOFOLLOW)
+            .open(path)
+    };
+    #[cfg(not(unix))]
+    let opened = {
+        reject_symlink(path)?;
+        std::fs::File::open(path)
+    };
+    opened.map_err(|e| {
+        if e.kind() == std::io::ErrorKind::NotFound {
+            crate::new_error!("blob file {:?} not found", path)
+        } else {
+            crate::new_error!("failed to open {:?}: {}", path, e)
+        }
+    })
+}
+
+/// Read a file in full, refusing if the file is bigger than `max_size`.
+///
+/// The cap is enforced on the actual byte stream via [`Read::take`], so files
+/// whose `metadata().len()` is misleading cannot exceed the limit. Symbolic
+/// links are rejected.
+pub(super) fn read_bounded(path: &Path, max_size: u64) -> crate::Result<Vec<u8>> {
+    let f = open_no_follow(path)?;
+    let hint = f.metadata().map(|m| m.len().min(max_size)).unwrap_or(0);
+    let mut buf = Vec::with_capacity(hint as usize);
+    // Read one extra byte so an oversize file is detected as "over the
+    // limit" and rejected, never silently truncated to the cap.
+    f.take(max_size.saturating_add(1))
+        .read_to_end(&mut buf)
+        .map_err(|e| crate::new_error!("failed to read {:?}: {}", path, e))?;
+    if buf.len() as u64 > max_size {
+        return Err(crate::new_error!(
+            "file {:?} exceeds maximum allowed {} bytes",
+            path,
+            max_size
+        ));
+    }
+    Ok(buf)
+}

--- a/src/hyperlight_host/src/sandbox/snapshot/file/media_types.rs
+++ b/src/hyperlight_host/src/sandbox/snapshot/file/media_types.rs
@@ -1,0 +1,48 @@
+/*
+Copyright 2025 The Hyperlight Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Media types are versioned by suffix. The loader matches each
+// version specifically (no `_CURRENT` shortcut on the read side); the
+// writer always emits `_CURRENT`. A new version is added by:
+//
+//   1. Declare `MT_FOO_V2` next to `MT_FOO_V1`.
+//   2. Point `MT_FOO_CURRENT` at `MT_FOO_V2`.
+//   3. Add a dispatch arm in the loader that converts v1 -> v2 (or
+//      rejects v1 if no compatibility window is offered).
+pub(super) const MT_CONFIG_V1: &str = "application/vnd.hyperlight.snapshot.config.v1+json";
+pub(super) const MT_CONFIG_CURRENT: &str = MT_CONFIG_V1;
+pub(super) const MT_SNAPSHOT_V1: &str = "application/vnd.hyperlight.snapshot.memory.v1";
+pub(super) const MT_SNAPSHOT_CURRENT: &str = MT_SNAPSHOT_V1;
+
+/// ABI version for the snapshot memory blob. Bumped whenever the
+/// host-guest contract for the bytes inside the snapshot blob changes
+/// (PEB layout, calling convention, init state, etc.). Independent of
+/// the config blob's media-type version.
+pub(super) const SNAPSHOT_ABI_VERSION: u32 = 1;
+
+/// OCI standard annotation key for a manifest's tag inside an image
+/// index. Set on the manifest descriptor in `index.json`, not on the
+/// manifest blob itself. See the OCI Image Spec, "Annotations" and
+/// the Image Layout spec.
+pub(super) const ANNOTATION_REF_NAME: &str = "org.opencontainers.image.ref.name";
+
+/// Advisory annotation keys recording the guest arch and hypervisor
+/// backend on the manifest descriptor in `index.json`. These mirror
+/// the authoritative `arch` and `hypervisor` fields in the config
+/// blob so registry UIs and tools like `oras` and `skopeo` can show
+/// them. The loader validates against the config blob.
+pub(super) const ANNOTATION_ARCH: &str = "dev.hyperlight.snapshot.arch";
+pub(super) const ANNOTATION_HYPERVISOR: &str = "dev.hyperlight.snapshot.hypervisor";

--- a/src/hyperlight_host/src/sandbox/snapshot/file/mod.rs
+++ b/src/hyperlight_host/src/sandbox/snapshot/file/mod.rs
@@ -1,0 +1,862 @@
+/*
+Copyright 2025 The Hyperlight Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! OCI Image Layout serde for [`Snapshot`]. See
+//! `docs/snapshot-oci-format.md` for the on-disk format.
+
+mod config;
+mod digest;
+mod fsutil;
+mod media_types;
+pub(crate) mod reference;
+
+use std::path::{Path, PathBuf};
+
+use hyperlight_common::flatbuffer_wrappers::host_function_details::HostFunctionDetails;
+use hyperlight_common::vmem::PAGE_SIZE;
+use oci_spec::image::{
+    Descriptor, DescriptorBuilder, ImageIndex, ImageIndexBuilder, ImageManifest,
+    ImageManifestBuilder, MediaType, SCHEMA_VERSION,
+};
+
+use self::config::{Arch, HostFunction, Hypervisor, MemoryLayout, OciSnapshotConfig, Sregs};
+use self::digest::{Digest256, oci_digest, parse_oci_digest, verify_blob_bytes, verify_blob_file};
+use self::fsutil::{put_blob, put_blob_if_absent, read_bounded, replace_file_atomic};
+use self::media_types::{
+    ANNOTATION_ARCH, ANNOTATION_HYPERVISOR, ANNOTATION_REF_NAME, MT_CONFIG_CURRENT, MT_CONFIG_V1,
+    MT_SNAPSHOT_CURRENT, MT_SNAPSHOT_V1, SNAPSHOT_ABI_VERSION,
+};
+use self::reference::{OciDigest, OciReference, OciTag};
+use super::{NextAction, Snapshot};
+use crate::hypervisor::regs::CommonSpecialRegisters;
+use crate::mem::layout::SandboxMemoryLayout;
+use crate::mem::memory_region::MemoryRegionFlags;
+use crate::mem::shared_mem::{ReadonlySharedMemory, SharedMemory};
+
+const OCI_LAYOUT_VERSION: &str = "1.0.0";
+
+/// Maximum size of any JSON blob read from disk during load:
+/// `oci-layout`, `index.json`, the OCI image manifest, and the
+/// Hyperlight config blob. Bounds the allocation done before parsing.
+const MAX_JSON_BLOB_SIZE: u64 = 1024 * 1024;
+
+/// Reject a JSON artifact larger than the cap the loader reads with
+/// [`read_bounded`]. The writer holds to the same cap so every layout
+/// it writes can be read back. `what` names the artifact in the error.
+fn check_json_blob_size(what: &str, len: usize) -> crate::Result<()> {
+    if len as u64 > MAX_JSON_BLOB_SIZE {
+        return Err(crate::new_error!(
+            "{} of {} bytes exceeds the {} byte maximum for a snapshot artifact",
+            what,
+            len,
+            MAX_JSON_BLOB_SIZE
+        ));
+    }
+    Ok(())
+}
+
+/// Select one manifest descriptor from `index` by `reference`.
+///
+/// A tag matches the `org.opencontainers.image.ref.name` annotation
+/// and must be unique. A digest matches the manifest content digest.
+/// Identical manifests shared across tags select the first, since
+/// they are byte-for-byte equal.
+fn select_manifest<'a>(
+    index: &'a ImageIndex,
+    reference: &OciReference,
+    path: &Path,
+) -> crate::Result<&'a Descriptor> {
+    match reference {
+        OciReference::Tag(tag) => {
+            let mut matching = index.manifests().iter().filter(|d| {
+                d.annotations()
+                    .as_ref()
+                    .and_then(|a| a.get(ANNOTATION_REF_NAME))
+                    .map(|s| s.as_str() == tag.as_str())
+                    .unwrap_or(false)
+            });
+            match (matching.next(), matching.next()) {
+                (None, _) => {
+                    let known: Vec<&str> = index
+                        .manifests()
+                        .iter()
+                        .filter_map(|d| {
+                            d.annotations()
+                                .as_ref()
+                                .and_then(|a| a.get(ANNOTATION_REF_NAME))
+                                .map(|s| s.as_str())
+                        })
+                        .collect();
+                    Err(crate::new_error!(
+                        "no manifest tagged {:?} in OCI layout {:?}. Available tags: {:?}",
+                        tag.as_str(),
+                        path,
+                        known
+                    ))
+                }
+                (Some(_), Some(_)) => Err(crate::new_error!(
+                    "OCI layout {:?} has multiple manifests tagged {:?}; tags must be unique",
+                    path,
+                    tag.as_str()
+                )),
+                (Some(d), None) => Ok(d),
+            }
+        }
+        OciReference::Digest(digest) => index
+            .manifests()
+            .iter()
+            .find(|d| d.digest().to_string() == digest.as_str())
+            .ok_or_else(|| {
+                crate::new_error!(
+                    "no manifest with digest {} in OCI layout {:?}",
+                    digest.as_str(),
+                    path
+                )
+            }),
+    }
+}
+
+fn read_layout_marker(path: &Path) -> crate::Result<()> {
+    let layout_bytes = read_bounded(&path.join("oci-layout"), MAX_JSON_BLOB_SIZE)
+        .map_err(|e| crate::new_error!("failed to read oci-layout: {}", e))?;
+    let layout_json: serde_json::Value = serde_json::from_slice(&layout_bytes)
+        .map_err(|e| crate::new_error!("oci-layout is not valid JSON: {}", e))?;
+    let v = layout_json
+        .get("imageLayoutVersion")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| crate::new_error!("oci-layout missing imageLayoutVersion field"))?;
+    if v != OCI_LAYOUT_VERSION {
+        return Err(crate::new_error!(
+            "unsupported OCI image layout version {:?} (expected {:?})",
+            v,
+            OCI_LAYOUT_VERSION
+        ));
+    }
+    Ok(())
+}
+
+fn load_manifest(
+    path: &Path,
+    blobs_dir: &Path,
+    reference: &OciReference,
+    verify_blobs: bool,
+) -> crate::Result<ImageManifest> {
+    let index_bytes = read_bounded(&path.join("index.json"), MAX_JSON_BLOB_SIZE)
+        .map_err(|e| crate::new_error!("failed to read index.json: {}", e))?;
+    let index: ImageIndex = serde_json::from_slice(&index_bytes)
+        .map_err(|e| crate::new_error!("failed to parse index.json: {}", e))?;
+    let manifest_desc = select_manifest(&index, reference, path)?;
+    if !matches!(manifest_desc.media_type(), MediaType::ImageManifest) {
+        return Err(crate::new_error!(
+            "manifest descriptor for {} has unexpected media type {:?} (expected {:?})",
+            reference,
+            manifest_desc.media_type().to_string(),
+            MediaType::ImageManifest.to_string()
+        ));
+    }
+    let manifest_hex = parse_oci_digest(manifest_desc.digest())?;
+    let manifest_path = blobs_dir.join(&manifest_hex);
+    let manifest_bytes = read_bounded(&manifest_path, MAX_JSON_BLOB_SIZE)?;
+    if manifest_bytes.len() as u64 != manifest_desc.size() {
+        return Err(crate::new_error!(
+            "OCI manifest size mismatch: descriptor says {}, file is {}",
+            manifest_desc.size(),
+            manifest_bytes.len()
+        ));
+    }
+    if verify_blobs {
+        verify_blob_bytes("manifest", &manifest_bytes, &manifest_hex)?;
+    }
+    let manifest: ImageManifest = serde_json::from_slice(&manifest_bytes)
+        .map_err(|e| crate::new_error!("failed to parse OCI manifest JSON: {}", e))?;
+    if manifest.schema_version() != SCHEMA_VERSION {
+        return Err(crate::new_error!(
+            "unsupported OCI manifest schemaVersion {} (expected {})",
+            manifest.schema_version(),
+            SCHEMA_VERSION
+        ));
+    }
+    Ok(manifest)
+}
+
+fn load_config(
+    blobs_dir: &Path,
+    cfg_desc: &Descriptor,
+    verify_blobs: bool,
+) -> crate::Result<OciSnapshotConfig> {
+    let cfg_hex = parse_oci_digest(cfg_desc.digest())?;
+    let cfg_path = blobs_dir.join(&cfg_hex);
+    let cfg_bytes = read_bounded(&cfg_path, MAX_JSON_BLOB_SIZE)?;
+    if cfg_bytes.len() as u64 != cfg_desc.size() {
+        return Err(crate::new_error!(
+            "config blob size mismatch: descriptor says {}, file is {}",
+            cfg_desc.size(),
+            cfg_bytes.len()
+        ));
+    }
+    if verify_blobs {
+        verify_blob_bytes("config", &cfg_bytes, &cfg_hex)?;
+    }
+    let cfg: OciSnapshotConfig = serde_json::from_slice(&cfg_bytes)
+        .map_err(|e| crate::new_error!("failed to parse Hyperlight config JSON: {}", e))?;
+    cfg.validate_for_load()?;
+    Ok(cfg)
+}
+
+fn open_snapshot_blob(
+    blobs_dir: &Path,
+    snap_desc: &Descriptor,
+    expected_blob_len: u64,
+    verify_blobs: bool,
+) -> crate::Result<std::fs::File> {
+    let snap_hex = parse_oci_digest(snap_desc.digest())?;
+    let snap_path = blobs_dir.join(&snap_hex);
+
+    let mut snap_file = self::fsutil::open_no_follow(&snap_path)?;
+
+    let snap_file_len = snap_file
+        .metadata()
+        .map_err(|e| crate::new_error!("failed to stat snapshot blob: {}", e))?
+        .len();
+    if snap_file_len != expected_blob_len {
+        return Err(crate::new_error!(
+            "snapshot blob size mismatch: file is {} bytes, expected {} (memory_size)",
+            snap_file_len,
+            expected_blob_len,
+        ));
+    }
+    if snap_file_len != snap_desc.size() {
+        return Err(crate::new_error!(
+            "snapshot blob size {} disagrees with OCI descriptor size {}",
+            snap_file_len,
+            snap_desc.size()
+        ));
+    }
+    if verify_blobs {
+        verify_blob_file("snapshot", &mut snap_file, &snap_hex)?;
+    }
+    Ok(snap_file)
+}
+
+impl Snapshot {
+    /// Save this snapshot into an OCI Image Layout directory on disk.
+    /// The saved snapshot can be loaded later with
+    /// [`Snapshot::load`].
+    ///
+    /// Returns the [`OciDigest`] of the manifest that was written,
+    /// which [`Snapshot::load`] accepts as a stable handle to
+    /// this exact snapshot.
+    ///
+    /// # `path`
+    ///
+    /// The OCI Image Layout directory to write to. The directory at
+    /// `path` is created if absent. Its parent directory must exist.
+    ///
+    /// If `path` holds no OCI layout, a new one is created. If it
+    /// holds one, this snapshot is added alongside the others. If
+    /// `path` holds something that is not a readable OCI layout, the
+    /// call fails and the directory is left unchanged.
+    ///
+    /// # `tag`
+    ///
+    /// A standard OCI tag that names this snapshot within the layout.
+    /// [`Snapshot::load`] can load the snapshot back by this tag.
+    ///
+    /// A tag points to one snapshot at a time. If the layout has a
+    /// snapshot under this tag, the tag is moved to the new snapshot.
+    /// The old snapshot's data stays on disk, reachable by its
+    /// digest but not by this tag. Snapshots under other tags are
+    /// untouched.
+    ///
+    /// # Portability
+    ///
+    /// Snapshot images are bound to the specific CPU architecture and
+    /// hypervisor that the snapshot was created on. For example, a
+    /// snapshot taken on x86_64 with KVM can only be loaded on an
+    /// x86_64 host running KVM. Loading on any other host is rejected.
+    ///
+    /// # Compatibility
+    ///
+    /// While Hyperlight is at version 0.x.y the on-disk format is not
+    /// stable. A snapshot written by one Hyperlight version is not
+    /// guaranteed to load on a different Hyperlight version. An
+    /// incompatible snapshot is always rejected at load time with a
+    /// clear error. It can never load and then misbehave once the
+    /// guest is running. Any release that breaks the format is called
+    /// out in the Hyperlight changelog.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use hyperlight_host::{MultiUseSandbox, UninitializedSandbox, GuestBinary};
+    /// # use hyperlight_host::sandbox::snapshot::OciTag;
+    /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let mut sandbox: MultiUseSandbox = UninitializedSandbox::new(
+    ///     GuestBinary::FilePath("guest.bin".into()),
+    ///     None,
+    /// )?.evolve()?;
+    ///
+    /// // Capture the initialized state and write it to an OCI layout on disk.
+    /// let snapshot = sandbox.snapshot()?;
+    /// let tag = OciTag::new("latest")?;
+    /// let digest = snapshot.save("./guest_snapshot", &tag)?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn save(&self, path: impl AsRef<Path>, tag: &OciTag) -> crate::Result<OciDigest> {
+        let path = path.as_ref();
+
+        // Building the config can reject the snapshot. Do it before
+        // writing any file.
+        let cfg = self.build_config()?;
+        let cfg_bytes = serde_json::to_vec_pretty(&cfg)
+            .map_err(|e| crate::new_error!("failed to serialise config JSON: {}", e))?;
+        check_json_blob_size("config blob", cfg_bytes.len())?;
+
+        // The parent directory must already exist. `path` itself is
+        // created if absent. An existing regular file at `path` is
+        // rejected by the underlying `create_dir`.
+        match path.parent() {
+            Some(p) if !p.as_os_str().is_empty() => {
+                let parent_meta = std::fs::metadata(p).map_err(|e| {
+                    crate::new_error!("save: parent directory {:?} not accessible: {}", p, e)
+                })?;
+                if !parent_meta.is_dir() {
+                    return Err(crate::new_error!(
+                        "save: parent of {:?} is not a directory",
+                        path
+                    ));
+                }
+            }
+            _ => {}
+        }
+        match std::fs::create_dir(path) {
+            Ok(()) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
+                let meta = std::fs::metadata(path)
+                    .map_err(|e| crate::new_error!("save: failed to stat {:?}: {}", path, e))?;
+                if !meta.is_dir() {
+                    return Err(crate::new_error!(
+                        "save: {:?} exists and is not a directory",
+                        path
+                    ));
+                }
+            }
+            Err(e) => {
+                return Err(crate::new_error!(
+                    "save: failed to create layout dir {:?}: {}",
+                    path,
+                    e
+                ));
+            }
+        }
+
+        // Validate any pre-existing `oci-layout` marker before
+        // touching anything else, so a foreign layout (future
+        // version, hand-edited file) is reported without altering
+        // the directory.
+        let layout_marker = path.join("oci-layout");
+        let marker_existed = layout_marker
+            .try_exists()
+            .map_err(|e| crate::new_error!("save: failed to stat {:?}: {}", layout_marker, e))?;
+        if marker_existed {
+            let bytes = read_bounded(&layout_marker, MAX_JSON_BLOB_SIZE).map_err(|e| {
+                crate::new_error!("save: failed to read existing oci-layout: {}", e)
+            })?;
+            let v: serde_json::Value = serde_json::from_slice(&bytes).map_err(|e| {
+                crate::new_error!("save: existing oci-layout is not valid JSON: {}", e)
+            })?;
+            match v.get("imageLayoutVersion").and_then(|s| s.as_str()) {
+                Some(s) if s == OCI_LAYOUT_VERSION => {}
+                Some(other) => {
+                    return Err(crate::new_error!(
+                        "save: existing imageLayoutVersion {:?} is unsupported (expected {:?})",
+                        other,
+                        OCI_LAYOUT_VERSION
+                    ));
+                }
+                None => {
+                    return Err(crate::new_error!(
+                        "save: existing oci-layout is missing imageLayoutVersion"
+                    ));
+                }
+            }
+        }
+
+        let index_path = path.join("index.json");
+        let index_existed = index_path
+            .try_exists()
+            .map_err(|e| crate::new_error!("save: failed to stat {:?}: {}", index_path, e))?;
+        let mut manifests: Vec<Descriptor> = if index_existed {
+            let bytes = read_bounded(&index_path, MAX_JSON_BLOB_SIZE).map_err(|e| {
+                crate::new_error!("save: failed to read existing index.json: {}", e)
+            })?;
+            let existing: ImageIndex = serde_json::from_slice(&bytes).map_err(|e| {
+                crate::new_error!(
+                    "save: existing index.json is not a valid OCI image index: {}",
+                    e
+                )
+            })?;
+            existing.manifests().to_vec()
+        } else {
+            Vec::new()
+        };
+
+        let new_desc = self.write_blobs_and_build_descriptor(path, tag, &cfg, &cfg_bytes)?;
+        let written_digest = OciDigest::from_oci_spec_digest(new_desc.digest());
+
+        // Replacement is by tag, not by digest: a new snapshot may
+        // hash to a different value but still claim the same logical
+        // ref. Blobs from the replaced manifest become orphans.
+        manifests.retain(|d| {
+            d.annotations()
+                .as_ref()
+                .and_then(|a| a.get(ANNOTATION_REF_NAME))
+                .map(|s| s.as_str() != tag.as_str())
+                .unwrap_or(true)
+        });
+        manifests.push(new_desc);
+
+        let index = ImageIndexBuilder::default()
+            .schema_version(SCHEMA_VERSION)
+            .media_type(MediaType::ImageIndex)
+            .manifests(manifests)
+            .build()
+            .map_err(|e| crate::new_error!("failed to build OCI index: {}", e))?;
+        let index_bytes = serde_json::to_vec_pretty(&index)
+            .map_err(|e| crate::new_error!("failed to serialise OCI index: {}", e))?;
+        check_json_blob_size("index.json", index_bytes.len())?;
+
+        // Write the marker before the index swap. A loader that sees
+        // the new index requires the marker; ordering them this way
+        // keeps the layout valid at every step.
+        if !marker_existed {
+            let layout_bytes = serde_json::to_vec(&serde_json::json!({
+                "imageLayoutVersion": OCI_LAYOUT_VERSION,
+            }))
+            .map_err(|e| crate::new_error!("failed to serialise oci-layout: {}", e))?;
+            replace_file_atomic(&layout_marker, &layout_bytes)?;
+        }
+
+        // Index swap is the commit point.
+        replace_file_atomic(&index_path, &index_bytes)?;
+
+        Ok(written_digest)
+    }
+
+    fn write_blobs_and_build_descriptor(
+        &self,
+        dir: &Path,
+        tag: &OciTag,
+        cfg: &OciSnapshotConfig,
+        cfg_bytes: &[u8],
+    ) -> crate::Result<Descriptor> {
+        let memory_bytes = self.memory.as_slice();
+        let memory_size = memory_bytes.len();
+        if memory_size == 0 || !memory_size.is_multiple_of(PAGE_SIZE) {
+            return Err(crate::new_error!(
+                "snapshot memory size {} must be a non-zero multiple of PAGE_SIZE",
+                memory_size
+            ));
+        }
+
+        let blobs_dir = dir.join("blobs").join("sha256");
+        std::fs::create_dir_all(&blobs_dir).map_err(|e| {
+            crate::new_error!("failed to create OCI blobs dir {:?}: {}", blobs_dir, e)
+        })?;
+
+        // Snapshot blob: the raw memory bytes.
+        let snapshot_digest = Digest256::from_bytes(memory_bytes);
+        put_blob_if_absent(&blobs_dir, &snapshot_digest, memory_bytes)?;
+
+        // Config blob.
+        let cfg_digest = Digest256::from_bytes(cfg_bytes);
+        put_blob(&blobs_dir, &cfg_digest, cfg_bytes)?;
+
+        // Manifest blob.
+        let config_descriptor = DescriptorBuilder::default()
+            .media_type(MediaType::Other(MT_CONFIG_CURRENT.to_string()))
+            .digest(oci_digest(&cfg_digest)?)
+            .size(cfg_bytes.len() as u64)
+            .build()
+            .map_err(|e| crate::new_error!("failed to build config descriptor: {}", e))?;
+        let snapshot_descriptor = DescriptorBuilder::default()
+            .media_type(MediaType::Other(MT_SNAPSHOT_CURRENT.to_string()))
+            .digest(oci_digest(&snapshot_digest)?)
+            .size(memory_size as u64)
+            .build()
+            .map_err(|e| crate::new_error!("failed to build snapshot descriptor: {}", e))?;
+        // `artifactType` is set equal to `config.mediaType` per OCI
+        // image-spec "Guidelines for Artifact Usage". Registries
+        // surface this on the distribution-spec referrers API. Tools
+        // that read only `config.mediaType` see the same value.
+        let manifest = ImageManifestBuilder::default()
+            .schema_version(SCHEMA_VERSION)
+            .media_type(MediaType::ImageManifest)
+            .artifact_type(MediaType::Other(MT_CONFIG_CURRENT.to_string()))
+            .config(config_descriptor)
+            .layers(vec![snapshot_descriptor])
+            .build()
+            .map_err(|e| crate::new_error!("failed to build OCI manifest: {}", e))?;
+        let manifest_bytes = serde_json::to_vec_pretty(&manifest)
+            .map_err(|e| crate::new_error!("failed to serialise OCI manifest: {}", e))?;
+        check_json_blob_size("manifest blob", manifest_bytes.len())?;
+        let manifest_digest = Digest256::from_bytes(&manifest_bytes);
+        put_blob(&blobs_dir, &manifest_digest, &manifest_bytes)?;
+
+        let mut anns = std::collections::HashMap::new();
+        anns.insert(ANNOTATION_REF_NAME.to_string(), tag.as_str().to_string());
+        anns.insert(ANNOTATION_ARCH.to_string(), cfg.arch.as_str().to_string());
+        anns.insert(
+            ANNOTATION_HYPERVISOR.to_string(),
+            cfg.hypervisor.as_str().to_string(),
+        );
+        DescriptorBuilder::default()
+            .media_type(MediaType::ImageManifest)
+            .digest(oci_digest(&manifest_digest)?)
+            .size(manifest_bytes.len() as u64)
+            .annotations(anns)
+            .build()
+            .map_err(|e| crate::new_error!("failed to build manifest descriptor: {}", e))
+    }
+
+    fn build_config(&self) -> crate::Result<OciSnapshotConfig> {
+        let (entrypoint_addr, sregs) = match (self.entrypoint, self.sregs.as_ref()) {
+            (NextAction::Call(addr), Some(sregs)) => (addr, Sregs::from(sregs)),
+            (NextAction::Call(_), None) => {
+                return Err(crate::new_error!(
+                    "snapshot inconsistent: Call entrypoint must have sregs"
+                ));
+            }
+            (NextAction::Initialise(_), _) => {
+                return Err(crate::new_error!(
+                    "pre-init snapshots cannot be persisted. Only a snapshot taken after the guest has run can be saved to disk"
+                ));
+            }
+            #[cfg(test)]
+            (NextAction::None, _) => {
+                return Err(crate::new_error!(
+                    "snapshot with NextAction::None cannot be persisted"
+                ));
+            }
+        };
+
+        let host_functions = match &self.host_functions.host_functions {
+            Some(v) => v.iter().map(HostFunction::from).collect(),
+            None => Vec::new(),
+        };
+
+        let l = &self.layout;
+        Ok(OciSnapshotConfig {
+            hyperlight_version: env!("CARGO_PKG_VERSION").to_string(),
+            arch: Arch::current(),
+            abi_version: SNAPSHOT_ABI_VERSION,
+            hypervisor: Hypervisor::current()
+                .ok_or_else(|| crate::new_error!("no hypervisor available to tag snapshot"))?,
+            stack_top_gva: self.stack_top_gva,
+            entrypoint_addr,
+            sregs,
+            layout: MemoryLayout {
+                input_data_size: l.input_data_size,
+                output_data_size: l.output_data_size,
+                heap_size: l.heap_size,
+                code_size: l.code_size,
+                init_data_size: l.init_data_size,
+                init_data_permissions: l.init_data_permissions.map(|f| f.bits()),
+                scratch_size: l.get_scratch_size(),
+                snapshot_size: l.snapshot_size,
+                pt_size: l.pt_size,
+            },
+            memory_size: self.memory.mem_size() as u64,
+            host_functions,
+            snapshot_generation: self.snapshot_generation,
+        })
+    }
+
+    /// Load a snapshot from an OCI Image Layout directory produced by
+    /// [`Snapshot::save`].
+    ///
+    /// # `path`
+    ///
+    /// The OCI Image Layout directory to read from. It must hold a
+    /// readable OCI layout containing at least one Hyperlight
+    /// snapshot.
+    ///
+    /// # `reference`
+    ///
+    /// Determines which snapshot in the layout to load, given as
+    /// either an [`OciTag`] or an [`OciDigest`]. Loading fails if no
+    /// snapshot in the layout has the given tag or digest.
+    ///
+    /// # Portability
+    ///
+    /// Snapshot images are bound to the specific CPU architecture and
+    /// hypervisor that the snapshot was created on. For example, a
+    /// snapshot taken on x86_64 with KVM can only be loaded on an
+    /// x86_64 host running KVM. Loading on any other host is rejected.
+    ///
+    /// # Compatibility
+    ///
+    /// While Hyperlight is at version 0.x.y the on-disk format is not
+    /// stable. A snapshot written by one Hyperlight version is not
+    /// guaranteed to load on a different Hyperlight version. An
+    /// incompatible snapshot is always rejected at load time with a
+    /// clear error. It can never load and then misbehave once the
+    /// guest is running. Any release that breaks the format is called
+    /// out in the Hyperlight changelog.
+    ///
+    /// # Verification
+    ///
+    /// This method does not check the manifest, config, or snapshot
+    /// blobs against their recorded sha256 digests. Load only from a
+    /// layout you trust.
+    ///
+    /// To check the digests on load at the expense of some
+    /// performance, use [`Snapshot::checked_load`].
+    ///
+    /// # File-mutation hazard
+    ///
+    /// The snapshot blob stays memory-mapped while the returned
+    /// `Snapshot` or any sandbox built from it is alive. The existing
+    /// blob files in the layout at `path` must not be overwritten,
+    /// truncated, or deleted while the mapping is live. Doing so can
+    /// corrupt guest memory and can lead to undefined behavior.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use std::sync::Arc;
+    /// # use hyperlight_host::{HostFunctions, MultiUseSandbox};
+    /// # use hyperlight_host::sandbox::snapshot::{OciTag, Snapshot};
+    /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let tag = OciTag::new("latest")?;
+    /// let snapshot = Arc::new(Snapshot::load("./guest_snapshot", tag)?);
+    /// let mut sandbox = MultiUseSandbox::from_snapshot(snapshot, HostFunctions::default(), None)?;
+    /// let result: String = sandbox.call("Echo", "hello".to_string())?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn load(path: impl AsRef<Path>, reference: impl Into<OciReference>) -> crate::Result<Self> {
+        Self::load_inner(path.as_ref(), &reference.into(), false)
+    }
+
+    /// Loads a snapshot like [`Snapshot::load`]. See its rustdoc for
+    /// `path`, `reference`, portability, and the file-mutation
+    /// hazard. This method additionally checks the manifest, config,
+    /// and snapshot blobs against their recorded sha256 digests
+    /// before use, at the expense of some performance.
+    ///
+    /// # Trust
+    ///
+    /// A digest check does not prove the bytes are authentic. Anyone
+    /// who edits a blob can recompute its digest to match, so a
+    /// hostile layout passes the check. Load only from a source you
+    /// trust.
+    pub fn checked_load(
+        path: impl AsRef<Path>,
+        reference: impl Into<OciReference>,
+    ) -> crate::Result<Self> {
+        Self::load_inner(path.as_ref(), &reference.into(), true)
+    }
+
+    fn load_inner(
+        path: &Path,
+        reference: &OciReference,
+        verify_blobs: bool,
+    ) -> crate::Result<Self> {
+        let meta = std::fs::metadata(path)
+            .map_err(|e| crate::new_error!("load failed to stat {:?}: {}", path, e))?;
+        if !meta.is_dir() {
+            return Err(crate::new_error!("load path {:?} is not a directory", path));
+        }
+
+        let blobs_dir: PathBuf = path.join("blobs").join("sha256");
+
+        // 1. oci-layout
+        read_layout_marker(path)?;
+
+        // 2. index.json -> manifest descriptor for `reference`.
+        //    Multiple manifests are valid in an OCI Image Layout. A
+        //    tag selects the one whose
+        //    `org.opencontainers.image.ref.name` annotation matches it
+        //    (two manifests sharing a tag is a malformed layout). A
+        //    digest selects the descriptor carrying that manifest
+        //    digest.
+        let manifest = load_manifest(path, &blobs_dir, reference, verify_blobs)?;
+        let cfg_desc = manifest.config();
+        // Loader dispatch on config media type. A future v2 lands
+        // as a new arm that converts to the in-memory current shape.
+        let cfg_media = cfg_desc.media_type().to_string();
+        match cfg_media.as_str() {
+            MT_CONFIG_V1 => {}
+            other => {
+                return Err(crate::new_error!(
+                    "unexpected config media type {:?} (supported: {:?})",
+                    other,
+                    MT_CONFIG_V1
+                ));
+            }
+        }
+        // `artifactType` mirrors `config.mediaType` (manifest.md
+        // "Guidelines for Artifact Usage"). The OCI spec leaves this
+        // field OPTIONAL. A Hyperlight snapshot requires it to be
+        // present and equal to `config.mediaType` so loaders can
+        // distinguish a Hyperlight artifact from an arbitrary
+        // manifest that happens to share blob layout.
+        match manifest.artifact_type() {
+            Some(at) if at.to_string() == cfg_media => {}
+            Some(at) => {
+                return Err(crate::new_error!(
+                    "OCI manifest artifactType {:?} does not match config media type {:?}",
+                    at.to_string(),
+                    cfg_media
+                ));
+            }
+            None => {
+                return Err(crate::new_error!(
+                    "OCI manifest is missing required artifactType (expected {:?})",
+                    cfg_media
+                ));
+            }
+        }
+        let layers = manifest.layers();
+        if layers.len() != 1 {
+            return Err(crate::new_error!(
+                "expected exactly one OCI layer (the snapshot), found {}",
+                layers.len()
+            ));
+        }
+        let snap_desc = &layers[0];
+        let snap_media = snap_desc.media_type().to_string();
+        match snap_media.as_str() {
+            MT_SNAPSHOT_V1 => {}
+            other => {
+                return Err(crate::new_error!(
+                    "unexpected snapshot layer media type {:?} (supported: {:?})",
+                    other,
+                    MT_SNAPSHOT_V1
+                ));
+            }
+        }
+
+        // 4. config blob
+        let cfg = load_config(&blobs_dir, cfg_desc, verify_blobs)?;
+
+        // 5. snapshot blob: open once, hash and mmap the same
+        //    handle so an attacker cannot swap the file between
+        //    verification and mapping.
+        let snap_file = open_snapshot_blob(&blobs_dir, snap_desc, cfg.memory_size, verify_blobs)?;
+
+        // 6. Reconstruct layout.
+        let mut sbox_cfg = crate::sandbox::SandboxConfiguration::default();
+        sbox_cfg.set_input_data_size(cfg.layout.input_data_size);
+        sbox_cfg.set_output_data_size(cfg.layout.output_data_size);
+        sbox_cfg.set_heap_size(cfg.layout.heap_size as u64);
+        sbox_cfg.set_scratch_size(cfg.layout.scratch_size);
+        let init_data_perms = match cfg.layout.init_data_permissions {
+            None => None,
+            Some(bits) => Some(MemoryRegionFlags::from_bits(bits).ok_or_else(|| {
+                crate::new_error!(
+                    "snapshot init_data_permissions {:#x} contains unknown flag bits",
+                    bits
+                )
+            })?),
+        };
+        let mut layout = SandboxMemoryLayout::new(
+            sbox_cfg,
+            cfg.layout.code_size,
+            cfg.layout.init_data_size,
+            init_data_perms,
+        )?;
+        // `snapshot_size` and `pt_size` are independent fields.
+        if let Some(pt) = cfg.layout.pt_size {
+            layout.set_pt_size(pt)?;
+        }
+        layout.set_snapshot_size(cfg.layout.snapshot_size);
+
+        // `snapshot_size` is the guest-visible prefix mapped into the
+        // snapshot region. It must cover at least the regions the
+        // layout fields describe (code, PEB, heap, init data),
+        // otherwise the guest mapping is too short to back them. The
+        // `snapshot_size + pt_size == memory_size` invariant alone
+        // does not bound `snapshot_size` from below, since a smaller
+        // `snapshot_size` can be offset by a larger `pt_size`.
+        let required_memory_size = layout.get_memory_size()? as u64;
+        if (layout.snapshot_size as u64) < required_memory_size {
+            return Err(crate::new_error!(
+                "snapshot snapshot_size ({}) is smaller than the layout size ({})",
+                layout.snapshot_size,
+                required_memory_size
+            ));
+        }
+
+        // 7. mmap the snapshot blob (file-backed CoW). The blob is
+        //    the raw memory image. `ReadonlySharedMemory::from_file`
+        //    surrounds it with host guard pages. The guest mapping
+        //    of the snapshot region covers only the data prefix
+        //    (`snapshot_size`). The PT tail sits past that prefix
+        //    in the host mapping and is copied into the scratch
+        //    region on restore. Keeping it out of the guest mapping
+        //    of the snapshot region avoids overlap with
+        //    `map_file_cow` regions installed immediately after the
+        //    snapshot in guest PA space.
+        let memory = ReadonlySharedMemory::from_file(&snap_file, layout.snapshot_size)?;
+
+        // The size validation in `open_snapshot_blob` stats the file
+        // before mapping. Nothing prevents the file from being
+        // truncated between that stat and the mmap, which would leave
+        // the mapping shorter than the config claims and make restore
+        // read past the end. Compare the mapped length against
+        // `memory_size` to reject a file mutated under us.
+        if memory.mem_size() as u64 != cfg.memory_size {
+            return Err(crate::new_error!(
+                "mapped snapshot size ({}) does not match config memory_size ({}); the blob may have changed during loading",
+                memory.mem_size(),
+                cfg.memory_size
+            ));
+        }
+
+        // 8. Build entrypoint + sregs back from the config.
+        let entrypoint = NextAction::Call(cfg.entrypoint_addr);
+        let sregs = Some(CommonSpecialRegisters::from(cfg.sregs));
+
+        // 9. Reconstitute host_functions metadata.
+        let snapshot_generation = cfg.snapshot_generation;
+        let host_funcs_vec: Vec<
+            hyperlight_common::flatbuffer_wrappers::host_function_definition::HostFunctionDefinition,
+        > = cfg.host_functions.into_iter().map(Into::into).collect();
+        let host_functions = if host_funcs_vec.is_empty() {
+            HostFunctionDetails {
+                host_functions: None,
+            }
+        } else {
+            HostFunctionDetails {
+                host_functions: Some(host_funcs_vec),
+            }
+        };
+
+        Ok(Snapshot {
+            layout,
+            memory,
+            load_info: crate::mem::exe::LoadInfo::dummy(),
+            stack_top_gva: cfg.stack_top_gva,
+            sregs,
+            entrypoint,
+            snapshot_generation,
+            host_functions,
+        })
+    }
+}

--- a/src/hyperlight_host/src/sandbox/snapshot/file/reference.rs
+++ b/src/hyperlight_host/src/sandbox/snapshot/file/reference.rs
@@ -1,0 +1,328 @@
+/*
+Copyright 2025 The Hyperlight Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! Validated identifiers for snapshots stored in an OCI Image Layout:
+//! a human-readable tag, a content digest, and the reference enum that
+//! selects a manifest by either one.
+
+use std::fmt;
+use std::str::FromStr;
+
+use oci_spec::image::{Digest as OciSpecDigest, DigestAlgorithm};
+
+/// A tag naming one snapshot inside an OCI Image Layout directory.
+/// Used to save a snapshot under a name and to load it back by that
+/// same name.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct OciTag(String);
+
+impl OciTag {
+    /// Construct a tag, validating it against the OCI Distribution
+    /// grammar `[a-zA-Z0-9_][a-zA-Z0-9._-]{0,127}`. Returns an error
+    /// if the input does not match.
+    pub fn new(tag: impl Into<String>) -> crate::Result<Self> {
+        Self::try_from(tag.into())
+    }
+
+    /// The tag as a string slice.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+fn validate_tag(tag: &str) -> crate::Result<()> {
+    let bytes = tag.as_bytes();
+    if bytes.is_empty() || bytes.len() > 128 {
+        return Err(crate::new_error!(
+            "tag {:?} is invalid: must be 1..=128 bytes",
+            tag
+        ));
+    }
+    let first = bytes[0];
+    if !(first.is_ascii_alphanumeric() || first == b'_') {
+        return Err(crate::new_error!(
+            "tag {:?} is invalid: first character must be alphanumeric or '_'",
+            tag
+        ));
+    }
+    for &b in &bytes[1..] {
+        if !(b.is_ascii_alphanumeric() || b == b'_' || b == b'.' || b == b'-') {
+            return Err(crate::new_error!(
+                "tag {:?} is invalid: characters after the first must be \
+                 alphanumeric or one of '_', '.', '-'",
+                tag
+            ));
+        }
+    }
+    Ok(())
+}
+
+impl FromStr for OciTag {
+    type Err = crate::HyperlightError;
+
+    fn from_str(s: &str) -> crate::Result<Self> {
+        validate_tag(s)?;
+        Ok(Self(s.to_string()))
+    }
+}
+
+impl TryFrom<&str> for OciTag {
+    type Error = crate::HyperlightError;
+
+    fn try_from(s: &str) -> crate::Result<Self> {
+        s.parse()
+    }
+}
+
+impl TryFrom<String> for OciTag {
+    type Error = crate::HyperlightError;
+
+    fn try_from(s: String) -> crate::Result<Self> {
+        validate_tag(&s)?;
+        Ok(Self(s))
+    }
+}
+
+impl AsRef<str> for OciTag {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for OciTag {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+/// A sha256 content digest in canonical `sha256:<64 lowercase hex>`
+/// form, identifying one snapshot by the bytes of its manifest.
+/// Names that snapshot for loading even when no tag points at it.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct OciDigest(String);
+
+impl OciDigest {
+    /// The digest as a `sha256:<hex>` string slice.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    /// Wrap a validated `oci-spec` digest. The caller guarantees it
+    /// uses the sha256 algorithm.
+    pub(super) fn from_oci_spec_digest(digest: &OciSpecDigest) -> Self {
+        Self(digest.to_string())
+    }
+}
+
+fn validate_digest(s: &str) -> crate::Result<String> {
+    let digest = OciSpecDigest::from_str(s)
+        .map_err(|e| crate::new_error!("invalid OCI digest {:?}: {}", s, e))?;
+    if digest.algorithm() != &DigestAlgorithm::Sha256 {
+        return Err(crate::new_error!(
+            "OCI digest {:?} must use the sha256 algorithm, found {}",
+            s,
+            digest.algorithm()
+        ));
+    }
+    Ok(digest.to_string())
+}
+
+impl FromStr for OciDigest {
+    type Err = crate::HyperlightError;
+
+    fn from_str(s: &str) -> crate::Result<Self> {
+        Ok(Self(validate_digest(s)?))
+    }
+}
+
+impl TryFrom<&str> for OciDigest {
+    type Error = crate::HyperlightError;
+
+    fn try_from(s: &str) -> crate::Result<Self> {
+        s.parse()
+    }
+}
+
+impl TryFrom<String> for OciDigest {
+    type Error = crate::HyperlightError;
+
+    fn try_from(s: String) -> crate::Result<Self> {
+        Ok(Self(validate_digest(&s)?))
+    }
+}
+
+impl AsRef<str> for OciDigest {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for OciDigest {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+/// Names one snapshot in an OCI Image Layout, either by tag or by
+/// content digest.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub enum OciReference {
+    /// A snapshot named by its tag.
+    Tag(OciTag),
+    /// A snapshot named by its content digest.
+    Digest(OciDigest),
+}
+
+impl From<OciTag> for OciReference {
+    fn from(tag: OciTag) -> Self {
+        OciReference::Tag(tag)
+    }
+}
+
+impl From<OciDigest> for OciReference {
+    fn from(digest: OciDigest) -> Self {
+        OciReference::Digest(digest)
+    }
+}
+
+impl FromStr for OciReference {
+    type Err = crate::HyperlightError;
+
+    /// Parse a tag or a digest. A `:` marks a digest, since the tag
+    /// grammar forbids that character.
+    fn from_str(s: &str) -> crate::Result<Self> {
+        if s.contains(':') {
+            Ok(OciReference::Digest(s.parse()?))
+        } else {
+            Ok(OciReference::Tag(s.parse()?))
+        }
+    }
+}
+
+impl fmt::Display for OciReference {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            OciReference::Tag(t) => fmt::Display::fmt(t, f),
+            OciReference::Digest(d) => fmt::Display::fmt(d, f),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A 64-character lowercase hex string, the body of a canonical
+    /// sha256 digest.
+    const HEX64: &str = "0000000000000000000000000000000000000000000000000000000000000000";
+
+    #[test]
+    fn tag_accepts_grammar_and_length_bounds() {
+        // First character may be alphanumeric or underscore.
+        assert!(OciTag::new("a").is_ok());
+        assert!(OciTag::new("Z").is_ok());
+        assert!(OciTag::new("9").is_ok());
+        assert!(OciTag::new("_").is_ok());
+        // Later characters add '.', '-'.
+        assert!(OciTag::new("v1.0_release-2").is_ok());
+        // 128 bytes is the maximum.
+        assert!(OciTag::new("a".repeat(128)).is_ok());
+    }
+
+    #[test]
+    fn tag_rejects_out_of_grammar_input() {
+        // Empty and over-length.
+        assert!(OciTag::new("").is_err());
+        assert!(OciTag::new("a".repeat(129)).is_err());
+        // First character cannot be '.', '-', or punctuation.
+        assert!(OciTag::new(".tag").is_err());
+        assert!(OciTag::new("-tag").is_err());
+        // Later characters cannot include these.
+        assert!(OciTag::new("a/b").is_err());
+        assert!(OciTag::new("a b").is_err());
+    }
+
+    #[test]
+    fn tag_never_contains_colon() {
+        // The reference parser routes on ':'. A valid tag must never
+        // carry one, otherwise a tag would be parsed as a digest.
+        assert!(OciTag::new("sha256:abc").is_err());
+    }
+
+    #[test]
+    fn digest_accepts_canonical_sha256() {
+        let s = format!("sha256:{HEX64}");
+        let d = OciDigest::try_from(s.as_str()).unwrap();
+        assert_eq!(d.as_str(), s);
+    }
+
+    #[test]
+    fn digest_rejects_non_sha256_algorithm() {
+        let s = format!("sha512:{}", "0".repeat(128));
+        assert!(OciDigest::try_from(s.as_str()).is_err());
+    }
+
+    #[test]
+    fn digest_rejects_malformed_input() {
+        // Missing algorithm prefix.
+        assert!(OciDigest::try_from(HEX64).is_err());
+        // Hex body of the wrong length.
+        assert!(OciDigest::try_from("sha256:abcd").is_err());
+    }
+
+    #[test]
+    fn reference_parses_tag_when_no_colon() {
+        let r: OciReference = "latest".parse().unwrap();
+        assert_eq!(r, OciReference::Tag(OciTag::new("latest").unwrap()));
+    }
+
+    #[test]
+    fn reference_parses_digest_when_colon_present() {
+        let s = format!("sha256:{HEX64}");
+        let r: OciReference = s.parse().unwrap();
+        assert_eq!(
+            r,
+            OciReference::Digest(OciDigest::try_from(s.as_str()).unwrap())
+        );
+    }
+
+    #[test]
+    fn tag_display_round_trips() {
+        let tag = OciTag::new("v1.2-rc1").unwrap();
+        assert_eq!(OciTag::new(tag.to_string()).unwrap(), tag);
+    }
+
+    #[test]
+    fn digest_display_round_trips() {
+        let d = OciDigest::try_from(format!("sha256:{HEX64}").as_str()).unwrap();
+        assert_eq!(OciDigest::try_from(d.to_string().as_str()).unwrap(), d);
+    }
+
+    #[test]
+    fn reference_display_round_trips() {
+        let tag_ref: OciReference = "latest".parse().unwrap();
+        assert_eq!(
+            tag_ref.to_string().parse::<OciReference>().unwrap(),
+            tag_ref
+        );
+
+        let digest_ref: OciReference = format!("sha256:{HEX64}").parse().unwrap();
+        assert_eq!(
+            digest_ref.to_string().parse::<OciReference>().unwrap(),
+            digest_ref
+        );
+    }
+}

--- a/src/hyperlight_host/src/sandbox/snapshot/file_tests.rs
+++ b/src/hyperlight_host/src/sandbox/snapshot/file_tests.rs
@@ -1,0 +1,2786 @@
+/*
+Copyright 2025 The Hyperlight Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! Tests for the OCI Image Layout snapshot format (`super::file`).
+
+#![cfg(test)]
+
+use std::sync::Arc;
+
+use hyperlight_testing::simple_guest_as_string;
+use serde_json::Value;
+use sha2::{Digest as _, Sha256};
+
+use crate::func::Registerable;
+use crate::sandbox::snapshot::{OciDigest, OciReference, OciTag, Snapshot};
+use crate::{GuestBinary, HostFunctions, MultiUseSandbox, UninitializedSandbox};
+
+fn create_test_sandbox() -> MultiUseSandbox {
+    let path = simple_guest_as_string().unwrap();
+    UninitializedSandbox::new(GuestBinary::FilePath(path), None)
+        .unwrap()
+        .evolve()
+        .unwrap()
+}
+
+fn create_snapshot() -> Arc<Snapshot> {
+    let mut sbox = create_test_sandbox();
+    sbox.snapshot().unwrap()
+}
+
+/// `Result::unwrap_err` requires `T: Debug`, but `Snapshot` is not
+/// `Debug`. This wrapper is the test-side equivalent.
+#[track_caller]
+fn unwrap_err_snapshot(r: crate::Result<Snapshot>) -> crate::HyperlightError {
+    match r {
+        Err(e) => e,
+        Ok(_) => panic!("expected snapshot load to fail"),
+    }
+}
+
+/// Locate the single config blob inside `oci_dir`. Returns its full
+/// path. Used by tests that mutate the on-disk JSON.
+fn find_config_blob(oci_dir: &std::path::Path) -> std::path::PathBuf {
+    let manifest_bytes = std::fs::read(oci_dir.join("index.json")).unwrap();
+    let index: Value = serde_json::from_slice(&manifest_bytes).unwrap();
+    let manifest_digest = index["manifests"][0]["digest"]
+        .as_str()
+        .unwrap()
+        .strip_prefix("sha256:")
+        .unwrap();
+    let manifest_path = oci_dir.join("blobs").join("sha256").join(manifest_digest);
+    let manifest: Value = serde_json::from_slice(&std::fs::read(&manifest_path).unwrap()).unwrap();
+    let cfg_digest = manifest["config"]["digest"]
+        .as_str()
+        .unwrap()
+        .strip_prefix("sha256:")
+        .unwrap();
+    oci_dir.join("blobs").join("sha256").join(cfg_digest)
+}
+
+/// Locate the snapshot (layer 0) blob inside `oci_dir`.
+fn find_snapshot_blob(oci_dir: &std::path::Path) -> std::path::PathBuf {
+    let index: Value =
+        serde_json::from_slice(&std::fs::read(oci_dir.join("index.json")).unwrap()).unwrap();
+    let manifest_digest = index["manifests"][0]["digest"]
+        .as_str()
+        .unwrap()
+        .strip_prefix("sha256:")
+        .unwrap();
+    let manifest_path = oci_dir.join("blobs").join("sha256").join(manifest_digest);
+    let manifest: Value = serde_json::from_slice(&std::fs::read(&manifest_path).unwrap()).unwrap();
+    let snap_digest = manifest["layers"][0]["digest"]
+        .as_str()
+        .unwrap()
+        .strip_prefix("sha256:")
+        .unwrap();
+    oci_dir.join("blobs").join("sha256").join(snap_digest)
+}
+
+// In-memory `from_snapshot` round-trips.
+
+#[test]
+fn from_snapshot_already_initialized_in_memory() {
+    let snapshot = create_snapshot();
+    let mut sbox2 =
+        MultiUseSandbox::from_snapshot(snapshot, HostFunctions::default(), None).unwrap();
+    let result: i32 = sbox2.call("GetStatic", ()).unwrap();
+    assert_eq!(result, 0);
+}
+
+#[test]
+fn from_snapshot_in_memory_pre_init() {
+    let snap = Snapshot::from_env(
+        GuestBinary::FilePath(simple_guest_as_string().unwrap()),
+        crate::sandbox::SandboxConfiguration::default(),
+    )
+    .unwrap();
+    let mut sbox =
+        MultiUseSandbox::from_snapshot(Arc::new(snap), HostFunctions::default(), None).unwrap();
+    let result: i32 = sbox.call("GetStatic", ()).unwrap();
+    assert_eq!(result, 0);
+}
+
+// Round-trip via OCI layout on disk.
+
+#[test]
+fn round_trip_save_load_call() {
+    let snapshot = create_snapshot();
+
+    let dir = tempfile::tempdir().unwrap();
+    let oci = dir.path().join("snap");
+    snapshot
+        .save(&oci, &OciTag::new("latest").unwrap())
+        .unwrap();
+
+    let loaded = Snapshot::checked_load(&oci, OciTag::new("latest").unwrap()).unwrap();
+    let mut sbox2 =
+        MultiUseSandbox::from_snapshot(Arc::new(loaded), HostFunctions::default(), None).unwrap();
+
+    let result: String = sbox2.call("Echo", "hello\n".to_string()).unwrap();
+    assert_eq!(result, "hello\n");
+}
+
+/// A pre-existing snapshot blob with the right length but wrong
+/// bytes (corruption, partial copy, foreign tool) must be detected
+/// and replaced by `save`, not silently trusted.
+#[test]
+fn save_self_heals_same_length_wrong_content_snapshot_blob() {
+    let snapshot = create_snapshot();
+
+    let dir = tempfile::tempdir().unwrap();
+    let oci = dir.path().join("snap");
+    snapshot
+        .save(&oci, &OciTag::new("latest").unwrap())
+        .unwrap();
+
+    // Overwrite the snapshot blob with wrong bytes of the same
+    // length, simulating on-disk corruption.
+    let snap_path = find_snapshot_blob(&oci);
+    let len = std::fs::metadata(&snap_path).unwrap().len() as usize;
+    std::fs::write(&snap_path, vec![0xAAu8; len]).unwrap();
+
+    // Re-save. `put_blob_if_absent` must notice the digest mismatch
+    // and rewrite the blob.
+    snapshot
+        .save(&oci, &OciTag::new("latest").unwrap())
+        .unwrap();
+
+    // A checked load succeeds: the rewritten blob matches the
+    // descriptor digest.
+    let loaded = Snapshot::checked_load(&oci, OciTag::new("latest").unwrap()).unwrap();
+    let mut sbox2 =
+        MultiUseSandbox::from_snapshot(Arc::new(loaded), HostFunctions::default(), None).unwrap();
+    let result: String = sbox2.call("Echo", "hello\n".to_string()).unwrap();
+    assert_eq!(result, "hello\n");
+}
+
+#[test]
+fn snapshot_and_pt_size_round_trip() {
+    let snap = create_snapshot();
+    let original_snapshot_size = snap.layout().snapshot_size;
+    let original_pt_size = snap.layout().pt_size;
+
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("running");
+    snap.save(&path, &OciTag::new("latest").unwrap()).unwrap();
+
+    let loaded = Snapshot::checked_load(&path, OciTag::new("latest").unwrap()).unwrap();
+    assert_eq!(loaded.layout().snapshot_size, original_snapshot_size);
+    assert_eq!(loaded.layout().pt_size, original_pt_size);
+}
+
+#[test]
+fn snapshot_generation_round_trip() {
+    let mut sbox = create_test_sandbox();
+    sbox.call::<String>("Echo", "a".to_string()).unwrap();
+    let snap1 = sbox.snapshot().unwrap();
+    sbox.call::<String>("Echo", "b".to_string()).unwrap();
+    sbox.call::<String>("Echo", "c".to_string()).unwrap();
+    let snap3 = sbox.snapshot().unwrap();
+    let gen1 = snap1.snapshot_generation();
+    let gen3 = snap3.snapshot_generation();
+    assert_ne!(gen1, gen3);
+
+    let dir = tempfile::tempdir().unwrap();
+    let p1 = dir.path().join("s1");
+    let p3 = dir.path().join("s3");
+    snap1.save(&p1, &OciTag::new("latest").unwrap()).unwrap();
+    snap3.save(&p3, &OciTag::new("latest").unwrap()).unwrap();
+
+    let loaded1 = Snapshot::checked_load(&p1, OciTag::new("latest").unwrap()).unwrap();
+    let loaded3 = Snapshot::checked_load(&p3, OciTag::new("latest").unwrap()).unwrap();
+    assert_eq!(loaded1.snapshot_generation(), gen1);
+    assert_eq!(loaded3.snapshot_generation(), gen3);
+}
+
+#[test]
+fn pre_init_snapshot_cannot_be_persisted() {
+    let snap = Snapshot::from_env(
+        GuestBinary::FilePath(simple_guest_as_string().unwrap()),
+        crate::sandbox::SandboxConfiguration::default(),
+    )
+    .unwrap();
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("preinit");
+    let err = snap
+        .save(&path, &OciTag::new("latest").unwrap())
+        .unwrap_err();
+    let msg = format!("{}", err);
+    assert!(
+        msg.contains("pre-init snapshots cannot be persisted"),
+        "expected pre-init rejection, got: {}",
+        msg
+    );
+    assert!(
+        !path.exists(),
+        "a rejected save must not create the layout directory"
+    );
+}
+
+// Restore semantics.
+
+#[test]
+fn restore_from_loaded_snapshot() {
+    let snapshot = create_snapshot();
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("snap");
+    snapshot
+        .save(&path, &OciTag::new("latest").unwrap())
+        .unwrap();
+
+    let loaded = Arc::new(Snapshot::checked_load(&path, OciTag::new("latest").unwrap()).unwrap());
+    let mut sbox2 =
+        MultiUseSandbox::from_snapshot(loaded.clone(), HostFunctions::default(), None).unwrap();
+
+    sbox2.call::<i32>("AddToStatic", 5i32).unwrap();
+    assert_eq!(sbox2.call::<i32>("GetStatic", ()).unwrap(), 5);
+
+    sbox2.restore(loaded).unwrap();
+    assert_eq!(sbox2.call::<i32>("GetStatic", ()).unwrap(), 0);
+}
+
+/// Independent loads of the same image are structurally identical, so a
+/// sandbox built from one accepts a restore from the other.
+#[test]
+fn restore_across_independent_oci_loads_succeeds() {
+    let snap1 = create_snapshot();
+
+    let dir = tempfile::tempdir().unwrap();
+    let p1 = dir.path().join("snap1");
+    snap1.save(&p1, &OciTag::new("latest").unwrap()).unwrap();
+    let p2 = dir.path().join("snap2");
+    snap1.save(&p2, &OciTag::new("latest").unwrap()).unwrap();
+
+    let loaded1 = Arc::new(Snapshot::checked_load(&p1, OciTag::new("latest").unwrap()).unwrap());
+    let loaded2 = Arc::new(Snapshot::checked_load(&p2, OciTag::new("latest").unwrap()).unwrap());
+
+    let mut sbox = MultiUseSandbox::from_snapshot(loaded2, HostFunctions::default(), None).unwrap();
+    sbox.restore(loaded1).unwrap();
+    assert_eq!(sbox.call::<i32>("GetStatic", ()).unwrap(), 0);
+}
+
+#[test]
+fn cow_does_not_mutate_backing_file() {
+    let snapshot = create_snapshot();
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("snap");
+    snapshot
+        .save(&path, &OciTag::new("latest").unwrap())
+        .unwrap();
+
+    // Hash every blob file to verify nothing changes after a CoW write
+    // through the loaded sandbox.
+    let blobs_dir = path.join("blobs").join("sha256");
+    let snapshot_before: std::collections::BTreeMap<_, _> = std::fs::read_dir(&blobs_dir)
+        .unwrap()
+        .map(|e| {
+            let e = e.unwrap();
+            let bytes = std::fs::read(e.path()).unwrap();
+            (e.file_name(), bytes)
+        })
+        .collect();
+
+    {
+        let loaded = Snapshot::checked_load(&path, OciTag::new("latest").unwrap()).unwrap();
+        let mut sbox =
+            MultiUseSandbox::from_snapshot(Arc::new(loaded), HostFunctions::default(), None)
+                .unwrap();
+        sbox.call::<i32>("AddToStatic", 99).unwrap();
+    }
+
+    let snapshot_after: std::collections::BTreeMap<_, _> = std::fs::read_dir(&blobs_dir)
+        .unwrap()
+        .map(|e| {
+            let e = e.unwrap();
+            let bytes = std::fs::read(e.path()).unwrap();
+            (e.file_name(), bytes)
+        })
+        .collect();
+    assert_eq!(
+        snapshot_before, snapshot_after,
+        "CoW writes must not mutate any blob in the OCI layout"
+    );
+}
+
+// Architecture, hypervisor, and ABI gating.
+
+/// Compute sha256 of `bytes` and return the lowercase hex digest.
+fn sha256_hex(bytes: &[u8]) -> String {
+    let arr: [u8; 32] = Sha256::digest(bytes).into();
+    hex::encode(arr)
+}
+
+fn rewrite_config<F: FnOnce(&mut Value)>(oci_dir: &std::path::Path, mutate: F) {
+    // Mutate the config blob and rewrite the manifest and index so blob
+    // filenames, descriptor sizes, and descriptor digests stay consistent.
+    // For tests that target the digest layer directly, write raw bytes.
+    let cfg_path = find_config_blob(oci_dir);
+    let mut cfg: Value = serde_json::from_slice(&std::fs::read(&cfg_path).unwrap()).unwrap();
+    mutate(&mut cfg);
+    let new_cfg_bytes = serde_json::to_vec_pretty(&cfg).unwrap();
+    let new_cfg_hex = sha256_hex(&new_cfg_bytes);
+    let blobs_dir = oci_dir.join("blobs").join("sha256");
+    let new_cfg_path = blobs_dir.join(&new_cfg_hex);
+    std::fs::write(&new_cfg_path, &new_cfg_bytes).unwrap();
+    if new_cfg_path != cfg_path {
+        std::fs::remove_file(&cfg_path).ok();
+    }
+
+    let mp = manifest_path(oci_dir);
+    let mut manifest: Value = serde_json::from_slice(&std::fs::read(&mp).unwrap()).unwrap();
+    manifest["config"]["digest"] = Value::from(format!("sha256:{}", new_cfg_hex));
+    manifest["config"]["size"] = Value::from(new_cfg_bytes.len() as u64);
+    let new_manifest_bytes = serde_json::to_vec_pretty(&manifest).unwrap();
+    let new_manifest_hex = sha256_hex(&new_manifest_bytes);
+    let new_manifest_path = blobs_dir.join(&new_manifest_hex);
+    std::fs::write(&new_manifest_path, &new_manifest_bytes).unwrap();
+    if new_manifest_path != mp {
+        std::fs::remove_file(&mp).ok();
+    }
+
+    let index_path = oci_dir.join("index.json");
+    let mut index: Value = serde_json::from_slice(&std::fs::read(&index_path).unwrap()).unwrap();
+    index["manifests"][0]["digest"] = Value::from(format!("sha256:{}", new_manifest_hex));
+    index["manifests"][0]["size"] = Value::from(new_manifest_bytes.len() as u64);
+    std::fs::write(index_path, serde_json::to_vec_pretty(&index).unwrap()).unwrap();
+}
+
+/// Locate the manifest blob path inside `oci_dir`.
+fn manifest_path(oci_dir: &std::path::Path) -> std::path::PathBuf {
+    let index: Value =
+        serde_json::from_slice(&std::fs::read(oci_dir.join("index.json")).unwrap()).unwrap();
+    let digest = index["manifests"][0]["digest"]
+        .as_str()
+        .unwrap()
+        .strip_prefix("sha256:")
+        .unwrap()
+        .to_string();
+    oci_dir.join("blobs").join("sha256").join(digest)
+}
+
+/// Mutate the on-disk manifest JSON and keep the index's manifest
+/// descriptor `size` and `digest` in sync.
+fn rewrite_manifest<F: FnOnce(&mut Value)>(oci_dir: &std::path::Path, mutate: F) {
+    let mp = manifest_path(oci_dir);
+    let mut manifest: Value = serde_json::from_slice(&std::fs::read(&mp).unwrap()).unwrap();
+    mutate(&mut manifest);
+    let new_bytes = serde_json::to_vec_pretty(&manifest).unwrap();
+    let new_hex = sha256_hex(&new_bytes);
+    let blobs_dir = oci_dir.join("blobs").join("sha256");
+    let new_path = blobs_dir.join(&new_hex);
+    std::fs::write(&new_path, &new_bytes).unwrap();
+    if new_path != mp {
+        std::fs::remove_file(&mp).ok();
+    }
+
+    let index_path = oci_dir.join("index.json");
+    let mut index: Value = serde_json::from_slice(&std::fs::read(&index_path).unwrap()).unwrap();
+    index["manifests"][0]["digest"] = Value::from(format!("sha256:{}", new_hex));
+    index["manifests"][0]["size"] = Value::from(new_bytes.len() as u64);
+    std::fs::write(index_path, serde_json::to_vec_pretty(&index).unwrap()).unwrap();
+}
+
+/// Mutate the on-disk index JSON in place. The index is the root of
+/// the OCI layout and is not referenced by any digest.
+fn rewrite_index<F: FnOnce(&mut Value)>(oci_dir: &std::path::Path, mutate: F) {
+    let path = oci_dir.join("index.json");
+    let mut index: Value = serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
+    mutate(&mut index);
+    std::fs::write(path, serde_json::to_vec_pretty(&index).unwrap()).unwrap();
+}
+
+#[test]
+fn arch_mismatch_rejected() {
+    let snapshot = create_snapshot();
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("snap");
+    snapshot
+        .save(&path, &OciTag::new("latest").unwrap())
+        .unwrap();
+
+    rewrite_config(&path, |cfg| {
+        cfg["arch"] = Value::from("aarch64");
+    });
+
+    let err = unwrap_err_snapshot(Snapshot::checked_load(
+        &path,
+        OciTag::new("latest").unwrap(),
+    ));
+    let msg = format!("{}", err);
+    assert!(
+        msg.contains("architecture") || msg.contains("arch"),
+        "expected architecture mismatch, got: {}",
+        msg
+    );
+}
+
+#[test]
+fn abi_version_mismatch_rejected() {
+    let snapshot = create_snapshot();
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("snap");
+    snapshot
+        .save(&path, &OciTag::new("latest").unwrap())
+        .unwrap();
+
+    rewrite_config(&path, |cfg| {
+        cfg["abi_version"] = Value::from(9999u32);
+    });
+
+    let err = unwrap_err_snapshot(Snapshot::checked_load(
+        &path,
+        OciTag::new("latest").unwrap(),
+    ));
+    let msg = format!("{}", err);
+    assert!(
+        msg.contains("ABI") || msg.contains("abi"),
+        "expected ABI version mismatch, got: {}",
+        msg
+    );
+}
+
+#[test]
+fn hypervisor_mismatch_rejected() {
+    let snapshot = create_snapshot();
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("snap");
+    snapshot
+        .save(&path, &OciTag::new("latest").unwrap())
+        .unwrap();
+
+    // Pick a hypervisor that is not the current one.
+    let current = cfg_current_hypervisor();
+    let other = if current == "kvm" { "mshv" } else { "kvm" };
+
+    rewrite_config(&path, |cfg| {
+        cfg["hypervisor"] = Value::from(other);
+    });
+
+    let err = unwrap_err_snapshot(Snapshot::checked_load(
+        &path,
+        OciTag::new("latest").unwrap(),
+    ));
+    let msg = format!("{}", err);
+    assert!(
+        msg.contains("hypervisor"),
+        "expected hypervisor mismatch, got: {}",
+        msg
+    );
+}
+
+fn cfg_current_hypervisor() -> &'static str {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("probe");
+    create_snapshot()
+        .save(&path, &OciTag::new("latest").unwrap())
+        .unwrap();
+    let cfg_path = find_config_blob(&path);
+    let cfg: Value = serde_json::from_slice(&std::fs::read(&cfg_path).unwrap()).unwrap();
+    match cfg["hypervisor"].as_str().unwrap() {
+        "kvm" => "kvm",
+        "mshv" => "mshv",
+        "whp" => "whp",
+        other => panic!("unknown hypervisor tag {other}"),
+    }
+}
+
+// A call snapshot must carry sregs. serde rejects a config that
+// omits the field.
+
+#[test]
+fn call_snapshot_without_sregs_rejected() {
+    let snapshot = create_snapshot();
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("snap");
+    snapshot
+        .save(&path, &OciTag::new("latest").unwrap())
+        .unwrap();
+
+    // Remove sregs from the config. serde rejects the missing
+    // field at parse time.
+    rewrite_config(&path, |cfg| {
+        cfg.as_object_mut().unwrap().remove("sregs");
+    });
+
+    let err = unwrap_err_snapshot(Snapshot::checked_load(
+        &path,
+        OciTag::new("latest").unwrap(),
+    ));
+    let msg = format!("{}", err);
+    assert!(
+        msg.contains("sregs") || msg.contains("missing field") || msg.contains("config"),
+        "expected serde error about missing sregs, got: {}",
+        msg
+    );
+}
+
+// Host-function validation. The loaded sandbox's `HostFunctions` must
+// be a superset (by name and signature) of those recorded in the snapshot.
+
+/// Build a `MultiUseSandbox` with the default host functions plus a
+/// custom `Add(i32, i32) -> i32`.
+fn create_sandbox_with_custom_host_funcs() -> MultiUseSandbox {
+    let path = simple_guest_as_string().unwrap();
+    let mut u = UninitializedSandbox::new(GuestBinary::FilePath(path), None).unwrap();
+    u.register_host_function("Add", |a: i32, b: i32| Ok(a + b))
+        .unwrap();
+    u.evolve().unwrap()
+}
+
+/// `HostFunctions::default()` plus a matching `Add(i32, i32) -> i32`.
+fn host_funcs_with_matching_add() -> HostFunctions {
+    let mut hf = HostFunctions::default();
+    hf.register_host_function("Add", |a: i32, b: i32| Ok(a + b))
+        .unwrap();
+    hf
+}
+
+#[test]
+fn from_snapshot_accepts_matching_host_functions() {
+    let mut sbox = create_sandbox_with_custom_host_funcs();
+    let snap = sbox.snapshot().unwrap();
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("snap");
+    snap.save(&path, &OciTag::new("latest").unwrap()).unwrap();
+
+    let loaded = Snapshot::checked_load(&path, OciTag::new("latest").unwrap()).unwrap();
+    let mut sbox2 =
+        MultiUseSandbox::from_snapshot(Arc::new(loaded), host_funcs_with_matching_add(), None)
+            .unwrap();
+    assert_eq!(sbox2.call::<i32>("GetStatic", ()).unwrap(), 0);
+}
+
+/// A snapshot taken with `Add` registered is rejected when loaded
+/// against a `HostFunctions` set that lacks `Add`.
+#[test]
+fn from_snapshot_rejects_missing_host_function() {
+    let mut sbox = create_sandbox_with_custom_host_funcs();
+    let snap = sbox.snapshot().unwrap();
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("snap");
+    snap.save(&path, &OciTag::new("latest").unwrap()).unwrap();
+
+    let loaded = Snapshot::checked_load(&path, OciTag::new("latest").unwrap()).unwrap();
+    let err = MultiUseSandbox::from_snapshot(Arc::new(loaded), HostFunctions::default(), None)
+        .expect_err("from_snapshot must reject a HostFunctions set missing `Add`");
+    let msg = format!("{}", err);
+    assert!(
+        msg.contains("missing") && msg.contains("Add"),
+        "expected missing-host-function error mentioning Add, got: {}",
+        msg
+    );
+}
+
+/// Loading registers `Add` with a signature different from the one the
+/// snapshot recorded, which must be refused.
+#[test]
+fn from_snapshot_rejects_signature_mismatch() {
+    let mut sbox = create_sandbox_with_custom_host_funcs();
+    let snap = sbox.snapshot().unwrap();
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("snap");
+    snap.save(&path, &OciTag::new("latest").unwrap()).unwrap();
+
+    let mut hf = HostFunctions::default();
+    hf.register_host_function("Add", |a: String, b: String| Ok(format!("{a}{b}")))
+        .unwrap();
+
+    let loaded = Snapshot::checked_load(&path, OciTag::new("latest").unwrap()).unwrap();
+    let err = MultiUseSandbox::from_snapshot(Arc::new(loaded), hf, None)
+        .expect_err("from_snapshot must reject a signature mismatch on Add");
+    let msg = format!("{}", err);
+    assert!(
+        msg.contains("signature mismatches") && msg.contains("Add"),
+        "expected signature-mismatch error mentioning Add, got: {}",
+        msg
+    );
+}
+
+/// Registering host functions beyond those the snapshot recorded is
+/// accepted.
+#[test]
+fn from_snapshot_accepts_extra_host_functions() {
+    let mut sbox = create_sandbox_with_custom_host_funcs();
+    let snap = sbox.snapshot().unwrap();
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("snap");
+    snap.save(&path, &OciTag::new("latest").unwrap()).unwrap();
+
+    let mut hf = host_funcs_with_matching_add();
+    hf.register_host_function("Mul", |a: i32, b: i32| Ok(a * b))
+        .unwrap();
+
+    let loaded = Snapshot::checked_load(&path, OciTag::new("latest").unwrap()).unwrap();
+    let mut sbox2 = MultiUseSandbox::from_snapshot(Arc::new(loaded), hf, None).unwrap();
+    assert_eq!(sbox2.call::<i32>("GetStatic", ()).unwrap(), 0);
+}
+
+#[test]
+fn from_snapshot_accepts_zero_arg_host_function() {
+    let path = simple_guest_as_string().unwrap();
+    let mut u = UninitializedSandbox::new(GuestBinary::FilePath(path), None).unwrap();
+    u.register_host_function("Zero", || Ok(7i64)).unwrap();
+    let mut sbox = u.evolve().unwrap();
+
+    let snap = sbox.snapshot().unwrap();
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("snap");
+    snap.save(&path, &OciTag::new("latest").unwrap()).unwrap();
+
+    let mut hf = HostFunctions::default();
+    hf.register_host_function("Zero", || Ok(7i64)).unwrap();
+
+    let loaded = Snapshot::checked_load(&path, OciTag::new("latest").unwrap()).unwrap();
+    let _sbox2 = MultiUseSandbox::from_snapshot(Arc::new(loaded), hf, None)
+        .expect("zero-arg host function must round-trip through OCI");
+}
+
+// OCI-shape invariants.
+
+#[test]
+fn missing_oci_layout_rejected() {
+    let snapshot = create_snapshot();
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("snap");
+    snapshot
+        .save(&path, &OciTag::new("latest").unwrap())
+        .unwrap();
+
+    std::fs::remove_file(path.join("oci-layout")).unwrap();
+
+    let err = unwrap_err_snapshot(Snapshot::checked_load(
+        &path,
+        OciTag::new("latest").unwrap(),
+    ));
+    let msg = format!("{}", err);
+    assert!(
+        msg.contains("oci-layout"),
+        "expected missing oci-layout error, got: {}",
+        msg
+    );
+}
+
+#[test]
+fn wrong_image_layout_version_rejected() {
+    let snapshot = create_snapshot();
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("snap");
+    snapshot
+        .save(&path, &OciTag::new("latest").unwrap())
+        .unwrap();
+
+    std::fs::write(
+        path.join("oci-layout"),
+        r#"{"imageLayoutVersion":"99.0.0"}"#,
+    )
+    .unwrap();
+
+    let err = unwrap_err_snapshot(Snapshot::checked_load(
+        &path,
+        OciTag::new("latest").unwrap(),
+    ));
+    let msg = format!("{}", err);
+    assert!(
+        msg.contains("image layout version") || msg.contains("imageLayoutVersion"),
+        "expected layout version error, got: {}",
+        msg
+    );
+}
+
+#[test]
+fn missing_index_rejected() {
+    let snapshot = create_snapshot();
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("snap");
+    snapshot
+        .save(&path, &OciTag::new("latest").unwrap())
+        .unwrap();
+
+    std::fs::remove_file(path.join("index.json")).unwrap();
+
+    let err = unwrap_err_snapshot(Snapshot::checked_load(
+        &path,
+        OciTag::new("latest").unwrap(),
+    ));
+    let msg = format!("{}", err);
+    assert!(
+        msg.contains("index.json"),
+        "expected missing index.json error, got: {}",
+        msg
+    );
+}
+
+#[test]
+fn snapshot_blob_size_mismatch_rejected() {
+    let snapshot = create_snapshot();
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("snap");
+    snapshot
+        .save(&path, &OciTag::new("latest").unwrap())
+        .unwrap();
+
+    // Truncate the snapshot blob by one byte.
+    let blobs_dir = path.join("blobs").join("sha256");
+    let manifest_bytes = std::fs::read(path.join("index.json")).unwrap();
+    let index: Value = serde_json::from_slice(&manifest_bytes).unwrap();
+    let manifest_digest = index["manifests"][0]["digest"]
+        .as_str()
+        .unwrap()
+        .strip_prefix("sha256:")
+        .unwrap();
+    let manifest_path = blobs_dir.join(manifest_digest);
+    let manifest: Value = serde_json::from_slice(&std::fs::read(&manifest_path).unwrap()).unwrap();
+    let snap_digest = manifest["layers"][0]["digest"]
+        .as_str()
+        .unwrap()
+        .strip_prefix("sha256:")
+        .unwrap();
+    let snap_path = blobs_dir.join(snap_digest);
+    let bytes = std::fs::read(&snap_path).unwrap();
+    std::fs::write(&snap_path, &bytes[..bytes.len() - 1]).unwrap();
+
+    let err = unwrap_err_snapshot(Snapshot::checked_load(
+        &path,
+        OciTag::new("latest").unwrap(),
+    ));
+    let msg = format!("{}", err);
+    assert!(
+        msg.contains("size") || msg.contains("mismatch"),
+        "expected size mismatch error, got: {}",
+        msg
+    );
+}
+
+#[test]
+fn snapshot_layout_snapshot_size_zero_rejected() {
+    let snapshot = create_snapshot();
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("snap");
+    snapshot
+        .save(&path, &OciTag::new("latest").unwrap())
+        .unwrap();
+    rewrite_config(&path, |cfg| {
+        cfg["layout"]["snapshot_size"] = Value::from(0u64);
+    });
+    let err = unwrap_err_snapshot(Snapshot::checked_load(
+        &path,
+        OciTag::new("latest").unwrap(),
+    ));
+    let msg = format!("{}", err);
+    assert!(
+        msg.contains("snapshot_size"),
+        "expected snapshot_size error, got: {}",
+        msg
+    );
+}
+
+#[test]
+fn snapshot_layout_snapshot_size_unaligned_rejected() {
+    let snapshot = create_snapshot();
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("snap");
+    snapshot
+        .save(&path, &OciTag::new("latest").unwrap())
+        .unwrap();
+    rewrite_config(&path, |cfg| {
+        let s = cfg["layout"]["snapshot_size"].as_u64().unwrap();
+        cfg["layout"]["snapshot_size"] = Value::from(s + 1);
+    });
+    let err = unwrap_err_snapshot(Snapshot::checked_load(
+        &path,
+        OciTag::new("latest").unwrap(),
+    ));
+    let msg = format!("{}", err);
+    assert!(
+        msg.contains("PAGE_SIZE") || msg.contains("multiple"),
+        "expected page alignment error, got: {}",
+        msg
+    );
+}
+
+#[test]
+fn snapshot_layout_snapshot_size_must_match_memory_size() {
+    let snapshot = create_snapshot();
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("snap");
+    snapshot
+        .save(&path, &OciTag::new("latest").unwrap())
+        .unwrap();
+    let page = hyperlight_common::vmem::PAGE_SIZE as u64;
+    rewrite_config(&path, |cfg| {
+        let m = cfg["memory_size"].as_u64().unwrap();
+        cfg["layout"]["snapshot_size"] = Value::from(m + page);
+    });
+    let err = unwrap_err_snapshot(Snapshot::checked_load(
+        &path,
+        OciTag::new("latest").unwrap(),
+    ));
+    let msg = format!("{}", err);
+    assert!(
+        msg.contains("does not equal memory_size"),
+        "expected snapshot_size + pt_size != memory_size error, got: {}",
+        msg
+    );
+}
+
+#[test]
+fn snapshot_size_smaller_than_layout_rejected() {
+    // Shrinking `snapshot_size` while growing `pt_size` by the same
+    // amount preserves `snapshot_size + pt_size == memory_size` and the
+    // blob length, yet leaves the guest mapping too short to back the
+    // regions the layout describes. The loader must compare
+    // `snapshot_size` against the size the layout fields imply.
+    let snapshot = create_snapshot();
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("snap");
+    snapshot
+        .save(&path, &OciTag::new("latest").unwrap())
+        .unwrap();
+    let page = hyperlight_common::vmem::PAGE_SIZE as u64;
+    // Size the layout fields imply. The guest-visible prefix must
+    // cover at least this much.
+    let required = snapshot.layout().get_memory_size().unwrap() as u64;
+    rewrite_config(&path, |cfg| {
+        let mem = cfg["memory_size"].as_u64().unwrap();
+        // One page short of the required size, with the page-table
+        // tail absorbing the rest so `memory_size` (and the blob
+        // length) stay constant.
+        let short = required - page;
+        cfg["layout"]["snapshot_size"] = Value::from(short);
+        cfg["layout"]["pt_size"] = Value::from(mem - short);
+        // Grow scratch to cover the larger pt tail so the scratch
+        // bound is not what trips.
+        cfg["layout"]["scratch_size"] = Value::from(mem + page);
+    });
+    let err = unwrap_err_snapshot(Snapshot::checked_load(
+        &path,
+        OciTag::new("latest").unwrap(),
+    ));
+    assert_err_contains(err, "is smaller than the layout size");
+}
+
+#[test]
+fn snapshot_layout_pt_size_unaligned_rejected() {
+    let snapshot = create_snapshot();
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("snap");
+    snapshot
+        .save(&path, &OciTag::new("latest").unwrap())
+        .unwrap();
+    rewrite_config(&path, |cfg| {
+        if let Some(p) = cfg["layout"]["pt_size"].as_u64() {
+            cfg["layout"]["pt_size"] = Value::from(p + 1);
+        } else {
+            cfg["layout"]["pt_size"] = Value::from(1u64);
+        }
+    });
+    let err = unwrap_err_snapshot(Snapshot::checked_load(
+        &path,
+        OciTag::new("latest").unwrap(),
+    ));
+    let msg = format!("{}", err);
+    assert!(
+        msg.contains("pt_size") || msg.contains("PAGE_SIZE") || msg.contains("multiple"),
+        "expected pt_size validation error, got: {}",
+        msg
+    );
+}
+
+#[test]
+fn missing_snapshot_blob_rejected() {
+    let snapshot = create_snapshot();
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("snap");
+    snapshot
+        .save(&path, &OciTag::new("latest").unwrap())
+        .unwrap();
+
+    let blobs_dir = path.join("blobs").join("sha256");
+    let manifest_bytes = std::fs::read(path.join("index.json")).unwrap();
+    let index: Value = serde_json::from_slice(&manifest_bytes).unwrap();
+    let manifest_digest = index["manifests"][0]["digest"]
+        .as_str()
+        .unwrap()
+        .strip_prefix("sha256:")
+        .unwrap();
+    let manifest_path = blobs_dir.join(manifest_digest);
+    let manifest: Value = serde_json::from_slice(&std::fs::read(&manifest_path).unwrap()).unwrap();
+    let snap_digest = manifest["layers"][0]["digest"]
+        .as_str()
+        .unwrap()
+        .strip_prefix("sha256:")
+        .unwrap();
+    std::fs::remove_file(blobs_dir.join(snap_digest)).unwrap();
+
+    let err = unwrap_err_snapshot(Snapshot::checked_load(
+        &path,
+        OciTag::new("latest").unwrap(),
+    ));
+    let msg = format!("{}", err);
+    assert!(
+        msg.contains("snapshot blob") || msg.contains("No such") || msg.contains("not found"),
+        "expected missing-blob error, got: {}",
+        msg
+    );
+}
+
+// Path semantics.
+
+#[test]
+fn checked_load_nonexistent_path_returns_error() {
+    let err = unwrap_err_snapshot(Snapshot::checked_load(
+        "/nonexistent/path/to/oci",
+        OciTag::new("latest").unwrap(),
+    ));
+    let msg = format!("{}", err);
+    assert!(
+        msg.contains("stat") || msg.contains("No such") || msg.contains("not found"),
+        "expected missing-path error, got: {}",
+        msg
+    );
+}
+
+#[test]
+fn checked_load_file_not_directory_rejected() {
+    let dir = tempfile::tempdir().unwrap();
+    let file_path = dir.path().join("not-a-dir");
+    std::fs::write(&file_path, b"hello").unwrap();
+    let err = unwrap_err_snapshot(Snapshot::checked_load(
+        &file_path,
+        OciTag::new("latest").unwrap(),
+    ));
+    let msg = format!("{}", err);
+    assert!(
+        msg.contains("not a directory"),
+        "expected not-a-directory error, got: {}",
+        msg
+    );
+}
+
+/// Two snapshots written to one directory under different tags coexist
+/// and load independently.
+#[test]
+fn save_appends_into_existing_layout_with_new_tag() {
+    let snap_a = create_snapshot();
+    let snap_b = create_snapshot();
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("store");
+
+    snap_a.save(&path, &OciTag::new("a").unwrap()).unwrap();
+    snap_b.save(&path, &OciTag::new("b").unwrap()).unwrap();
+
+    let _ = Snapshot::checked_load(&path, OciTag::new("a").unwrap()).unwrap();
+    let _ = Snapshot::checked_load(&path, OciTag::new("b").unwrap()).unwrap();
+
+    let index: Value =
+        serde_json::from_slice(&std::fs::read(path.join("index.json")).unwrap()).unwrap();
+    let manifests = index["manifests"].as_array().unwrap();
+    let tags: Vec<&str> = manifests
+        .iter()
+        .map(|m| {
+            m["annotations"]["org.opencontainers.image.ref.name"]
+                .as_str()
+                .unwrap()
+        })
+        .collect();
+    assert_eq!(tags.len(), 2);
+    assert!(tags.contains(&"a"));
+    assert!(tags.contains(&"b"));
+
+    // Every descriptor carries advisory arch and hypervisor
+    // annotations so registry UIs and OCI tooling can show them.
+    let expected_arch = if cfg!(target_arch = "aarch64") {
+        "aarch64"
+    } else {
+        "x86_64"
+    };
+    for m in manifests {
+        let anns = &m["annotations"];
+        assert_eq!(
+            anns["dev.hyperlight.snapshot.arch"].as_str().unwrap(),
+            expected_arch
+        );
+        let hv = anns["dev.hyperlight.snapshot.hypervisor"].as_str().unwrap();
+        assert!(
+            ["kvm", "mshv", "whp"].contains(&hv),
+            "unexpected hypervisor annotation: {}",
+            hv
+        );
+    }
+}
+
+#[test]
+fn save_replaces_descriptor_for_same_tag() {
+    let mut sbox = create_test_sandbox();
+    sbox.call::<String>("Echo", "first".to_string()).unwrap();
+    let snap_first = sbox.snapshot().unwrap();
+    sbox.call::<String>("Echo", "second".to_string()).unwrap();
+    let snap_second = sbox.snapshot().unwrap();
+    let gen_second = snap_second.snapshot_generation();
+
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("store");
+
+    snap_first
+        .save(&path, &OciTag::new("latest").unwrap())
+        .unwrap();
+    snap_second
+        .save(&path, &OciTag::new("latest").unwrap())
+        .unwrap();
+
+    let loaded = Snapshot::checked_load(&path, OciTag::new("latest").unwrap()).unwrap();
+    assert_eq!(loaded.snapshot_generation(), gen_second);
+
+    let index: Value =
+        serde_json::from_slice(&std::fs::read(path.join("index.json")).unwrap()).unwrap();
+    let entries: Vec<&Value> = index["manifests"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter(|m| {
+            m["annotations"]["org.opencontainers.image.ref.name"].as_str() == Some("latest")
+        })
+        .collect();
+    assert_eq!(entries.len(), 1, "expected one descriptor for tag 'latest'");
+}
+
+/// `save` creates the leaf directory but requires its parent chain to
+/// exist.
+#[test]
+fn save_requires_parent_dir_to_exist() {
+    let snap = create_snapshot();
+    let dir = tempfile::tempdir().unwrap();
+    let missing_parent = dir.path().join("a").join("b").join("c");
+    let path = missing_parent.join("store");
+    let err = snap
+        .save(&path, &OciTag::new("latest").unwrap())
+        .unwrap_err();
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("parent directory") || msg.contains("not accessible"),
+        "expected missing-parent error, got: {msg}"
+    );
+    assert!(!missing_parent.exists(), "no parent dirs should be created");
+}
+
+#[test]
+fn save_rejects_regular_file_at_path() {
+    let snap = create_snapshot();
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("not-a-dir");
+    std::fs::write(&path, b"i am a file").unwrap();
+    let err = snap
+        .save(&path, &OciTag::new("latest").unwrap())
+        .unwrap_err();
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("is not a directory") || msg.contains("layout dir"),
+        "expected non-directory error, got: {msg}"
+    );
+    assert_eq!(std::fs::read(&path).unwrap(), b"i am a file");
+}
+
+/// A pre-existing `oci-layout` with an unknown version is left in place
+/// and the call errors.
+#[test]
+fn save_rejects_unsupported_existing_layout_version() {
+    let snap = create_snapshot();
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("store");
+    std::fs::create_dir_all(&path).unwrap();
+    std::fs::write(
+        path.join("oci-layout"),
+        br#"{"imageLayoutVersion":"99.0.0"}"#,
+    )
+    .unwrap();
+    let err = snap
+        .save(&path, &OciTag::new("latest").unwrap())
+        .unwrap_err();
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("imageLayoutVersion") || msg.contains("unsupported"),
+        "expected unsupported-version error, got: {msg}"
+    );
+    assert!(
+        !path.join("index.json").exists(),
+        "save must not have written index.json"
+    );
+}
+
+#[test]
+fn save_into_empty_existing_directory() {
+    let snap = create_snapshot();
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("store");
+    std::fs::create_dir_all(&path).unwrap();
+
+    snap.save(&path, &OciTag::new("latest").unwrap()).unwrap();
+    let _ = Snapshot::checked_load(&path, OciTag::new("latest").unwrap()).unwrap();
+    assert!(path.join("oci-layout").exists());
+    assert!(path.join("index.json").exists());
+}
+
+/// Files in the layout dir that are not part of the OCI structure are
+/// left alone, matching containers/image, crane, and regclient.
+#[test]
+fn save_preserves_unrelated_files_in_layout_dir() {
+    let snap = create_snapshot();
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("store");
+    std::fs::create_dir_all(&path).unwrap();
+    std::fs::write(path.join("README.md"), b"keep me").unwrap();
+
+    snap.save(&path, &OciTag::new("latest").unwrap()).unwrap();
+    assert_eq!(std::fs::read(path.join("README.md")).unwrap(), b"keep me");
+}
+
+/// Saving the same snapshot under the same tag twice keeps one
+/// descriptor and reuses the content-addressed blobs.
+#[test]
+fn save_same_tag_same_content_is_idempotent() {
+    let snap = create_snapshot();
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("store");
+
+    snap.save(&path, &OciTag::new("latest").unwrap()).unwrap();
+    let blobs_after_first: Vec<_> = std::fs::read_dir(path.join("blobs").join("sha256"))
+        .unwrap()
+        .filter_map(|e| e.ok().map(|e| e.file_name()))
+        .collect();
+
+    snap.save(&path, &OciTag::new("latest").unwrap()).unwrap();
+    let blobs_after_second: Vec<_> = std::fs::read_dir(path.join("blobs").join("sha256"))
+        .unwrap()
+        .filter_map(|e| e.ok().map(|e| e.file_name()))
+        .collect();
+    assert_eq!(blobs_after_first.len(), blobs_after_second.len());
+
+    let index: Value =
+        serde_json::from_slice(&std::fs::read(path.join("index.json")).unwrap()).unwrap();
+    let manifests = index["manifests"].as_array().unwrap();
+    assert_eq!(manifests.len(), 1);
+    assert_eq!(
+        manifests[0]["annotations"]["org.opencontainers.image.ref.name"],
+        "latest"
+    );
+}
+
+/// Two tags written from one in-memory snapshot share all three blobs
+/// (manifest, config, snapshot).
+#[test]
+fn save_shares_blobs_across_tags_with_identical_content() {
+    let snap = create_snapshot();
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("store");
+
+    snap.save(&path, &OciTag::new("a").unwrap()).unwrap();
+    snap.save(&path, &OciTag::new("b").unwrap()).unwrap();
+
+    let blobs: Vec<_> = std::fs::read_dir(path.join("blobs").join("sha256"))
+        .unwrap()
+        .filter_map(|e| e.ok().map(|e| e.file_name()))
+        .collect();
+    assert_eq!(blobs.len(), 3, "expected 3 deduped blobs, got {:?}", blobs);
+}
+
+/// Replacing one tag in a three-tag layout keeps the other two
+/// descriptors intact.
+#[test]
+fn save_replace_in_middle_preserves_other_tags() {
+    let mut sbox = create_test_sandbox();
+    let snap_a = sbox.snapshot().unwrap();
+    sbox.call::<String>("Echo", "x".to_string()).unwrap();
+    let snap_b = sbox.snapshot().unwrap();
+    sbox.call::<String>("Echo", "y".to_string()).unwrap();
+    let snap_c = sbox.snapshot().unwrap();
+    sbox.call::<String>("Echo", "z".to_string()).unwrap();
+    let snap_b2 = sbox.snapshot().unwrap();
+    let gen_b2 = snap_b2.snapshot_generation();
+
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("store");
+    snap_a.save(&path, &OciTag::new("a").unwrap()).unwrap();
+    snap_b.save(&path, &OciTag::new("b").unwrap()).unwrap();
+    snap_c.save(&path, &OciTag::new("c").unwrap()).unwrap();
+    snap_b2.save(&path, &OciTag::new("b").unwrap()).unwrap();
+
+    let index: Value =
+        serde_json::from_slice(&std::fs::read(path.join("index.json")).unwrap()).unwrap();
+    let tags: Vec<&str> = index["manifests"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|m| {
+            m["annotations"]["org.opencontainers.image.ref.name"]
+                .as_str()
+                .unwrap()
+        })
+        .collect();
+    assert_eq!(tags.len(), 3);
+    assert!(tags.contains(&"a"));
+    assert!(tags.contains(&"b"));
+    assert!(tags.contains(&"c"));
+
+    let loaded_b = Snapshot::checked_load(&path, OciTag::new("b").unwrap()).unwrap();
+    assert_eq!(loaded_b.snapshot_generation(), gen_b2);
+}
+
+#[test]
+fn save_rejects_malformed_existing_oci_layout_json() {
+    let snap = create_snapshot();
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("store");
+    std::fs::create_dir_all(&path).unwrap();
+    std::fs::write(path.join("oci-layout"), b"not json").unwrap();
+
+    let err = snap
+        .save(&path, &OciTag::new("latest").unwrap())
+        .unwrap_err();
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("oci-layout") && msg.contains("JSON"),
+        "expected oci-layout JSON error, got: {msg}"
+    );
+    assert!(!path.join("index.json").exists());
+}
+
+#[test]
+fn save_rejects_existing_oci_layout_missing_version() {
+    let snap = create_snapshot();
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("store");
+    std::fs::create_dir_all(&path).unwrap();
+    std::fs::write(path.join("oci-layout"), br#"{"other":"field"}"#).unwrap();
+
+    let err = snap
+        .save(&path, &OciTag::new("latest").unwrap())
+        .unwrap_err();
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("imageLayoutVersion"),
+        "expected missing-version error, got: {msg}"
+    );
+    assert!(!path.join("index.json").exists());
+}
+
+#[test]
+fn save_rejects_malformed_existing_index_json() {
+    let snap = create_snapshot();
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("store");
+    std::fs::create_dir_all(&path).unwrap();
+    std::fs::write(
+        path.join("oci-layout"),
+        br#"{"imageLayoutVersion":"1.0.0"}"#,
+    )
+    .unwrap();
+    std::fs::write(path.join("index.json"), b"{not valid json").unwrap();
+
+    let err = snap
+        .save(&path, &OciTag::new("latest").unwrap())
+        .unwrap_err();
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("index.json"),
+        "expected index.json error, got: {msg}"
+    );
+    assert_eq!(
+        std::fs::read(path.join("index.json")).unwrap(),
+        b"{not valid json",
+        "save must not overwrite a malformed existing index.json"
+    );
+}
+
+/// A snapshot blob whose bytes have been replaced (with length
+/// preserved so descriptor sizes still match) must be rejected via
+/// digest mismatch.
+#[test]
+fn checked_load_rejects_snapshot_blob_byte_mutation() {
+    let snapshot = create_snapshot();
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("snap");
+    snapshot
+        .save(&path, &OciTag::new("latest").unwrap())
+        .unwrap();
+
+    // Flip one byte in the middle of the snapshot blob. Length is
+    // preserved so only a digest re-hash can detect this.
+    let blobs_dir = path.join("blobs").join("sha256");
+    let index: Value =
+        serde_json::from_slice(&std::fs::read(path.join("index.json")).unwrap()).unwrap();
+    let manifest_digest = index["manifests"][0]["digest"]
+        .as_str()
+        .unwrap()
+        .strip_prefix("sha256:")
+        .unwrap()
+        .to_string();
+    let manifest: Value =
+        serde_json::from_slice(&std::fs::read(blobs_dir.join(&manifest_digest)).unwrap()).unwrap();
+    let snap_digest = manifest["layers"][0]["digest"]
+        .as_str()
+        .unwrap()
+        .strip_prefix("sha256:")
+        .unwrap()
+        .to_string();
+    let snap_path = blobs_dir.join(&snap_digest);
+    let mut bytes = std::fs::read(&snap_path).unwrap();
+    let mid = bytes.len() / 2;
+    bytes[mid] ^= 0xFF;
+    std::fs::write(&snap_path, &bytes).unwrap();
+
+    let err = unwrap_err_snapshot(Snapshot::checked_load(
+        &path,
+        OciTag::new("latest").unwrap(),
+    ));
+    let msg = format!("{}", err);
+    assert!(
+        msg.contains("digest") || msg.contains("hash") || msg.contains("sha256"),
+        "expected digest-mismatch error, got: {}",
+        msg
+    );
+}
+
+/// Config-blob byte mutation must be caught by digest verification
+/// before any structural validator runs.
+#[test]
+fn checked_load_rejects_config_blob_byte_mutation() {
+    let snapshot = create_snapshot();
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("snap");
+    snapshot
+        .save(&path, &OciTag::new("latest").unwrap())
+        .unwrap();
+
+    let cfg_path = find_config_blob(&path);
+    let mut bytes = std::fs::read(&cfg_path).unwrap();
+    // Length-preserving byte flip so the digest layer rejects before
+    // the JSON parser.
+    bytes[0] = b' ';
+    std::fs::write(&cfg_path, &bytes).unwrap();
+
+    let err = unwrap_err_snapshot(Snapshot::checked_load(
+        &path,
+        OciTag::new("latest").unwrap(),
+    ));
+    let msg = format!("{}", err);
+    assert!(
+        msg.contains("digest") || msg.contains("hash") || msg.contains("sha256"),
+        "expected digest-mismatch error, got: {}",
+        msg
+    );
+}
+
+// Input validation for `checked_load`.
+
+fn save_for_mutation() -> (tempfile::TempDir, std::path::PathBuf) {
+    let snapshot = create_snapshot();
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("snap");
+    snapshot
+        .save(&path, &OciTag::new("latest").unwrap())
+        .unwrap();
+    (dir, path)
+}
+
+fn assert_err_contains(err: crate::HyperlightError, needle: &str) {
+    let msg = format!("{}", err);
+    assert!(
+        msg.contains(needle),
+        "expected error to contain {:?}, got: {}",
+        needle,
+        msg
+    );
+}
+
+#[test]
+fn malformed_oci_layout_rejected() {
+    let (_dir, path) = save_for_mutation();
+    std::fs::write(path.join("oci-layout"), b"not-valid-json{").unwrap();
+    let err = unwrap_err_snapshot(Snapshot::checked_load(
+        &path,
+        OciTag::new("latest").unwrap(),
+    ));
+    assert_err_contains(err, "oci-layout");
+}
+
+#[test]
+fn oci_layout_missing_version_field_rejected() {
+    let (_dir, path) = save_for_mutation();
+    std::fs::write(path.join("oci-layout"), r#"{"unrelated":"field"}"#).unwrap();
+    let err = unwrap_err_snapshot(Snapshot::checked_load(
+        &path,
+        OciTag::new("latest").unwrap(),
+    ));
+    assert_err_contains(err, "imageLayoutVersion");
+}
+
+#[test]
+fn malformed_index_json_rejected() {
+    let (_dir, path) = save_for_mutation();
+    std::fs::write(path.join("index.json"), b"{not json").unwrap();
+    let err = unwrap_err_snapshot(Snapshot::checked_load(
+        &path,
+        OciTag::new("latest").unwrap(),
+    ));
+    assert_err_contains(err, "index.json");
+}
+
+#[test]
+fn empty_index_rejected() {
+    let (_dir, path) = save_for_mutation();
+    rewrite_index(&path, |idx| {
+        idx["manifests"] = Value::Array(Vec::new());
+    });
+    let err = unwrap_err_snapshot(Snapshot::checked_load(
+        &path,
+        OciTag::new("latest").unwrap(),
+    ));
+    assert_err_contains(err, "no manifest tagged");
+}
+
+/// Two manifests sharing one `org.opencontainers.image.ref.name`
+/// annotation are ambiguous, so the load is refused.
+#[test]
+fn checked_load_rejects_duplicate_tag_in_index() {
+    let (_dir, path) = save_for_mutation();
+    rewrite_index(&path, |idx| {
+        let first = idx["manifests"][0].clone();
+        idx["manifests"].as_array_mut().unwrap().push(first);
+    });
+    let err = unwrap_err_snapshot(Snapshot::checked_load(
+        &path,
+        OciTag::new("latest").unwrap(),
+    ));
+    assert_err_contains(err, "multiple manifests tagged");
+}
+
+#[test]
+fn missing_manifest_blob_rejected() {
+    let (_dir, path) = save_for_mutation();
+    std::fs::remove_file(manifest_path(&path)).unwrap();
+    let err = unwrap_err_snapshot(Snapshot::checked_load(
+        &path,
+        OciTag::new("latest").unwrap(),
+    ));
+    let msg = format!("{}", err);
+    assert!(
+        msg.contains("open") || msg.contains("No such") || msg.contains("not found"),
+        "expected missing-manifest error, got: {}",
+        msg
+    );
+}
+
+#[test]
+fn bad_digest_format_rejected() {
+    let (_dir, path) = save_for_mutation();
+    rewrite_index(&path, |idx| {
+        // `oci-spec` validates descriptor digests on parse and rejects
+        // values lacking the algorithm prefix.
+        idx["manifests"][0]["digest"] = Value::from("deadbeef");
+    });
+    let err = unwrap_err_snapshot(Snapshot::checked_load(
+        &path,
+        OciTag::new("latest").unwrap(),
+    ));
+    let msg = format!("{}", err);
+    assert!(
+        msg.contains("digest") || msg.contains("index.json"),
+        "expected digest or parse error, got: {}",
+        msg
+    );
+}
+
+/// `load` reaches the manifest JSON parser. The digest
+/// path is covered by `checked_load_rejects_manifest_blob_byte_mutation`.
+#[test]
+fn malformed_manifest_json_rejected() {
+    let (_dir, path) = save_for_mutation();
+    let mp = manifest_path(&path);
+    std::fs::write(&mp, b"{not json").unwrap();
+    // Match the descriptor size so the JSON parser runs, not the size
+    // check.
+    let new_len = std::fs::metadata(&mp).unwrap().len();
+    rewrite_index(&path, |idx| {
+        idx["manifests"][0]["size"] = Value::from(new_len);
+    });
+    let err = unwrap_err_snapshot(Snapshot::load(&path, OciTag::new("latest").unwrap()));
+    assert_err_contains(err, "manifest");
+}
+
+#[test]
+fn wrong_manifest_schema_version_rejected() {
+    let (_dir, path) = save_for_mutation();
+    rewrite_manifest(&path, |m| {
+        m["schemaVersion"] = Value::from(99u32);
+    });
+    let err = unwrap_err_snapshot(Snapshot::checked_load(
+        &path,
+        OciTag::new("latest").unwrap(),
+    ));
+    assert_err_contains(err, "schemaVersion");
+}
+
+#[test]
+fn unknown_config_media_type_rejected() {
+    let (_dir, path) = save_for_mutation();
+    rewrite_manifest(&path, |m| {
+        m["config"]["mediaType"] = Value::from("application/vnd.example.unknown.v1+json");
+    });
+    let err = unwrap_err_snapshot(Snapshot::checked_load(
+        &path,
+        OciTag::new("latest").unwrap(),
+    ));
+    assert_err_contains(err, "config media type");
+}
+
+#[test]
+fn empty_layers_rejected() {
+    let (_dir, path) = save_for_mutation();
+    rewrite_manifest(&path, |m| {
+        m["layers"] = Value::Array(Vec::new());
+    });
+    let err = unwrap_err_snapshot(Snapshot::checked_load(
+        &path,
+        OciTag::new("latest").unwrap(),
+    ));
+    assert_err_contains(err, "layer");
+}
+
+#[test]
+fn extra_layers_rejected() {
+    let (_dir, path) = save_for_mutation();
+    rewrite_manifest(&path, |m| {
+        let first = m["layers"][0].clone();
+        m["layers"].as_array_mut().unwrap().push(first);
+    });
+    let err = unwrap_err_snapshot(Snapshot::checked_load(
+        &path,
+        OciTag::new("latest").unwrap(),
+    ));
+    assert_err_contains(err, "layer");
+}
+
+#[test]
+fn unknown_snapshot_layer_media_type_rejected() {
+    let (_dir, path) = save_for_mutation();
+    rewrite_manifest(&path, |m| {
+        m["layers"][0]["mediaType"] = Value::from("application/vnd.example.unknown.v1");
+    });
+    let err = unwrap_err_snapshot(Snapshot::checked_load(
+        &path,
+        OciTag::new("latest").unwrap(),
+    ));
+    assert_err_contains(err, "snapshot layer media type");
+}
+
+/// Annotations injected by third-party tools (cosign, ORAS, build
+/// pipelines) must not break load. The OCI envelope around
+/// `OciSnapshotConfig` is parsed via `oci-spec`'s lenient types.
+#[test]
+fn manifest_and_index_annotations_tolerated() {
+    let snapshot = create_snapshot();
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("snap");
+    snapshot
+        .save(&path, &OciTag::new("latest").unwrap())
+        .unwrap();
+
+    rewrite_manifest(&path, |m| {
+        let mut anns = serde_json::Map::new();
+        anns.insert(
+            "org.opencontainers.image.created".to_string(),
+            Value::from("2024-01-01T00:00:00Z"),
+        );
+        anns.insert(
+            "dev.sigstore.cosign/signature".to_string(),
+            Value::from("MEUCIQDsignature"),
+        );
+        m["annotations"] = Value::Object(anns);
+    });
+    rewrite_index(&path, |idx| {
+        let mut anns = serde_json::Map::new();
+        anns.insert(
+            "org.opencontainers.image.ref.name".to_string(),
+            Value::from("v1.2.3"),
+        );
+        idx["annotations"] = Value::Object(anns);
+    });
+
+    let loaded = Snapshot::checked_load(&path, OciTag::new("latest").unwrap()).unwrap();
+    let mut sbox2 =
+        MultiUseSandbox::from_snapshot(Arc::new(loaded), HostFunctions::default(), None).unwrap();
+    assert_eq!(sbox2.call::<i32>("GetStatic", ()).unwrap(), 0);
+}
+
+#[test]
+fn config_blob_size_descriptor_mismatch_rejected() {
+    let (_dir, path) = save_for_mutation();
+    // Bump the config descriptor's claimed size, leaving the blob as written.
+    rewrite_manifest(&path, |m| {
+        let sz = m["config"]["size"].as_u64().unwrap();
+        m["config"]["size"] = Value::from(sz + 1);
+    });
+    let err = unwrap_err_snapshot(Snapshot::checked_load(
+        &path,
+        OciTag::new("latest").unwrap(),
+    ));
+    assert_err_contains(err, "config blob size mismatch");
+}
+
+/// `load` reaches the config JSON parser. The digest path
+/// is covered by `checked_load_rejects_config_blob_byte_mutation`.
+#[test]
+fn malformed_config_json_rejected() {
+    let (_dir, path) = save_for_mutation();
+    let cfg_path = find_config_blob(&path);
+    std::fs::write(&cfg_path, b"{not json").unwrap();
+    // Match descriptor sizes so the JSON parser runs, not the size
+    // check.
+    let new_cfg_len = std::fs::metadata(&cfg_path).unwrap().len();
+    rewrite_manifest(&path, |m| {
+        m["config"]["size"] = Value::from(new_cfg_len);
+    });
+    let err = unwrap_err_snapshot(Snapshot::load(&path, OciTag::new("latest").unwrap()));
+    assert_err_contains(err, "config JSON");
+}
+
+#[test]
+fn memory_size_zero_rejected() {
+    let (_dir, path) = save_for_mutation();
+    rewrite_config(&path, |cfg| {
+        cfg["memory_size"] = Value::from(0u64);
+    });
+    let err = unwrap_err_snapshot(Snapshot::checked_load(
+        &path,
+        OciTag::new("latest").unwrap(),
+    ));
+    assert_err_contains(err, "memory_size");
+}
+
+#[test]
+fn memory_size_unaligned_rejected() {
+    let (_dir, path) = save_for_mutation();
+    rewrite_config(&path, |cfg| {
+        let sz = cfg["memory_size"].as_u64().unwrap();
+        cfg["memory_size"] = Value::from(sz + 1);
+    });
+    let err = unwrap_err_snapshot(Snapshot::checked_load(
+        &path,
+        OciTag::new("latest").unwrap(),
+    ));
+    let msg = format!("{}", err);
+    // Either the page-alignment check or the file-size check trips.
+    assert!(
+        msg.contains("memory_size") || msg.contains("PAGE_SIZE") || msg.contains("size"),
+        "expected memory_size rejection, got: {}",
+        msg
+    );
+}
+
+#[test]
+fn bad_init_data_permissions_rejected() {
+    let (_dir, path) = save_for_mutation();
+    rewrite_config(&path, |cfg| {
+        // 1u32 << 31 is well outside the defined READ|WRITE|EXECUTE bits.
+        cfg["layout"]["init_data_permissions"] = Value::from(0x8000_0000u32);
+    });
+    let err = unwrap_err_snapshot(Snapshot::checked_load(
+        &path,
+        OciTag::new("latest").unwrap(),
+    ));
+    assert_err_contains(err, "init_data_permissions");
+}
+
+#[test]
+fn entrypoint_addr_outside_snapshot_region_rejected() {
+    let (_dir, path) = save_for_mutation();
+    rewrite_config(&path, |cfg| {
+        // Far above any plausible snapshot region and outside guest
+        // mapped memory.
+        cfg["entrypoint_addr"] = Value::from(0xDEAD_BEEF_0000u64);
+    });
+    let err = unwrap_err_snapshot(Snapshot::checked_load(
+        &path,
+        OciTag::new("latest").unwrap(),
+    ));
+    assert_err_contains(err, "entrypoint addr");
+}
+
+#[test]
+fn entrypoint_addr_below_base_address_rejected() {
+    let (_dir, path) = save_for_mutation();
+    rewrite_config(&path, |cfg| {
+        // Below BASE_ADDRESS (0x1000).
+        cfg["entrypoint_addr"] = Value::from(0u64);
+    });
+    let err = unwrap_err_snapshot(Snapshot::checked_load(
+        &path,
+        OciTag::new("latest").unwrap(),
+    ));
+    assert_err_contains(err, "entrypoint addr");
+}
+
+// `load`: skips blob digest verification, runs every
+// other validator.
+
+#[test]
+fn load_round_trips() {
+    let snapshot = create_snapshot();
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("snap");
+    snapshot
+        .save(&path, &OciTag::new("latest").unwrap())
+        .unwrap();
+
+    let loaded = Snapshot::load(&path, OciTag::new("latest").unwrap()).unwrap();
+    let mut sbox2 =
+        MultiUseSandbox::from_snapshot(Arc::new(loaded), HostFunctions::default(), None).unwrap();
+    let result: String = sbox2.call("Echo", "hi\n".to_string()).unwrap();
+    assert_eq!(result, "hi\n");
+}
+
+/// Field-level validators (arch, abi, hypervisor, layout and entrypoint
+/// bounds) still fire under `load`.
+#[test]
+fn load_still_validates_config_fields() {
+    let (_dir, path) = save_for_mutation();
+    rewrite_config(&path, |cfg| {
+        cfg["arch"] = Value::from("aarch64");
+    });
+    let err = unwrap_err_snapshot(Snapshot::load(&path, OciTag::new("latest").unwrap()));
+    let msg = format!("{}", err);
+    assert!(
+        msg.contains("architecture") || msg.contains("arch"),
+        "expected architecture mismatch under load, got: {}",
+        msg
+    );
+}
+
+/// A length-preserving byte flip breaks the snapshot blob's sha256 but
+/// leaves the layout valid. `checked_load` rejects it on the digest,
+/// `load` loads it.
+#[test]
+fn load_accepts_digest_mismatched_snapshot_blob() {
+    let snapshot = create_snapshot();
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("snap");
+    snapshot
+        .save(&path, &OciTag::new("latest").unwrap())
+        .unwrap();
+
+    let snap_path = find_snapshot_blob(&path);
+    let mut bytes = std::fs::read(&snap_path).unwrap();
+    let mid = bytes.len() / 2;
+    bytes[mid] ^= 0xFF;
+    std::fs::write(&snap_path, &bytes).unwrap();
+
+    let err = unwrap_err_snapshot(Snapshot::checked_load(
+        &path,
+        OciTag::new("latest").unwrap(),
+    ));
+    assert_err_contains(err, "digest");
+
+    let _ = Snapshot::load(&path, OciTag::new("latest").unwrap())
+        .expect("load loads a digest-mismatched blob");
+}
+
+/// Flipping a manifest body byte while the index's descriptor digest is
+/// stale must be caught by digest verification before any field-level
+/// manifest validator runs.
+#[test]
+fn checked_load_rejects_manifest_blob_byte_mutation() {
+    let snapshot = create_snapshot();
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("snap");
+    snapshot
+        .save(&path, &OciTag::new("latest").unwrap())
+        .unwrap();
+
+    let mp = manifest_path(&path);
+    let mut bytes = std::fs::read(&mp).unwrap();
+    // Length-preserving flip.
+    bytes[0] ^= 0x20;
+    std::fs::write(&mp, &bytes).unwrap();
+
+    let err = unwrap_err_snapshot(Snapshot::checked_load(
+        &path,
+        OciTag::new("latest").unwrap(),
+    ));
+    assert_err_contains(err, "digest mismatch");
+}
+
+#[test]
+fn checked_load_unknown_tag_lists_available_tags() {
+    let snap = create_snapshot();
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("layout");
+    snap.save(&path, &OciTag::new("alpha").unwrap()).unwrap();
+
+    let err = unwrap_err_snapshot(Snapshot::checked_load(
+        &path,
+        OciTag::new("missing").unwrap(),
+    ));
+    let msg = format!("{}", err);
+    assert!(
+        msg.contains("no manifest tagged") && msg.contains("\"missing\""),
+        "expected unknown-tag error mentioning the requested tag, got: {}",
+        msg
+    );
+    assert!(
+        msg.contains("alpha"),
+        "expected available-tags listing to include the actual tag, got: {}",
+        msg
+    );
+}
+
+/// External tools (`oras`, `crane manifest`, `skopeo inspect`) read the
+/// tag from the `ref.name` annotation on the manifest descriptor.
+#[test]
+fn manifest_descriptor_carries_ref_name_annotation() {
+    let snap = create_snapshot();
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("layout");
+    snap.save(&path, &OciTag::new("production-v3").unwrap())
+        .unwrap();
+
+    let index: Value =
+        serde_json::from_slice(&std::fs::read(path.join("index.json")).unwrap()).unwrap();
+    let manifest = &index["manifests"][0];
+    assert_eq!(
+        manifest["annotations"]["org.opencontainers.image.ref.name"]
+            .as_str()
+            .unwrap(),
+        "production-v3"
+    );
+}
+
+// Tag validation. Grammar is enforced when an [`OciTag`] is parsed.
+
+#[test]
+fn empty_tag_rejected() {
+    assert!(OciTag::new("").is_err());
+}
+
+#[test]
+fn tag_with_illegal_leading_char_rejected() {
+    assert!(OciTag::new(".dotleader").is_err());
+    assert!(OciTag::new("-dashleader").is_err());
+}
+
+#[test]
+fn tag_with_illegal_chars_rejected() {
+    assert!(OciTag::new("with/slash").is_err());
+    assert!(OciTag::new("with space").is_err());
+}
+
+#[test]
+fn long_tag_within_limit_accepted() {
+    let snap = create_snapshot();
+    let dir = tempfile::tempdir().unwrap();
+    let long = OciTag::new("a".repeat(128)).unwrap();
+    snap.save(dir.path().join("snap"), &long).unwrap();
+    let _ = Snapshot::checked_load(dir.path().join("snap"), long).unwrap();
+}
+
+#[test]
+fn over_long_tag_rejected() {
+    assert!(OciTag::new("a".repeat(129)).is_err());
+}
+
+// Save-shape invariants. The on-disk JSON must match what the OCI spec
+// prescribes.
+
+#[test]
+fn manifest_descriptor_uses_image_manifest_media_type() {
+    let snap = create_snapshot();
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("layout");
+    snap.save(&path, &OciTag::new("latest").unwrap()).unwrap();
+    let index: Value =
+        serde_json::from_slice(&std::fs::read(path.join("index.json")).unwrap()).unwrap();
+    assert_eq!(
+        index["manifests"][0]["mediaType"].as_str().unwrap(),
+        "application/vnd.oci.image.manifest.v1+json"
+    );
+}
+
+/// A descriptor that does not advertise an OCI image manifest is
+/// refused even when the blob would parse.
+#[test]
+fn manifest_descriptor_non_image_manifest_rejected() {
+    let snap = create_snapshot();
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("layout");
+    snap.save(&path, &OciTag::new("latest").unwrap()).unwrap();
+    rewrite_index(&path, |idx| {
+        idx["manifests"][0]["mediaType"] = Value::from("application/vnd.oci.image.index.v1+json");
+    });
+    let err = unwrap_err_snapshot(Snapshot::checked_load(
+        &path,
+        OciTag::new("latest").unwrap(),
+    ));
+    let msg = format!("{}", err);
+    assert!(
+        msg.contains("unexpected media type"),
+        "expected manifest-descriptor media type error, got: {}",
+        msg
+    );
+}
+
+#[test]
+fn manifest_uses_correct_config_and_layer_media_types() {
+    let snap = create_snapshot();
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("layout");
+    snap.save(&path, &OciTag::new("latest").unwrap()).unwrap();
+    let manifest: Value =
+        serde_json::from_slice(&std::fs::read(manifest_path(&path)).unwrap()).unwrap();
+    assert_eq!(
+        manifest["config"]["mediaType"].as_str().unwrap(),
+        "application/vnd.hyperlight.snapshot.config.v1+json"
+    );
+    assert_eq!(manifest["layers"].as_array().unwrap().len(), 1);
+    assert_eq!(
+        manifest["layers"][0]["mediaType"].as_str().unwrap(),
+        "application/vnd.hyperlight.snapshot.memory.v1"
+    );
+    // `artifactType` mirrors `config.mediaType` so registries that surface
+    // the distribution-spec referrers API report a useful type, and tooling
+    // that falls back to `config.mediaType` sees the same value.
+    assert_eq!(
+        manifest["artifactType"].as_str().unwrap(),
+        "application/vnd.hyperlight.snapshot.config.v1+json"
+    );
+}
+
+#[test]
+fn manifest_missing_artifact_type_rejected() {
+    let snap = create_snapshot();
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("layout");
+    snap.save(&path, &OciTag::new("latest").unwrap()).unwrap();
+    rewrite_manifest(&path, |m| {
+        m.as_object_mut().unwrap().remove("artifactType");
+    });
+    let err = unwrap_err_snapshot(Snapshot::checked_load(
+        &path,
+        OciTag::new("latest").unwrap(),
+    ));
+    assert_err_contains(err, "missing required artifactType");
+}
+
+#[test]
+fn manifest_mismatched_artifact_type_rejected() {
+    let snap = create_snapshot();
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("layout");
+    snap.save(&path, &OciTag::new("latest").unwrap()).unwrap();
+    rewrite_manifest(&path, |m| {
+        m["artifactType"] = Value::from("application/vnd.example.bogus.v1+json");
+    });
+    let err = unwrap_err_snapshot(Snapshot::checked_load(
+        &path,
+        OciTag::new("latest").unwrap(),
+    ));
+    assert_err_contains(err, "does not match config media type");
+}
+
+#[test]
+fn save_writes_oci_layout_marker() {
+    let snap = create_snapshot();
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("layout");
+    snap.save(&path, &OciTag::new("latest").unwrap()).unwrap();
+    let marker: Value =
+        serde_json::from_slice(&std::fs::read(path.join("oci-layout")).unwrap()).unwrap();
+    assert_eq!(marker["imageLayoutVersion"].as_str().unwrap(), "1.0.0");
+}
+
+// Tag selection edge cases.
+
+#[test]
+fn tag_lookup_is_case_sensitive() {
+    let snap = create_snapshot();
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("layout");
+    snap.save(&path, &OciTag::new("MyTag").unwrap()).unwrap();
+
+    let err = unwrap_err_snapshot(Snapshot::checked_load(&path, OciTag::new("mytag").unwrap()));
+    assert_err_contains(err, "no manifest tagged");
+
+    let _ = Snapshot::checked_load(&path, OciTag::new("MyTag").unwrap()).unwrap();
+}
+
+/// A miscased annotation key like `org.OpenContainers.image.ref.name`
+/// leaves the manifest untagged from the loader's perspective.
+#[test]
+fn ref_name_annotation_key_is_case_sensitive() {
+    let (_dir, path) = save_for_mutation();
+    rewrite_index(&path, |idx| {
+        let anns = idx["manifests"][0]["annotations"].as_object_mut().unwrap();
+        let value = anns.remove("org.opencontainers.image.ref.name").unwrap();
+        anns.insert("org.OpenContainers.image.ref.name".to_string(), value);
+    });
+    let err = unwrap_err_snapshot(Snapshot::checked_load(
+        &path,
+        OciTag::new("latest").unwrap(),
+    ));
+    assert_err_contains(err, "no manifest tagged");
+}
+
+#[test]
+fn tag_with_all_valid_special_chars_accepted() {
+    let snap = create_snapshot();
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("layout");
+    let valid = OciTag::new("v1.2.3-rc.1_build").unwrap();
+    snap.save(&path, &valid).unwrap();
+    let _ = Snapshot::checked_load(&path, valid).unwrap();
+}
+
+/// A standard ref.name annotation resolves by tag even alongside
+/// unrelated annotations (cosign signatures, build pipelines).
+#[test]
+fn other_descriptor_annotations_do_not_interfere() {
+    let (_dir, path) = save_for_mutation();
+    rewrite_index(&path, |idx| {
+        let anns = idx["manifests"][0]["annotations"].as_object_mut().unwrap();
+        anns.insert(
+            "dev.sigstore.cosign/signature".to_string(),
+            Value::from("MEUCIQDfake"),
+        );
+        anns.insert("io.example.build.id".to_string(), Value::from("12345"));
+    });
+    let _ = Snapshot::checked_load(&path, OciTag::new("latest").unwrap()).unwrap();
+}
+
+// Bad sha256 digest format on the inner descriptors (config and snapshot
+// layer). The index-side equivalent is `bad_digest_format_rejected`.
+
+#[test]
+fn bad_config_descriptor_digest_format_rejected() {
+    let (_dir, path) = save_for_mutation();
+    rewrite_manifest(&path, |m| {
+        m["config"]["digest"] = Value::from("md5:deadbeef");
+    });
+    let err = unwrap_err_snapshot(Snapshot::checked_load(
+        &path,
+        OciTag::new("latest").unwrap(),
+    ));
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("digest"),
+        "expected digest-format error, got: {msg}"
+    );
+}
+
+#[test]
+fn bad_snapshot_layer_descriptor_digest_format_rejected() {
+    let (_dir, path) = save_for_mutation();
+    rewrite_manifest(&path, |m| {
+        m["layers"][0]["digest"] = Value::from("sha256:tooshort");
+    });
+    let err = unwrap_err_snapshot(Snapshot::checked_load(
+        &path,
+        OciTag::new("latest").unwrap(),
+    ));
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("digest"),
+        "expected digest-format error, got: {msg}"
+    );
+}
+
+// Missing inner blobs.
+
+#[test]
+fn missing_config_blob_rejected() {
+    let (_dir, path) = save_for_mutation();
+    let cfg_path = find_config_blob(&path);
+    std::fs::remove_file(&cfg_path).unwrap();
+    let err = unwrap_err_snapshot(Snapshot::checked_load(
+        &path,
+        OciTag::new("latest").unwrap(),
+    ));
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("open") || msg.contains("No such") || msg.contains("not found"),
+        "expected missing-config-blob error, got: {msg}"
+    );
+}
+
+// Size-bound enforcement.
+
+/// The manifest reader bounds input to 1 MiB. The descriptor size is
+/// matched so the bound trips before any size-mismatch check.
+#[test]
+fn manifest_blob_too_large_rejected() {
+    let (_dir, path) = save_for_mutation();
+    let mp = manifest_path(&path);
+    let huge = vec![b'a'; (1024 * 1024 + 16) as usize];
+    std::fs::write(&mp, &huge).unwrap();
+    rewrite_index(&path, |idx| {
+        idx["manifests"][0]["size"] = Value::from(huge.len() as u64);
+    });
+    let err = unwrap_err_snapshot(Snapshot::load(&path, OciTag::new("latest").unwrap()));
+    assert_err_contains(err, "exceeds maximum allowed");
+}
+
+#[test]
+fn config_blob_too_large_rejected() {
+    let (_dir, path) = save_for_mutation();
+    let cfg_path = find_config_blob(&path);
+    let huge = vec![b'a'; (1024 * 1024 + 16) as usize];
+    std::fs::write(&cfg_path, &huge).unwrap();
+    rewrite_manifest(&path, |m| {
+        m["config"]["size"] = Value::from(huge.len() as u64);
+    });
+    let err = unwrap_err_snapshot(Snapshot::load(&path, OciTag::new("latest").unwrap()));
+    assert_err_contains(err, "exceeds maximum allowed");
+}
+
+#[test]
+fn oci_layout_too_large_rejected() {
+    let (_dir, path) = save_for_mutation();
+    let huge = vec![b'a'; 1024 * 1024 + 16];
+    std::fs::write(path.join("oci-layout"), &huge).unwrap();
+    let err = unwrap_err_snapshot(Snapshot::checked_load(
+        &path,
+        OciTag::new("latest").unwrap(),
+    ));
+    assert_err_contains(err, "exceeds maximum allowed");
+}
+
+#[test]
+fn index_json_too_large_rejected() {
+    let (_dir, path) = save_for_mutation();
+    let huge = vec![b'a'; 1024 * 1024 + 16];
+    std::fs::write(path.join("index.json"), &huge).unwrap();
+    let err = unwrap_err_snapshot(Snapshot::checked_load(
+        &path,
+        OciTag::new("latest").unwrap(),
+    ));
+    assert_err_contains(err, "exceeds maximum allowed");
+}
+
+#[test]
+fn index_json_too_large_on_write_rejected() {
+    let snap = create_snapshot();
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("store");
+    snap.save(&path, &OciTag::new("keep").unwrap()).unwrap();
+
+    // Pad one annotation so the index sits just under the read cap.
+    // Each filler byte adds one byte of output, so the target length is
+    // exact. The file still reads, so save parses it, then the new
+    // "latest" descriptor pushes the index over the cap.
+    let index_path = path.join("index.json");
+    let base = {
+        let idx: Value = serde_json::from_slice(&std::fs::read(&index_path).unwrap()).unwrap();
+        idx["manifests"][0].clone()
+    };
+    let build = |filler_len: usize| -> Vec<u8> {
+        let mut d = base.clone();
+        d["annotations"]["dev.hyperlight.test.filler"] = Value::from("a".repeat(filler_len));
+        let index = serde_json::json!({
+            "schemaVersion": 2,
+            "mediaType": "application/vnd.oci.image.index.v1+json",
+            "manifests": [d],
+        });
+        serde_json::to_vec_pretty(&index).unwrap()
+    };
+    let target = 1024 * 1024 - 50;
+    let filler = target - build(0).len();
+    let bytes = build(filler);
+    assert!(
+        bytes.len() <= 1024 * 1024,
+        "crafted index must pass the read bound"
+    );
+    std::fs::write(&index_path, &bytes).unwrap();
+
+    let err = snap
+        .save(&path, &OciTag::new("latest").unwrap())
+        .unwrap_err();
+    assert_err_contains(err, "index.json");
+
+    // The check runs before the index is written, so the crafted index
+    // stays on disk.
+    assert_eq!(std::fs::read(&index_path).unwrap(), bytes);
+}
+
+#[test]
+fn config_blob_too_large_on_write_rejected() {
+    let guest = simple_guest_as_string().unwrap();
+    let mut u = UninitializedSandbox::new(GuestBinary::FilePath(guest), None).unwrap();
+    // Each host function adds its name and signature to the config
+    // JSON. Long names reach the 1 MiB cap with a modest count.
+    let long = "h".repeat(300);
+    for i in 0..3000 {
+        u.register_host_function(&format!("{long}{i}"), |a: i32, b: i32| Ok(a + b))
+            .unwrap();
+    }
+    let mut sbox = u.evolve().unwrap();
+    let snap = sbox.snapshot().unwrap();
+
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("snap");
+    let err = snap
+        .save(&path, &OciTag::new("latest").unwrap())
+        .unwrap_err();
+    assert_err_contains(err, "config blob");
+}
+
+#[test]
+fn memory_size_too_large_rejected() {
+    let (_dir, path) = save_for_mutation();
+    rewrite_config(&path, |cfg| {
+        // 16 GiB exceeds MAX_MEMORY_SIZE.
+        cfg["memory_size"] = Value::from(16u64 * 1024 * 1024 * 1024);
+    });
+    let err = unwrap_err_snapshot(Snapshot::checked_load(
+        &path,
+        OciTag::new("latest").unwrap(),
+    ));
+    assert_err_contains(err, "memory_size");
+}
+
+#[test]
+fn layout_field_too_large_rejected() {
+    let (_dir, path) = save_for_mutation();
+    rewrite_config(&path, |cfg| {
+        // 64 GiB exceeds MAX_MEMORY_SIZE for an individual region.
+        cfg["layout"]["heap_size"] = Value::from(64u64 * 1024 * 1024 * 1024);
+    });
+    let err = unwrap_err_snapshot(Snapshot::checked_load(
+        &path,
+        OciTag::new("latest").unwrap(),
+    ));
+    assert_err_contains(err, "heap_size");
+}
+
+#[test]
+fn stack_top_gva_zero_rejected() {
+    let (_dir, path) = save_for_mutation();
+    rewrite_config(&path, |cfg| {
+        cfg["stack_top_gva"] = Value::from(0u64);
+    });
+    let err = unwrap_err_snapshot(Snapshot::checked_load(
+        &path,
+        OciTag::new("latest").unwrap(),
+    ));
+    assert_err_contains(err, "stack_top_gva");
+}
+
+#[test]
+fn stack_top_gva_out_of_range_rejected() {
+    let (_dir, path) = save_for_mutation();
+    rewrite_config(&path, |cfg| {
+        cfg["stack_top_gva"] = Value::from(u64::MAX);
+    });
+    let err = unwrap_err_snapshot(Snapshot::checked_load(
+        &path,
+        OciTag::new("latest").unwrap(),
+    ));
+    assert_err_contains(err, "stack_top_gva");
+}
+
+#[test]
+#[cfg(unix)]
+fn symlink_snapshot_blob_rejected() {
+    let (_dir, path) = save_for_mutation();
+    // Replace the snapshot blob with a symlink to its real bytes. A
+    // content-addressed blob must be a regular file, so the loader
+    // refuses to follow the link.
+    let blob = find_snapshot_blob(&path);
+    let real = blob.with_extension("real");
+    std::fs::rename(&blob, &real).unwrap();
+    std::os::unix::fs::symlink(&real, &blob).unwrap();
+    let err = unwrap_err_snapshot(Snapshot::checked_load(
+        &path,
+        OciTag::new("latest").unwrap(),
+    ));
+    assert_err_contains(err, "symbolic link");
+}
+
+#[test]
+#[cfg(unix)]
+fn symlink_config_blob_rejected() {
+    let (_dir, path) = save_for_mutation();
+    // The config blob is read through `read_bounded`, which opens
+    // with `O_NOFOLLOW`. Replacing it with a symlink to its real
+    // bytes makes the open fail.
+    let blob = find_config_blob(&path);
+    let real = blob.with_extension("real");
+    std::fs::rename(&blob, &real).unwrap();
+    std::os::unix::fs::symlink(&real, &blob).unwrap();
+    let err = unwrap_err_snapshot(Snapshot::checked_load(
+        &path,
+        OciTag::new("latest").unwrap(),
+    ));
+    assert_err_contains(err, "symbolic link");
+}
+
+#[test]
+#[cfg(unix)]
+fn save_replaces_symlink_snapshot_blob_with_regular_file() {
+    let snapshot = create_snapshot();
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("snap");
+    snapshot
+        .save(&path, &OciTag::new("latest").unwrap())
+        .unwrap();
+
+    // Replace the snapshot blob with a symlink to its real bytes. A
+    // content-addressed blob must be a regular file, so the writer
+    // must not trust the symlink as an already-present blob.
+    let blob = find_snapshot_blob(&path);
+    let real = blob.with_extension("real");
+    std::fs::rename(&blob, &real).unwrap();
+    std::os::unix::fs::symlink(&real, &blob).unwrap();
+
+    // Re-save. `put_blob_if_absent` sees the path is a symlink, not a
+    // regular file, and rewrites it via an atomic rename.
+    snapshot
+        .save(&path, &OciTag::new("latest").unwrap())
+        .unwrap();
+
+    let meta = std::fs::symlink_metadata(&blob).unwrap();
+    assert!(
+        meta.file_type().is_file() && !meta.file_type().is_symlink(),
+        "expected the snapshot blob to be a regular file after re-save"
+    );
+
+    let loaded = Snapshot::checked_load(&path, OciTag::new("latest").unwrap()).unwrap();
+    let mut sbox =
+        MultiUseSandbox::from_snapshot(Arc::new(loaded), HostFunctions::default(), None).unwrap();
+    let result: String = sbox.call("Echo", "hello\n".to_string()).unwrap();
+    assert_eq!(result, "hello\n");
+}
+
+/// A snapshot descriptor claiming a size different from the blob file is
+/// rejected before mmap.
+#[test]
+fn snapshot_descriptor_size_disagrees_with_file_rejected() {
+    let (_dir, path) = save_for_mutation();
+    rewrite_manifest(&path, |m| {
+        let sz = m["layers"][0]["size"].as_u64().unwrap();
+        m["layers"][0]["size"] = Value::from(sz + 1);
+    });
+    let err = unwrap_err_snapshot(Snapshot::load(&path, OciTag::new("latest").unwrap()));
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("snapshot blob size"),
+        "expected snapshot-blob descriptor disagreement error, got: {msg}"
+    );
+}
+
+// `load` runs every non-digest validator. The unverified
+// path is faster, not more permissive.
+
+// Round-trip data fidelity for fields not exercised by the
+// load-then-call-the-guest tests above.
+
+#[test]
+fn round_trip_preserves_stack_top_gva() {
+    let snap = create_snapshot();
+    let original = snap.stack_top_gva();
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("layout");
+    snap.save(&path, &OciTag::new("latest").unwrap()).unwrap();
+    let loaded = Snapshot::checked_load(&path, OciTag::new("latest").unwrap()).unwrap();
+    assert_eq!(loaded.stack_top_gva(), original);
+}
+
+#[test]
+fn round_trip_preserves_non_default_scratch_size() {
+    use crate::sandbox::SandboxConfiguration;
+    let mut cfg = SandboxConfiguration::default();
+    let custom_scratch: usize = 256 * 1024;
+    cfg.set_scratch_size(custom_scratch);
+    let mut sbox = UninitializedSandbox::new(
+        GuestBinary::FilePath(simple_guest_as_string().unwrap()),
+        Some(cfg),
+    )
+    .unwrap()
+    .evolve()
+    .unwrap();
+    let snap = sbox.snapshot().unwrap();
+    let original = snap.layout().get_scratch_size();
+    assert_eq!(original, custom_scratch);
+
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("layout");
+    snap.save(&path, &OciTag::new("latest").unwrap()).unwrap();
+    let loaded = Snapshot::checked_load(&path, OciTag::new("latest").unwrap()).unwrap();
+    assert_eq!(loaded.layout().get_scratch_size(), custom_scratch);
+}
+
+#[test]
+fn snapshot_config_records_entrypoint_and_sregs() {
+    let snap = create_snapshot();
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("layout");
+    snap.save(&path, &OciTag::new("latest").unwrap()).unwrap();
+    let cfg: Value =
+        serde_json::from_slice(&std::fs::read(find_config_blob(&path)).unwrap()).unwrap();
+    assert!(
+        cfg["entrypoint_addr"].is_u64(),
+        "config must carry entrypoint_addr"
+    );
+    assert!(cfg["sregs"].is_object(), "config must carry sregs");
+}
+
+#[test]
+fn round_trip_preserves_host_function_signatures() {
+    let mut sbox = create_sandbox_with_custom_host_funcs();
+    let snap = sbox.snapshot().unwrap();
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("layout");
+    snap.save(&path, &OciTag::new("latest").unwrap()).unwrap();
+
+    let cfg: Value =
+        serde_json::from_slice(&std::fs::read(find_config_blob(&path)).unwrap()).unwrap();
+    let funcs = cfg["host_functions"].as_array().unwrap();
+    let add = funcs
+        .iter()
+        .find(|f| f["function_name"].as_str().unwrap() == "Add")
+        .expect("Add must be recorded");
+    assert_eq!(
+        add["parameter_types"].as_array().unwrap().len(),
+        2,
+        "Add signature must record two parameters"
+    );
+    // Loading and using the snapshot must accept the same signature.
+    let loaded = Snapshot::checked_load(&path, OciTag::new("latest").unwrap()).unwrap();
+    let _ = MultiUseSandbox::from_snapshot(Arc::new(loaded), host_funcs_with_matching_add(), None)
+        .unwrap();
+}
+
+#[test]
+fn snapshot_with_no_host_functions_round_trips() {
+    let snap = create_snapshot();
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("layout");
+    snap.save(&path, &OciTag::new("latest").unwrap()).unwrap();
+
+    // A config that records no host functions must load. Clearing the
+    // array breaks the config digest, so the load skips verification.
+    rewrite_config(&path, |cfg| {
+        cfg["host_functions"] = Value::Array(Vec::new());
+    });
+    let cfg: Value =
+        serde_json::from_slice(&std::fs::read(find_config_blob(&path)).unwrap()).unwrap();
+    assert!(cfg["host_functions"].as_array().unwrap().is_empty());
+
+    let loaded = Snapshot::load(&path, OciTag::new("latest").unwrap()).unwrap();
+    let _ =
+        MultiUseSandbox::from_snapshot(Arc::new(loaded), HostFunctions::default(), None).unwrap();
+}
+
+// Snapshot lineage and restore semantics. `restore` accepts any
+// snapshot whose memory layout and host-function set match the sandbox.
+// Snapshots within a compatible set are interchangeable.
+
+#[test]
+fn linear_chain_restore_in_order() {
+    let mut sbox = create_test_sandbox();
+    let s0 = sbox.snapshot().unwrap();
+    sbox.call::<i32>("AddToStatic", 10i32).unwrap();
+    let s10 = sbox.snapshot().unwrap();
+    sbox.call::<i32>("AddToStatic", 20i32).unwrap();
+    let s30 = sbox.snapshot().unwrap();
+
+    sbox.restore(s0.clone()).unwrap();
+    assert_eq!(sbox.call::<i32>("GetStatic", ()).unwrap(), 0);
+    sbox.restore(s10.clone()).unwrap();
+    assert_eq!(sbox.call::<i32>("GetStatic", ()).unwrap(), 10);
+    sbox.restore(s30.clone()).unwrap();
+    assert_eq!(sbox.call::<i32>("GetStatic", ()).unwrap(), 30);
+}
+
+#[test]
+fn restore_idempotent() {
+    let mut sbox = create_test_sandbox();
+    sbox.call::<i32>("AddToStatic", 11i32).unwrap();
+    let s = sbox.snapshot().unwrap();
+
+    sbox.call::<i32>("AddToStatic", 22i32).unwrap();
+    sbox.restore(s.clone()).unwrap();
+    assert_eq!(sbox.call::<i32>("GetStatic", ()).unwrap(), 11);
+
+    // No mutation between restores.
+    sbox.restore(s.clone()).unwrap();
+    assert_eq!(sbox.call::<i32>("GetStatic", ()).unwrap(), 11);
+
+    // Mutation after the second restore must take effect.
+    sbox.call::<i32>("AddToStatic", 1i32).unwrap();
+    assert_eq!(sbox.call::<i32>("GetStatic", ()).unwrap(), 12);
+}
+
+#[test]
+fn separate_oci_loads_are_mutually_restore_compatible() {
+    let mut seed = create_test_sandbox();
+    let snap = seed.snapshot().unwrap();
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("layout");
+    snap.save(&path, &OciTag::new("v1").unwrap()).unwrap();
+
+    let s_x = Arc::new(Snapshot::checked_load(&path, OciTag::new("v1").unwrap()).unwrap());
+    let s_y = Arc::new(Snapshot::checked_load(&path, OciTag::new("v1").unwrap()).unwrap());
+
+    let mut sbox_x =
+        MultiUseSandbox::from_snapshot(s_x.clone(), HostFunctions::default(), None).unwrap();
+    sbox_x.restore(s_y.clone()).unwrap();
+    assert_eq!(sbox_x.call::<i32>("GetStatic", ()).unwrap(), 0);
+
+    sbox_x.restore(s_x.clone()).unwrap();
+    assert_eq!(sbox_x.call::<i32>("GetStatic", ()).unwrap(), 0);
+}
+
+/// Snapshots taken before and after a save+load round-trip remain
+/// mutually restore-compatible.
+#[test]
+fn oci_loaded_snapshot_supports_full_lifecycle() {
+    let mut seed = create_test_sandbox();
+    let snap = seed.snapshot().unwrap();
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("layout");
+    snap.save(&path, &OciTag::new("v1").unwrap()).unwrap();
+
+    let loaded = Arc::new(Snapshot::checked_load(&path, OciTag::new("v1").unwrap()).unwrap());
+    let mut sbox =
+        MultiUseSandbox::from_snapshot(loaded.clone(), HostFunctions::default(), None).unwrap();
+
+    sbox.call::<i32>("AddToStatic", 1i32).unwrap();
+    let s1 = sbox.snapshot().unwrap();
+    sbox.call::<i32>("AddToStatic", 2i32).unwrap();
+    let s3 = sbox.snapshot().unwrap();
+    sbox.call::<i32>("AddToStatic", 4i32).unwrap();
+
+    sbox.restore(s1.clone()).unwrap();
+    assert_eq!(sbox.call::<i32>("GetStatic", ()).unwrap(), 1);
+    sbox.restore(s3.clone()).unwrap();
+    assert_eq!(sbox.call::<i32>("GetStatic", ()).unwrap(), 3);
+    sbox.restore(loaded.clone()).unwrap();
+    assert_eq!(sbox.call::<i32>("GetStatic", ()).unwrap(), 0);
+
+    let s_post = sbox.snapshot().unwrap();
+    sbox.call::<i32>("AddToStatic", 50i32).unwrap();
+    sbox.restore(s_post.clone()).unwrap();
+    assert_eq!(sbox.call::<i32>("GetStatic", ()).unwrap(), 0);
+    sbox.restore(s3.clone()).unwrap();
+    assert_eq!(sbox.call::<i32>("GetStatic", ()).unwrap(), 3);
+}
+
+// Typed references: `OciTag`, `OciDigest`, `OciReference`.
+
+/// The digest returned by `save` addresses the tag's manifest and
+/// loads the same snapshot.
+#[test]
+fn save_returns_manifest_digest_that_loads() {
+    let mut sbox = create_test_sandbox();
+    sbox.call::<String>("Echo", "x".to_string()).unwrap();
+    let snap = sbox.snapshot().unwrap();
+    let expected_gen = snap.snapshot_generation();
+
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("layout");
+    let digest = snap.save(&path, &OciTag::new("latest").unwrap()).unwrap();
+
+    let loaded = Snapshot::checked_load(&path, digest).unwrap();
+    assert_eq!(loaded.snapshot_generation(), expected_gen);
+}
+
+/// The returned digest is the sha256 of the manifest blob, matching the
+/// digest recorded for that tag's manifest descriptor in `index.json`.
+#[test]
+fn save_returns_digest_matching_index_manifest_descriptor() {
+    let snap = create_snapshot();
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("layout");
+    let digest = snap.save(&path, &OciTag::new("latest").unwrap()).unwrap();
+
+    let index: Value =
+        serde_json::from_slice(&std::fs::read(path.join("index.json")).unwrap()).unwrap();
+    let descriptor_digest = index["manifests"][0]["digest"].as_str().unwrap();
+    assert_eq!(digest.as_str(), descriptor_digest);
+
+    // The digest also matches the sha256 of the manifest blob bytes.
+    let manifest_hex = descriptor_digest.strip_prefix("sha256:").unwrap();
+    let manifest_bytes =
+        std::fs::read(path.join("blobs").join("sha256").join(manifest_hex)).unwrap();
+    assert_eq!(
+        digest.as_str(),
+        format!("sha256:{}", sha256_hex(&manifest_bytes))
+    );
+}
+
+/// Loading by digest selects the matching manifest regardless of how
+/// many tags share the layout.
+#[test]
+fn checked_load_by_digest_selects_correct_manifest_among_tags() {
+    let mut sbox = create_test_sandbox();
+    sbox.call::<String>("Echo", "a".to_string()).unwrap();
+    let snap_a = sbox.snapshot().unwrap();
+    let gen_a = snap_a.snapshot_generation();
+    sbox.call::<String>("Echo", "b".to_string()).unwrap();
+    let snap_b = sbox.snapshot().unwrap();
+    let gen_b = snap_b.snapshot_generation();
+
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("layout");
+    let digest_a = snap_a.save(&path, &OciTag::new("a").unwrap()).unwrap();
+    let digest_b = snap_b.save(&path, &OciTag::new("b").unwrap()).unwrap();
+    assert_ne!(digest_a.as_str(), digest_b.as_str());
+
+    let loaded_a = Snapshot::checked_load(&path, digest_a).unwrap();
+    let loaded_b = Snapshot::checked_load(&path, digest_b).unwrap();
+    assert_eq!(loaded_a.snapshot_generation(), gen_a);
+    assert_eq!(loaded_b.snapshot_generation(), gen_b);
+}
+
+#[test]
+fn checked_load_accepts_reference_value() {
+    let snap = create_snapshot();
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("layout");
+    snap.save(&path, &OciTag::new("v1").unwrap()).unwrap();
+
+    let reference: OciReference = "v1".parse().unwrap();
+    let _ = Snapshot::checked_load(&path, reference).unwrap();
+}
+
+#[test]
+fn unknown_digest_reports_missing_manifest() {
+    let snap = create_snapshot();
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("layout");
+    snap.save(&path, &OciTag::new("latest").unwrap()).unwrap();
+
+    let absent: OciDigest = format!("sha256:{}", "0".repeat(64)).parse().unwrap();
+    let err = unwrap_err_snapshot(Snapshot::checked_load(&path, absent));
+    assert_err_contains(err, "no manifest with digest");
+}
+
+#[test]
+fn oci_digest_parsing_accepts_canonical_sha256() {
+    let canonical = format!("sha256:{}", "a".repeat(64));
+    let digest: OciDigest = canonical.parse().unwrap();
+    assert_eq!(digest.as_str(), canonical);
+}
+
+#[test]
+fn oci_digest_parsing_rejects_malformed_values() {
+    // Bare hex without the algorithm prefix.
+    assert!("a".repeat(64).parse::<OciDigest>().is_err());
+    // Uppercase hex is outside the canonical sha256 grammar.
+    assert!(
+        format!("sha256:{}", "A".repeat(64))
+            .parse::<OciDigest>()
+            .is_err()
+    );
+    // Wrong digest length.
+    assert!("sha256:deadbeef".parse::<OciDigest>().is_err());
+    // Unsupported algorithm.
+    assert!(
+        format!("sha512:{}", "a".repeat(128))
+            .parse::<OciDigest>()
+            .is_err()
+    );
+}
+
+#[test]
+fn oci_reference_parsing_disambiguates_on_colon() {
+    let tag_ref: OciReference = "latest".parse().unwrap();
+    assert!(matches!(tag_ref, OciReference::Tag(_)));
+
+    let digest_ref: OciReference = format!("sha256:{}", "a".repeat(64)).parse().unwrap();
+    assert!(matches!(digest_ref, OciReference::Digest(_)));
+}
+
+/// Adding a new tag to a layout that a live `Snapshot` is already
+/// mapped from must not disturb that mapping. `save` writes only new
+/// content-addressed blobs and swaps `index.json` atomically, so the
+/// blob the mapping holds open stays byte-for-byte identical.
+#[test]
+fn save_new_tag_into_loaded_layout_preserves_live_mapping() {
+    let snap_a = create_snapshot();
+
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("store");
+    snap_a.save(&path, &OciTag::new("a").unwrap()).unwrap();
+
+    // Load tag "a" and keep the mapping live.
+    let loaded_a = Arc::new(Snapshot::checked_load(&path, OciTag::new("a").unwrap()).unwrap());
+
+    // Record the full mapped image and every on-disk blob before the
+    // second save, so any byte change is caught.
+    let mapping_before = loaded_a.memory.as_slice().to_vec();
+    let blobs_dir = path.join("blobs").join("sha256");
+    let blobs_before = read_blob_dir(&blobs_dir);
+
+    // While the mapping is live, write a different snapshot under a
+    // new tag into the same layout.
+    let mut other = create_test_sandbox();
+    other.call::<i32>("AddToStatic", 42i32).unwrap();
+    let snap_b = other.snapshot().unwrap();
+    snap_b.save(&path, &OciTag::new("b").unwrap()).unwrap();
+
+    // The live mapping is unchanged, byte for byte.
+    assert_eq!(
+        loaded_a.memory.as_slice(),
+        mapping_before.as_slice(),
+        "live snapshot mapping changed after a new tag was written"
+    );
+
+    // The blob the mapping holds open is still present and unchanged,
+    // and the second save only adds blobs.
+    let blobs_after = read_blob_dir(&blobs_dir);
+    for (name, bytes) in &blobs_before {
+        assert_eq!(
+            blobs_after.get(name),
+            Some(bytes),
+            "existing blob {name:?} was modified by the second save"
+        );
+    }
+
+    // A sandbox built on the live mapping still restores cleanly.
+    let mut live =
+        MultiUseSandbox::from_snapshot(loaded_a.clone(), HostFunctions::default(), None).unwrap();
+    live.call::<i32>("AddToStatic", 7i32).unwrap();
+    assert_eq!(live.call::<i32>("GetStatic", ()).unwrap(), 7);
+    live.restore(loaded_a).unwrap();
+    assert_eq!(live.call::<i32>("GetStatic", ()).unwrap(), 0);
+
+    // Both tags resolve and load independently.
+    let _ = Snapshot::checked_load(&path, OciTag::new("a").unwrap()).unwrap();
+    let _ = Snapshot::checked_load(&path, OciTag::new("b").unwrap()).unwrap();
+}
+
+/// Read every file in a `blobs/sha256` directory into a name-keyed map
+/// for byte-for-byte comparison.
+fn read_blob_dir(
+    blobs_dir: &std::path::Path,
+) -> std::collections::BTreeMap<std::ffi::OsString, Vec<u8>> {
+    std::fs::read_dir(blobs_dir)
+        .unwrap()
+        .map(|e| {
+            let e = e.unwrap();
+            (e.file_name(), std::fs::read(e.path()).unwrap())
+        })
+        .collect()
+}

--- a/src/hyperlight_host/src/sandbox/snapshot/mod.rs
+++ b/src/hyperlight_host/src/sandbox/snapshot/mod.rs
@@ -14,8 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+mod file;
+mod file_tests;
+
 use std::collections::HashMap;
 
+pub use file::reference::{OciDigest, OciReference, OciTag};
 use hyperlight_common::flatbuffer_wrappers::host_function_details::HostFunctionDetails;
 use hyperlight_common::layout::{scratch_base_gpa, scratch_base_gva};
 use hyperlight_common::vmem;


### PR DESCRIPTION
Adds save/load of `Snapshot` to disk as an OCI Image Layout. Public API:

* `Snapshot::save(path, tag)` (returns the manifest's sha256 digest)
* `Snapshot::checked_load(path, reference)` where `reference` is a tag or a sha256 digest (verifies sha256 on every blob)
* `Snapshot::load(path, reference)` (skips the sha256 digest checks for speed)

## Known limitations

* Core dumps from a snapshot-loaded sandbox lack `binary_path` and AT_ENTRY for
  `Call` snapshots. `mem_profile` lacks accurate traces. Fixing either requires
  extending the on-disk format.
* `max_guest_log_level` is not plumbed through snapshot load. It is also
  intrinsically ineffective for `Call` snapshots and should be addressed
  separately.
* The backing OCI directory must not be modified, truncated, renamed over, or
  deleted for the lifetime of a loaded `Snapshot` or any `MultiUseSandbox`
  built from it. On Linux this is unenforced. On Windows the OS refuses the
  operation with `ERROR_USER_MAPPED_FILE` (1224). Firecracker has the same
  constraint:
  > The memory file (pointed by `backend_path` when using `File` backend type,
  > or pointed by `mem_file_path`) must be considered immutable from
  > Firecracker and host point of view. It backs the guest OS memory for read
  > access through the page cache. External modification to this file corrupts
  > the guest memory and leads to undefined behavior.

  [firecracker docs](https://github.com/firecracker-microvm/firecracker/blob/main/docs/snapshotting/snapshot-support.md#loading-snapshots
)

## Future work

Typed error variants. TSC and rand seeding capture. Fuzz target for `checked_load`.
CoW overlay layers. Cross-hypervisor portability via sregs normalisation. Huge
page support (`MAP_HUGETLB`)
