### PR TITLE
Add script and run update for pinning action versions

### DIFF
--- a/.github/workflows/CargoAudit.yml
+++ b/.github/workflows/CargoAudit.yml
@@ -13,14 +13,14 @@ jobs:
   audit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       # We are not using the common workflow here because it installs a bunch of tools we don't need.
       # TODO: Once the runner image is updated to include the necessary tools (without downloading), we can switch to the common workflow.
-      - uses: dtolnay/rust-toolchain@master
+      - uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6  # v1.16.1
         with:
           toolchain: "1.89"
 
-      - uses: rustsec/audit-check@v2.0.0
+      - uses: rustsec/audit-check@69366f33c96575abad1ee0dba8212993eecbe998  # v2.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CargoPublish.yml
+++ b/.github/workflows/CargoPublish.yml
@@ -27,13 +27,13 @@ jobs:
     if: ${{ startsWith(github.ref, 'refs/heads/release/v') || inputs.dry_run }}
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
           fetch-tags: true
           submodules: true
 
-      - uses: hyperlight-dev/ci-setup-workflow@v1.9.0
+      - uses: hyperlight-dev/ci-setup-workflow@f6bd9cc86d0737976d2128c8b8ced8edc017cbb4  # v1.9.0
         with:
           rust-toolchain: "1.89"
 
@@ -81,7 +81,7 @@ jobs:
           needs_publish hyperlight-guest-tracing
 
       - name: Authenticate with crates.io
-        uses: rust-lang/crates-io-auth-action@v1
+        uses: rust-lang/crates-io-auth-action@bbd81622f20ce9e2dd9622e3218b975523e45bbe  # v1.0.4
         id: crates-io-auth
 
       - name: Publish hyperlight-libc

--- a/.github/workflows/Coverage.yml
+++ b/.github/workflows/Coverage.yml
@@ -35,9 +35,9 @@ jobs:
           matrix.hypervisor,
           matrix.cpu)) }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
-      - uses: hyperlight-dev/ci-setup-workflow@v1.9.0
+      - uses: hyperlight-dev/ci-setup-workflow@f6bd9cc86d0737976d2128c8b8ced8edc017cbb4  # v1.9.0
         with:
           rust-toolchain: "1.89"
         env:
@@ -48,7 +48,7 @@ jobs:
           sudo chown -R $(id -u):$(id -g) /opt/cargo || true
 
       - name: Rust cache
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
         with:
           shared-key: "${{ runner.os }}-debug"
           cache-on-failure: "true"
@@ -79,14 +79,14 @@ jobs:
           echo '> For a detailed per-file breakdown, download the **HTML coverage report** from the Artifacts section below.' >> $GITHUB_STEP_SUMMARY
 
       - name: Upload HTML coverage report
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: coverage-html-${{ matrix.hypervisor }}-${{ matrix.cpu }}
           path: target/coverage/html/
           if-no-files-found: error
 
       - name: Upload LCOV coverage report
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: coverage-lcov-${{ matrix.hypervisor }}-${{ matrix.cpu }}
           path: target/coverage/lcov.info
@@ -100,7 +100,7 @@ jobs:
       issues: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Notify Coverage Failure
         run: ./dev/notify-ci-failure.sh --title="Weekly Coverage Failure - ${{ github.run_number }}" --labels="area/ci-periodics,area/testing,lifecycle/needs-review"

--- a/.github/workflows/CreateDevcontainerImage.yml
+++ b/.github/workflows/CreateDevcontainerImage.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Read Rust toolchain version from ${{ env.RUST_TOOLCHAIN_FILE }}
         id: toolchain
@@ -42,7 +42,7 @@ jobs:
         
       # Uses the `docker/login-action` action to log in to the Container registry registry using the account and password that will publish the packages. Once published, the packages are scoped to the account defined here.
       - name: Log in to the Container registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee  # v4.2.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -50,13 +50,13 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9  # v6.1.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
       - name: Build and push Docker image
         id: push
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf  # v7.2.0
         with:
           context: ./.devcontainer
           push: true

