### PR TITLE
Fix broken rust cache

### DIFF
--- a/.github/workflows/PrimeCaches.yml
+++ b/.github/workflows/PrimeCaches.yml
@@ -1,0 +1,103 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+
+# Builds on main to populate the GitHub Actions cache for all Swatinem/rust-cache
+# shared-keys used by PR workflows. Caches saved on `refs/heads/main` are
+# restorable from every PR via the base-branch fallback. PR workflows are
+# configured with `save-if: github.ref == 'refs/heads/main'`, so they only ever
+# read from this cache.
+#
+# No tests are run here. The goal is just to populate dependency build artifacts
+# so that PR jobs start warm.
+
+name: Prime Caches
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: full
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  # Populate v0-rust-guests-{debug,release}-Linux-x64 caches.
+  guests:
+    strategy:
+      fail-fast: false
+      matrix:
+        config: [debug, release]
+    uses: ./.github/workflows/dep_build_guests.yml
+    secrets: inherit
+    with:
+      config: ${{ matrix.config }}
+
+  # Populate v0-rust-code-checks-{linux,windows} caches.
+  code-checks:
+    uses: ./.github/workflows/dep_code_checks.yml
+    secrets: inherit
+
+  # Populate v0-rust-{Linux,Windows}-{hypervisor}-{debug,release} caches used
+  # by dep_build_test.yml. Linux is primed once per hypervisor because the kvm
+  # pools run Ubuntu and the mshv3 pools run Azure Linux 3, and we want each
+  # distro to restore a cache produced under its own libc. Only the host
+  # dependency graph is built here, no tests are run.
+  host:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - hypervisor: kvm
+            config: debug
+          - hypervisor: kvm
+            config: release
+          - hypervisor: mshv3
+            config: debug
+          - hypervisor: mshv3
+            config: release
+          - hypervisor: hyperv-ws2025
+            config: debug
+          - hypervisor: hyperv-ws2025
+            config: release
+    timeout-minutes: 30
+    runs-on: ${{ fromJson(
+        format('["self-hosted", "{0}", "X64", "1ES.Pool=hld-{1}-amd", "JobId=prime-cache-{2}-{3}-{4}-{5}-{6}"]',
+          matrix.hypervisor == 'hyperv-ws2025' && 'Windows' || 'Linux',
+          matrix.hypervisor == 'hyperv-ws2025' && 'win2025' || matrix.hypervisor == 'mshv3' && 'azlinux3-mshv' || matrix.hypervisor,
+          matrix.hypervisor,
+          matrix.config,
+          github.run_id,
+          github.run_number,
+          github.run_attempt)) }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: hyperlight-dev/ci-setup-workflow@v1.9.0
+        with:
+          rust-toolchain: "1.89"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Fix cargo home permissions
+        if: runner.os == 'Linux'
+        run: |
+          sudo chown -R $(id -u):$(id -g) /opt/cargo || true
+
+      - name: Rust cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "${{ runner.os }}-${{ matrix.hypervisor }}-${{ matrix.config }}"
+          cache-on-failure: "true"
+          # Only save on main as caches are not shared across branches.
+          # https://docs.github.com/en/actions/reference/workflows-and-actions/dependency-caching#restrictions-for-accessing-a-cache
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+
+      - name: Build host
+        run: just build ${{ matrix.config }}

--- a/.github/workflows/dep_benchmarks.yml
+++ b/.github/workflows/dep_benchmarks.yml
@@ -97,7 +97,7 @@ jobs:
       - name: Rust cache
         uses: Swatinem/rust-cache@v2
         with:
-          shared-key: "${{ runner.os }}-release"
+          shared-key: "${{ runner.os }}-${{ inputs.hypervisor }}-release"
           save-if: "false"
 
       - name: Download Rust guests

--- a/.github/workflows/dep_build_guests.yml
+++ b/.github/workflows/dep_build_guests.yml
@@ -61,6 +61,9 @@ jobs:
         with:
           shared-key: "guests-${{ inputs.config }}"
           cache-on-failure: "true"
+          # Only save on main as caches are not shared across branches.
+          # https://docs.github.com/en/actions/reference/workflows-and-actions/dependency-caching#restrictions-for-accessing-a-cache
+          save-if: ${{ github.ref == 'refs/heads/main' }}
           workspaces: |
             . -> target
             src/tests/rust_guests/simpleguest -> target

--- a/.github/workflows/dep_build_test.yml
+++ b/.github/workflows/dep_build_test.yml
@@ -64,8 +64,11 @@ jobs:
       - name: Rust cache
         uses: Swatinem/rust-cache@v2
         with:
-          shared-key: "${{ runner.os }}-${{ inputs.config }}"
+          shared-key: "${{ runner.os }}-${{ inputs.hypervisor }}-${{ inputs.config }}"
           cache-on-failure: "true"
+          # Only save on main as caches are not shared across branches.
+          # https://docs.github.com/en/actions/reference/workflows-and-actions/dependency-caching#restrictions-for-accessing-a-cache
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Download Rust guests
         uses: actions/download-artifact@v8

--- a/.github/workflows/dep_code_checks.yml
+++ b/.github/workflows/dep_code_checks.yml
@@ -57,6 +57,9 @@ jobs:
         with:
           shared-key: "code-checks-linux"
           cache-on-failure: "true"
+          # Only save on main as caches are not shared across branches.
+          # https://docs.github.com/en/actions/reference/workflows-and-actions/dependency-caching#restrictions-for-accessing-a-cache
+          save-if: ${{ github.ref == 'refs/heads/main' }}
           workspaces: |
             . -> target
             src/tests/rust_guests/simpleguest -> target
@@ -128,6 +131,9 @@ jobs:
         with:
           shared-key: "code-checks-windows"
           cache-on-failure: "true"
+          # Only save on main as caches are not shared across branches.
+          # https://docs.github.com/en/actions/reference/workflows-and-actions/dependency-caching#restrictions-for-accessing-a-cache
+          save-if: ${{ github.ref == 'refs/heads/main' }}
           workspaces: |
             . -> target
             src/tests/rust_guests/simpleguest -> target

--- a/.github/workflows/dep_run_examples.yml
+++ b/.github/workflows/dep_run_examples.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Rust cache
         uses: Swatinem/rust-cache@v2
         with:
-          shared-key: "${{ runner.os }}-${{ inputs.config }}"
+          shared-key: "${{ runner.os }}-${{ inputs.hypervisor }}-${{ inputs.config }}"
           save-if: "false"
 
       - name: Download Rust guests


### PR DESCRIPTION
Our existing caching is broken because the cache is written from pr branches, but cannot be consumed by other branches 
https://docs.github.com/en/actions/reference/workflows-and-actions/dependency-caching#restrictions-for-accessing-a-cache.

This PR adds a workflow on default branch (main) to prime the caches (to make it available to all branches), and makes PRs branches read-only for the caches. Also splits cache on kvm (ubuntu) and mshv (azl3) since I believe this is necessary. 