--- a/.github/workflows/CreateRelease.yml
+++ b/.github/workflows/CreateRelease.yml
@@ -28,9 +28,9 @@ jobs:
     needs: [release-blocker-check]
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
-      - uses: hyperlight-dev/ci-setup-workflow@v1.9.0
+      - uses: hyperlight-dev/ci-setup-workflow@f6bd9cc86d0737976d2128c8b8ced8edc017cbb4  # v1.9.0
         with:
           rust-toolchain: "1.89"
         env:
@@ -49,9 +49,9 @@ jobs:
     needs: [release-blocker-check]
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
-      - uses: hyperlight-dev/ci-setup-workflow@v1.9.0
+      - uses: hyperlight-dev/ci-setup-workflow@f6bd9cc86d0737976d2128c8b8ced8edc017cbb4  # v1.9.0
         with:
           rust-toolchain: "1.89"
         env:
@@ -115,13 +115,13 @@ jobs:
         if: ${{ contains(github.ref, 'refs/heads/release/') }}
         run: echo "CONFIG=release" >> $GITHUB_ENV
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
           fetch-tags: true
           submodules: true
 
-      - uses: hyperlight-dev/ci-setup-workflow@v1.9.0
+      - uses: hyperlight-dev/ci-setup-workflow@f6bd9cc86d0737976d2128c8b8ced8edc017cbb4  # v1.9.0
         with:
           rust-toolchain: "1.89"
         env:
@@ -146,7 +146,7 @@ jobs:
           just tar-static-lib
 
       - name: Download all benchmarks
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           pattern: benchmarks_*
 

--- a/.github/workflows/CreateReleaseBranch.yml
+++ b/.github/workflows/CreateReleaseBranch.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Create Release Branch
         run: |

--- a/.github/workflows/DailyBenchmarks.yml
+++ b/.github/workflows/DailyBenchmarks.yml
@@ -63,7 +63,7 @@ jobs:
       issues: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Notify Benchmark Failure
         run: ./dev/notify-ci-failure.sh --title="Benchmark Failure - ${{ github.run_number }}" --labels="area/benchmarks,area/testing,lifecycle/needs-review,release-blocker"

--- a/.github/workflows/Fuzzing.yml
+++ b/.github/workflows/Fuzzing.yml
@@ -32,7 +32,7 @@ jobs:
       issues: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Notify Fuzzing Failure
         run: ./dev/notify-ci-failure.sh --labels="area/fuzzing,area/testing,lifecycle/needs-review,release-blocker"

--- a/.github/workflows/IssueLabelChecker.yml
+++ b/.github/workflows/IssueLabelChecker.yml
@@ -11,7 +11,7 @@ jobs:
   labeler:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
     - name: Check and Add label
       run: |
         # The cryptic head -c -1 is because otherwise gh always terminates output with a newline

--- a/.github/workflows/PRLabelChecker.yml
+++ b/.github/workflows/PRLabelChecker.yml
@@ -11,7 +11,7 @@ jobs:
   check-labels:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Ensure exactly one "kind/*" label is applied
         run: |
           # Count the number of "kind/*" labels directly from the PR labels

--- a/.github/workflows/PrimeCaches.yml
+++ b/.github/workflows/PrimeCaches.yml
@@ -77,9 +77,9 @@ jobs:
           github.run_number,
           github.run_attempt)) }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
-      - uses: hyperlight-dev/ci-setup-workflow@v1.9.0
+      - uses: hyperlight-dev/ci-setup-workflow@f6bd9cc86d0737976d2128c8b8ced8edc017cbb4  # v1.9.0
         with:
           rust-toolchain: "1.89"
         env:
@@ -91,7 +91,7 @@ jobs:
           sudo chown -R $(id -u):$(id -g) /opt/cargo || true
 
       - name: Rust cache
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
         with:
           shared-key: "${{ runner.os }}-${{ matrix.hypervisor }}-${{ matrix.config }}"
           cache-on-failure: "true"

--- a/.github/workflows/ReleaseBlockerCheck.yml
+++ b/.github/workflows/ReleaseBlockerCheck.yml
@@ -23,7 +23,7 @@ jobs:
   check-blockers:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       
       - name: Check for Release Blocking Issues
         run: |

--- a/.github/workflows/ReleaseBlockerLabelCleanUp.yml
+++ b/.github/workflows/ReleaseBlockerLabelCleanUp.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Remove release-blocker label from closed issue
         run: |
           ISSUE_NUMBER=${{ github.event.issue.number }}

--- a/.github/workflows/RustNightly.yml
+++ b/.github/workflows/RustNightly.yml
@@ -42,9 +42,9 @@ jobs:
     env:
       TARGET_TRIPLE: x86_64-unknown-linux-musl
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
-      - uses: hyperlight-dev/ci-setup-workflow@v1.9.0
+      - uses: hyperlight-dev/ci-setup-workflow@f6bd9cc86d0737976d2128c8b8ced8edc017cbb4  # v1.9.0
         with:
           rust-toolchain: "1.89"
         env:
@@ -58,14 +58,14 @@ jobs:
       # rust-cache cleans "anything not a dependency" from target dirs, removing the sysroot.
       # We cache sysroot separately to avoid rebuilding it (~10s) on every run.
       - name: Sysroot cache
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         with:
           path: |
             src/tests/rust_guests/target/sysroot
           key: sysroot-linux-${{ matrix.config }}-${{ hashFiles('rust-toolchain.toml') }}
 
       - name: Rust cache
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
         with:
           shared-key: "nightly-${{ matrix.config }}"
           cache-on-failure: "true"
@@ -134,7 +134,7 @@ jobs:
       issues: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Notify Nightly Failure
         run: ./dev/notify-ci-failure.sh --title="Nightly musl Failure - ${{ github.run_number }}" --labels="area/ci-periodics,area/testing,lifecycle/needs-review,release-blocker"

--- a/.github/workflows/ValidatePullRequest.yml
+++ b/.github/workflows/ValidatePullRequest.yml
@@ -23,7 +23,7 @@ jobs:
     outputs:
       docs-only: ${{ steps.docs-only.outputs.result }}
     steps:
-      - uses: dorny/paths-filter@v4
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d  # v4.0.1
         id: changes
         with:
           filters: |
@@ -32,7 +32,7 @@ jobs:
               - '**/*.txt'
             all:
               - '**/*'
-      - uses: actions/github-script@v9
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
         id: docs-only
         with:
           script: |
@@ -144,15 +144,15 @@ jobs:
     name: spell check with typos
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
     - name: Spell Check Repo
-      uses: crate-ci/typos@v1.47.2
+      uses: crate-ci/typos@3e8e1dbf18c56a9ed625484ca941497c73e7da2c  # v1.47.2
 
   license-headers:
     name: check license headers
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
     - name: Check License Headers
       run: ./dev/check-license-headers.sh
 

--- a/.github/workflows/auto-merge-dependabot.yml
+++ b/.github/workflows/auto-merge-dependabot.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
 
       # Gets the GitHub App token
-      - uses: actions/create-github-app-token@v3
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
         id: get-app-token
         with:
           # required
@@ -33,7 +33,7 @@ jobs:
           permission-contents: write
 
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           token: ${{ steps.get-app-token.outputs.token }}
           persist-credentials: false

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -19,15 +19,15 @@ jobs:
     # If you do not check out your code, Copilot will do this for you.
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       # For rust-fmt 
       - name: Set up nightly rust 
-        uses: dtolnay/rust-toolchain@nightly
+        uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6  # v1.16.1
         with:
           components: rustfmt
 
-      - uses: hyperlight-dev/ci-setup-workflow@v1.9.0
+      - uses: hyperlight-dev/ci-setup-workflow@f6bd9cc86d0737976d2128c8b8ced8edc017cbb4  # v1.9.0
         with:
           rust-toolchain: "1.89" 
         env:

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -25,7 +25,9 @@ jobs:
       - name: Set up nightly rust 
         uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6  # v1.16.1
         with:
+          toolchain: nightly
           components: rustfmt
+          
 
       - uses: hyperlight-dev/ci-setup-workflow@f6bd9cc86d0737976d2128c8b8ced8edc017cbb4  # v1.9.0
         with:

--- a/.github/workflows/dep_benchmarks.yml
+++ b/.github/workflows/dep_benchmarks.yml
@@ -81,9 +81,9 @@ jobs:
           github.run_number,
           github.run_attempt)) }} 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
-      - uses: hyperlight-dev/ci-setup-workflow@v1.9.0
+      - uses: hyperlight-dev/ci-setup-workflow@f6bd9cc86d0737976d2128c8b8ced8edc017cbb4  # v1.9.0
         with:
           rust-toolchain: "1.89"
         env:
@@ -95,19 +95,19 @@ jobs:
           sudo chown -R $(id -u):$(id -g) /opt/cargo || true
 
       - name: Rust cache
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
         with:
           shared-key: "${{ runner.os }}-${{ inputs.hypervisor }}-release"
           save-if: "false"
 
       - name: Download Rust guests
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           name: rust-guests-release
           path: src/tests/rust_guests/bin/release/
 
       - name: Download C guests
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           name: c-guests-release
           path: src/tests/c_guests/bin/release/
@@ -117,7 +117,7 @@ jobs:
 
       - name: Download baseline from previous run
         if: ${{ inputs.baseline_run_id != '' }}
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           name: benchmarks_${{ runner.os }}_${{ inputs.hypervisor }}_${{ inputs.cpu }}
           path: ./target/criterion/
@@ -135,7 +135,7 @@ jobs:
       - name: Run benchmarks
         run: just bench-ci main
 
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: benchmarks_${{ runner.os }}_${{ inputs.hypervisor }}_${{ inputs.cpu }}
           path: ./target/criterion/

--- a/.github/workflows/dep_build_guests.yml
+++ b/.github/workflows/dep_build_guests.yml
@@ -31,9 +31,9 @@ jobs:
     timeout-minutes: 15
     runs-on: [self-hosted, Linux, X64, "1ES.Pool=hld-kvm-amd", "JobId=build-guests-${{ inputs.config }}-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}"]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
-      - uses: hyperlight-dev/ci-setup-workflow@v1.9.0
+      - uses: hyperlight-dev/ci-setup-workflow@f6bd9cc86d0737976d2128c8b8ced8edc017cbb4  # v1.9.0
         with:
           rust-toolchain: "1.89"
         env:
@@ -48,14 +48,14 @@ jobs:
       # rust-cache cleans "anything not a dependency" from target dirs, removing the sysroot.
       # We cache sysroot separately to avoid rebuilding it (~10s) on every run.
       - name: Sysroot cache
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         with:
           path: |
             src/tests/rust_guests/target/sysroot
           key: sysroot-linux-${{ inputs.config }}-${{ hashFiles('rust-toolchain.toml') }}
 
       - name: Rust cache
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
         with:
           shared-key: "guests-${{ inputs.config }}"
           cache-on-failure: "true"
@@ -80,7 +80,7 @@ jobs:
           just move-c-guests ${{ inputs.config }}
 
       - name: Upload Rust guests
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: rust-guests-${{ inputs.config }}
           path: |
@@ -89,7 +89,7 @@ jobs:
           if-no-files-found: error
 
       - name: Upload C guests
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: c-guests-${{ inputs.config }}
           path: src/tests/c_guests/bin/${{ inputs.config }}/
@@ -98,7 +98,7 @@ jobs:
 
       - name: Upload interface.wasm
         if: inputs.config == 'debug'
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: interface-wasm
           path: src/tests/rust_guests/witguest/interface.wasm
@@ -107,7 +107,7 @@ jobs:
 
       - name: Upload twoworlds.wasm
         if: inputs.config == 'debug'
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: twoworlds-wasm
           path: src/tests/rust_guests/witguest/twoworlds.wasm

--- a/.github/workflows/dep_build_test.yml
+++ b/.github/workflows/dep_build_test.yml
@@ -48,9 +48,9 @@ jobs:
           github.run_number,
           github.run_attempt)) }} 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
-      - uses: hyperlight-dev/ci-setup-workflow@v1.9.0
+      - uses: hyperlight-dev/ci-setup-workflow@f6bd9cc86d0737976d2128c8b8ced8edc017cbb4  # v1.9.0
         with:
           rust-toolchain: "1.89"
         env:
@@ -62,7 +62,7 @@ jobs:
           sudo chown -R $(id -u):$(id -g) /opt/cargo || true
 
       - name: Rust cache
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
         with:
           shared-key: "${{ runner.os }}-${{ inputs.hypervisor }}-${{ inputs.config }}"
           cache-on-failure: "true"
@@ -71,25 +71,25 @@ jobs:
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Download Rust guests
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           name: rust-guests-${{ inputs.config }}
           path: src/tests/rust_guests/bin/${{ inputs.config }}/
 
       - name: Download C guests
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           name: c-guests-${{ inputs.config }}
           path: src/tests/c_guests/bin/${{ inputs.config }}/
 
       - name: Download interface.wasm
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           name: interface-wasm
           path: src/tests/rust_guests/witguest/
 
       - name: Download twoworlds.wasm
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           name: twoworlds-wasm
           path: src/tests/rust_guests/witguest/

--- a/.github/workflows/dep_code_checks.yml
+++ b/.github/workflows/dep_code_checks.yml
@@ -28,9 +28,9 @@ jobs:
     timeout-minutes: 30
     runs-on: ["self-hosted", "Linux", "X64", "1ES.Pool=hld-kvm-amd", "JobId=linux-checks-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}"]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
-      - uses: hyperlight-dev/ci-setup-workflow@v1.9.0
+      - uses: hyperlight-dev/ci-setup-workflow@f6bd9cc86d0737976d2128c8b8ced8edc017cbb4  # v1.9.0
         with:
           rust-toolchain: "1.89" 
         env:
@@ -44,14 +44,14 @@ jobs:
       # rust-cache cleans "anything not a dependency" from target dirs, removing the sysroot.
       # We cache sysroot separately to avoid rebuilding it (~10s) on every run.
       - name: Sysroot cache
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         with:
           path: |
             src/tests/rust_guests/target/sysroot
           key: sysroot-linux-${{ hashFiles('rust-toolchain.toml') }}
 
       - name: Rust cache
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
         with:
           shared-key: "code-checks-linux"
           cache-on-failure: "true"
@@ -100,9 +100,9 @@ jobs:
     timeout-minutes: 30
     runs-on: ["self-hosted", "Windows", "X64", "1ES.Pool=hld-win2025-amd", "JobId=windows-checks-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}"]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
-      - uses: hyperlight-dev/ci-setup-workflow@v1.9.0
+      - uses: hyperlight-dev/ci-setup-workflow@f6bd9cc86d0737976d2128c8b8ced8edc017cbb4  # v1.9.0
         with:
           rust-toolchain: "1.89" 
         env:
@@ -112,14 +112,14 @@ jobs:
       # rust-cache cleans "anything not a dependency" from target dirs, removing the sysroot.
       # We cache sysroot separately to avoid rebuilding it (~10s) on every run.
       - name: Sysroot cache
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         with:
           path: |
             src/tests/rust_guests/target/sysroot
           key: sysroot-windows-${{ hashFiles('rust-toolchain.toml') }}
 
       - name: Rust cache
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
         with:
           shared-key: "code-checks-windows"
           cache-on-failure: "true"

--- a/.github/workflows/dep_fuzzing.yml
+++ b/.github/workflows/dep_fuzzing.yml
@@ -29,16 +29,16 @@ jobs:
         target: ${{ fromJson(inputs.targets) }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
-      - uses: hyperlight-dev/ci-setup-workflow@v1.9.0
+      - uses: hyperlight-dev/ci-setup-workflow@f6bd9cc86d0737976d2128c8b8ced8edc017cbb4  # v1.9.0
         with:
           rust-toolchain: "1.89"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download Rust guests
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           name: rust-guests-release
           path: src/tests/rust_guests/bin/release/
@@ -52,7 +52,7 @@ jobs:
 
       - name: Upload Crash Artifacts
         if: failure() # This ensures artifacts are only uploaded on failure
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: fuzz-crash-artifacts
           path: fuzz/artifacts/

--- a/.github/workflows/dep_run_examples.yml
+++ b/.github/workflows/dep_run_examples.yml
@@ -48,9 +48,9 @@ jobs:
           github.run_number,
           github.run_attempt)) }} 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
-      - uses: hyperlight-dev/ci-setup-workflow@v1.9.0
+      - uses: hyperlight-dev/ci-setup-workflow@f6bd9cc86d0737976d2128c8b8ced8edc017cbb4  # v1.9.0
         with:
           rust-toolchain: "1.89"
         env:
@@ -62,19 +62,19 @@ jobs:
           sudo chown -R $(id -u):$(id -g) /opt/cargo || true
 
       - name: Rust cache
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
         with:
           shared-key: "${{ runner.os }}-${{ inputs.hypervisor }}-${{ inputs.config }}"
           save-if: "false"
 
       - name: Download Rust guests
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           name: rust-guests-${{ inputs.config }}
           path: src/tests/rust_guests/bin/${{ inputs.config }}/
 
       - name: Download C guests
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           name: c-guests-${{ inputs.config }}
           path: src/tests/c_guests/bin/${{ inputs.config }}/

--- a/.github/workflows/dep_update_guest_locks.yml
+++ b/.github/workflows/dep_update_guest_locks.yml
@@ -29,7 +29,7 @@ jobs:
       # Get GitHub App token for pushing commits back to the PR
       # Uses the same app as auto-merge-dependabot.yml
       - name: Get GitHub App token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
         id: get-app-token
         with:
           app-id: ${{ secrets.DEPENDABOT_APP_ID }}
@@ -37,7 +37,7 @@ jobs:
           permission-contents: write
 
       - name: Checkout PR branch
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           token: ${{ steps.get-app-token.outputs.token }}
           ref: ${{ github.head_ref }}
@@ -45,7 +45,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup Rust toolchain
-        uses: hyperlight-dev/ci-setup-workflow@v1.9.0
+        uses: hyperlight-dev/ci-setup-workflow@f6bd9cc86d0737976d2128c8b8ced8edc017cbb4  # v1.9.0
         with:
           rust-toolchain: "1.89"
         env:

--- a/hack/update-actions.sh
+++ b/hack/update-actions.sh
@@ -2,7 +2,7 @@
 # Scans workflow files for GitHub Actions, resolves the latest release,
 # and prints the pinned hash reference.
 #
-# Usage: ./scripts/update-actions.sh [--update]
+# Usage: ./hack/update-actions.sh [--update]
 #   --update   Apply the pinned hashes to the workflow files in-place
 # Requires: gh (GitHub CLI), authenticated
 
@@ -34,15 +34,17 @@ fi
 # Resolve latest release + commit hash for each action
 declare -A latest_tag latest_hash
 
+sed_escape_regex() {
+    printf '%s' "$1" | sed -E 's/[][\\.^$*+?{}()|]/\\&/g'
+}
+
 resolve_tag_sha() {
     local repo=$1 tag=$2
-    local ref_obj obj_type obj_sha
+    local ref_data obj_type obj_sha
 
-    ref_obj=$(gh api "repos/$repo/git/ref/tags/$tag" \
-        --jq '.object' 2>/dev/null) || true
-
-    obj_type=$(echo "$ref_obj" | jq -r '.type // empty' 2>/dev/null) || true
-    obj_sha=$(echo "$ref_obj" | jq -r '.sha // empty' 2>/dev/null) || true
+    ref_data=$(gh api "repos/$repo/git/ref/tags/$tag" \
+        --jq '[.object.type // "", .object.sha // ""] | @tsv' 2>/dev/null) || true
+    read -r obj_type obj_sha <<< "$ref_data"
 
     # Dereference annotated tags to get the commit
     if [[ "$obj_type" == "tag" ]]; then
@@ -122,6 +124,8 @@ if [[ "$do_update" == true ]]; then
         current="${entry##*@}"
         hash="${latest_hash[$entry]}"
         tag="${latest_tag[$entry]}"
+        escaped_repo=$(sed_escape_regex "$repo")
+        escaped_current=$(sed_escape_regex "$current")
 
         if [[ "$hash" == "(not found)" || "$current" == "$hash" ]]; then
             continue
@@ -130,7 +134,7 @@ if [[ "$do_update" == true ]]; then
         # Replace repo@current with repo@hash # tag in all workflow files
         while IFS= read -r file; do
             if grep -q "${repo}@${current}" "$file"; then
-                sed -i "s|${repo}@${current}|${repo}@${hash}  # ${tag}|g" "$file"
+                sed -i -E "s|${escaped_repo}@${escaped_current}([[:space:]]*#.*)?|${repo}@${hash}  # ${tag}|g" "$file"
                 echo "Updated $repo in $(basename "$file"): ${current} -> ${hash} (${tag})"
                 updated=$((updated + 1))
             fi

--- a/hack/update-actions.sh
+++ b/hack/update-actions.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+# Scans workflow files for GitHub Actions, resolves the latest release,
+# and prints the pinned hash reference.
+#
+# Usage: ./scripts/update-actions.sh [--update]
+#   --update   Apply the pinned hashes to the workflow files in-place
+# Requires: gh (GitHub CLI), authenticated
+
+set -euo pipefail
+
+do_update=false
+if [[ "${1:-}" == "--update" ]]; then
+    do_update=true
+fi
+
+if ! command -v gh &>/dev/null; then
+    echo "Error: gh (GitHub CLI) is required. Install from https://cli.github.com" >&2
+    exit 1
+fi
+
+workflow_dir="$(git rev-parse --show-toplevel)/.github/workflows"
+
+# Extract unique action references (owner/repo@version) from all workflow files
+mapfile -t actions < <(
+    grep -rhoP 'uses:\s*\K[a-zA-Z0-9_-]+/[a-zA-Z0-9_-]+@\S+' "$workflow_dir" \
+    | sort -u
+)
+
+if [[ ${#actions[@]} -eq 0 ]]; then
+    echo "No actions found in $workflow_dir"
+    exit 0
+fi
+
+# Resolve latest release + commit hash for each action
+declare -A latest_tag latest_hash
+
+resolve_tag_sha() {
+    local repo=$1 tag=$2
+    local ref_obj obj_type obj_sha
+
+    ref_obj=$(gh api "repos/$repo/git/ref/tags/$tag" \
+        --jq '.object' 2>/dev/null) || true
+
+    obj_type=$(echo "$ref_obj" | jq -r '.type // empty' 2>/dev/null) || true
+    obj_sha=$(echo "$ref_obj" | jq -r '.sha // empty' 2>/dev/null) || true
+
+    # Dereference annotated tags to get the commit
+    if [[ "$obj_type" == "tag" ]]; then
+        obj_sha=$(gh api "repos/$repo/git/tags/$obj_sha" \
+            --jq '.object.sha' 2>/dev/null) || true
+    fi
+
+    echo "${obj_sha:-(not found)}"
+}
+
+for entry in "${actions[@]}"; do
+    repo="${entry%%@*}"
+    current="${entry##*@}"
+
+    # Get the newest release (any major version)
+    release=$(gh release list --repo "$repo" --limit 100 --json tagName \
+        --jq '.[].tagName' 2>/dev/null \
+        | grep -E '^v[0-9]' \
+        | sort -V \
+        | tail -1) || true
+
+    if [[ -z "$release" ]]; then
+        release="$current"
+    fi
+
+    latest_tag["$entry"]="$release"
+    latest_hash["$entry"]=$(resolve_tag_sha "$repo" "$release")
+done
+
+markdown_escape() {
+    local value=$1
+    value=${value//\\/\\\\}
+    value=${value//|/\\|}
+    printf '%s' "$value"
+}
+
+# Print summary table
+echo "| ACTION | CURRENT | LATEST | LATEST HASH | UPDATE? | URL |"
+echo "| --- | --- | --- | --- | --- | --- |"
+
+for entry in "${actions[@]}"; do
+    repo="${entry%%@*}"
+    current="${entry##*@}"
+    if [[ "$current" != "${latest_hash[$entry]}" ]]; then
+        needs_update="YES"
+    else
+        needs_update="no"
+    fi
+
+    printf '| %s | %s | %s | %s | %s | %s |\n' \
+        "$(markdown_escape "$repo")" \
+        "$(markdown_escape "$current")" \
+        "$(markdown_escape "${latest_tag[$entry]}")" \
+        "$(markdown_escape "${latest_hash[$entry]}")" \
+        "$needs_update" \
+        "$(markdown_escape "https://github.com/$repo/releases")"
+done
+
+# Print pinned references
+echo ""
+echo "# Pinned references (copy into workflows):"
+for entry in "${actions[@]}"; do
+    repo="${entry%%@*}"
+    hash="${latest_hash[$entry]}"
+    tag="${latest_tag[$entry]}"
+    if [[ "$hash" != "(not found)" ]]; then
+        echo "  $repo@$hash  # $tag"
+    fi
+done
+
+# Apply updates to workflow files
+if [[ "$do_update" == true ]]; then
+    echo ""
+    updated=0
+    for entry in "${actions[@]}"; do
+        repo="${entry%%@*}"
+        current="${entry##*@}"
+        hash="${latest_hash[$entry]}"
+        tag="${latest_tag[$entry]}"
+
+        if [[ "$hash" == "(not found)" || "$current" == "$hash" ]]; then
+            continue
+        fi
+
+        # Replace repo@current with repo@hash # tag in all workflow files
+        while IFS= read -r file; do
+            if grep -q "${repo}@${current}" "$file"; then
+                sed -i "s|${repo}@${current}|${repo}@${hash}  # ${tag}|g" "$file"
+                echo "Updated $repo in $(basename "$file"): ${current} -> ${hash} (${tag})"
+                updated=$((updated + 1))
+            fi
+        done < <(find "$workflow_dir" -name '*.yml' -o -name '*.yaml')
+    done
+
+    if [[ $updated -eq 0 ]]; then
+        echo "No updates needed."
+    else
+        echo ""
+        echo "Updated $updated action reference(s). Review changes with: git diff"
+    fi
+fi


### PR DESCRIPTION
This pins all of our github actions to hashes https://docs.github.com/en/actions/reference/security/secure-use#using-third-party-actions.  Dependabot will still work and use hashes when pushing updates.

It removes https://github.com/dtolnay/rust-toolchain for actions-rust-lang/setup-rust-toolchain which is maintained.

| ACTION | CURRENT | LATEST | LATEST HASH | UPDATE? | URL |
| --- | --- | --- | --- | --- | --- |
| Swatinem/rust-cache | v2 | v2.9.1 | c19371144df3bb44fab255c43d04cbc2ab54d1c4 | YES | https://github.com/Swatinem/rust-cache/releases |
| actions/cache | v5 | v5.0.5 | 27d5ce7f107fe9357f9df03efb73ab90386fccae | YES | https://github.com/actions/cache/releases |
| actions/checkout | v6 | v6.0.2 | de0fac2e4500dabe0009e67214ff5f5447ce83dd | YES | https://github.com/actions/checkout/releases |
| actions/create-github-app-token | v3 | v3.2.0 | bcd2ba49218906704ab6c1aa796996da409d3eb1 | YES | https://github.com/actions/create-github-app-token/releases |
| actions/download-artifact | v8 | v8.0.1 | 3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c | YES | https://github.com/actions/download-artifact/releases |
| actions/github-script | v9 | v9.0.0 | 3a2844b7e9c422d3c10d287c895573f7108da1b3 | YES | https://github.com/actions/github-script/releases |
| actions/upload-artifact | v7 | v7.0.1 | 043fb46d1a93c77aae656e7c1c64a875d1fc6a0a | YES | https://github.com/actions/upload-artifact/releases |
| crate-ci/typos | v1.46.3 | v1.47.0 | f8a58b6b53f2279f71eb605f03a4ae4d10608f45 | YES | https://github.com/crate-ci/typos/releases |
| docker/build-push-action | v7 | v7.2.0 | f9f3042f7e2789586610d6e8b85c8f03e5195baf | YES | https://github.com/docker/build-push-action/releases |
| docker/login-action | v4 | v4.2.0 | 650006c6eb7dba73a995cc03b0b2d7f5ca915bee | YES | https://github.com/docker/login-action/releases |
| docker/metadata-action | v6 | v6.1.0 | 80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 | YES | https://github.com/docker/metadata-action/releases |
| dorny/paths-filter | v4 | v4.0.1 | fbd0ab8f3e69293af611ebaee6363fc25e6d187d | YES | https://github.com/dorny/paths-filter/releases |
| actions-rust-lang/setup-rust-toolchain | | v1.16.1 | 46268bd060767258de96ed93c1251119784f2ab6 | YES | https://github.com/actions-rust-lang/setup-rust-toolchain/releases |
| hyperlight-dev/ci-setup-workflow | v1.9.0 | v1.9.0 | f6bd9cc86d0737976d2128c8b8ced8edc017cbb4 | YES | https://github.com/hyperlight-dev/ci-setup-workflow/releases |
| rust-lang/crates-io-auth-action | v1 | v1.0.4 | bbd81622f20ce9e2dd9622e3218b975523e45bbe | YES | https://github.com/rust-lang/crates-io-auth-action/releases |
| rustsec/audit-check | v2.0.0 | v2.0.0 | 69366f33c96575abad1ee0dba8212993eecbe998 | YES | https://github.com/rustsec/audit-check/releases |