### PR TITLE
Build rust guests without hyperlight-libc

### DIFF
--- a/src/hyperlight_guest_bin/src/lib.rs
+++ b/src/hyperlight_guest_bin/src/lib.rs
@@ -203,6 +203,8 @@ fn _panic_handler(info: &core::panic::PanicInfo) -> ! {
 
 unsafe extern "C" {
     fn hyperlight_main();
+
+    #[cfg(feature = "libc")]
     fn srand(seed: u32);
 }
 
@@ -222,7 +224,7 @@ core::arch::global_asm!(
 /// user initialisation
 pub(crate) extern "C" fn generic_init(
     peb_address: u64,
-    seed: u64,
+    _seed: u64,
     ops: u64,
     max_log_level: u64,
 ) -> u64 {
@@ -248,11 +250,13 @@ pub(crate) extern "C" fn generic_init(
     #[cfg(feature = "trace_guest")]
     let guest_start_tsc = hyperlight_guest_tracing::invariant_tsc::read_tsc();
 
+    #[cfg(feature = "libc")]
     unsafe {
-        let srand_seed = (((peb_address << 8) ^ (seed >> 4)) >> 32) as u32;
-        // Set the seed for the random number generator for C code using rand;
+        let srand_seed = (((peb_address << 8) ^ (_seed >> 4)) >> 32) as u32;
         srand(srand_seed);
+    }
 
+    unsafe {
         OS_PAGE_SIZE = ops as u32;
     }
 

--- a/src/tests/rust_guests/Cargo.lock
+++ b/src/tests/rust_guests/Cargo.lock
@@ -68,26 +68,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
-name = "bindgen"
-version = "0.72.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
-dependencies = [
- "bitflags",
- "cexpr",
- "clang-sys",
- "itertools 0.13.0",
- "log",
- "prettyplease",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash",
- "shlex 1.3.0",
- "syn",
-]
-
-[[package]]
 name = "bitflags"
 version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -120,42 +100,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "cc"
-version = "1.2.63"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
-dependencies = [
- "find-msvc-tools",
- "shlex 2.0.1",
-]
-
-[[package]]
-name = "cexpr"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
-dependencies = [
- "nom",
-]
-
-[[package]]
-name = "cfg-if"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
-
-[[package]]
-name = "clang-sys"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
-dependencies = [
- "glob",
- "libc",
- "libloading",
 ]
 
 [[package]]
@@ -208,12 +152,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
-name = "find-msvc-tools"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
-
-[[package]]
 name = "flatbuffers"
 version = "25.12.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -228,12 +166,6 @@ name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
-
-[[package]]
-name = "glob"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "hashbrown"
@@ -267,7 +199,7 @@ version = "0.15.0"
 dependencies = [
  "env_logger",
  "hyperlight-component-util",
- "itertools 0.14.0",
+ "itertools",
  "prettyplease",
  "proc-macro2",
  "quote",
@@ -278,7 +210,7 @@ dependencies = [
 name = "hyperlight-component-util"
 version = "0.15.0"
 dependencies = [
- "itertools 0.14.0",
+ "itertools",
  "prettyplease",
  "proc-macro2",
  "quote",
@@ -309,7 +241,6 @@ dependencies = [
  "hyperlight-guest",
  "hyperlight-guest-macro",
  "hyperlight-guest-tracing",
- "hyperlight-libc",
  "linkme",
  "log",
  "spin 0.12.0",
@@ -337,16 +268,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyperlight-libc"
-version = "0.15.0"
-dependencies = [
- "anyhow",
- "bindgen",
- "cc",
- "glob",
-]
-
-[[package]]
 name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -363,15 +284,6 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
-
-[[package]]
-name = "itertools"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
-dependencies = [
- "either",
-]
 
 [[package]]
 name = "itertools"
@@ -410,22 +322,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "libc"
-version = "0.2.186"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
-
-[[package]]
-name = "libloading"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
-dependencies = [
- "cfg-if",
- "windows-link",
 ]
 
 [[package]]
@@ -468,22 +364,6 @@ name = "memchr"
 version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
-
-[[package]]
-name = "minimal-lexical"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
-
-[[package]]
-name = "nom"
-version = "7.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
-dependencies = [
- "memchr",
- "minimal-lexical",
-]
 
 [[package]]
 name = "once_cell"
@@ -585,12 +465,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
-name = "rustc-hash"
-version = "2.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
-
-[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -652,18 +526,6 @@ dependencies = [
  "serde_core",
  "zmij",
 ]
-
-[[package]]
-name = "shlex"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
-
-[[package]]
-name = "shlex"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "simpleguest"

--- a/src/tests/rust_guests/dummyguest/Cargo.toml
+++ b/src/tests/rust_guests/dummyguest/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 
 [dependencies]
-hyperlight-guest-bin = { path = "../../../hyperlight_guest_bin" }
+hyperlight-guest-bin = { path = "../../../hyperlight_guest_bin", default-features = false }
 hyperlight-common = { path = "../../../hyperlight_common", default-features = false }
 
 [features]

--- a/src/tests/rust_guests/simpleguest/Cargo.toml
+++ b/src/tests/rust_guests/simpleguest/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 hyperlight-guest = { path = "../../../hyperlight_guest" }
-hyperlight-guest-bin = { path = "../../../hyperlight_guest_bin" }
+hyperlight-guest-bin = { path = "../../../hyperlight_guest_bin", default-features = false, features = ["macros"] }
 hyperlight-common = { path = "../../../hyperlight_common", default-features = false }
 hyperlight-guest-tracing = { path = "../../../hyperlight_guest_tracing" }
 log = {version = "0.4", default-features = false }

--- a/src/tests/rust_guests/witguest/Cargo.toml
+++ b/src/tests/rust_guests/witguest/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 hyperlight-guest = { path = "../../../hyperlight_guest" }
-hyperlight-guest-bin = { path = "../../../hyperlight_guest_bin" }
+hyperlight-guest-bin = { path = "../../../hyperlight_guest_bin", default-features = false }
 hyperlight-common = { path = "../../../hyperlight_common", default-features = false }
 hyperlight-component-macro = { path = "../../../hyperlight_component_macro" }
 spin = "0.10.0"


### PR DESCRIPTION
Rust guests transitively depend on hyperlight-libc (picolibc) through hyperlight-guest-bin's default libc feature. The only reason the dependency was needed was an unconditional call to picolibc's srand in generic_init. The Rust guests themselves never use it.

This PR: 
- Gates the srand extern and the call in generic_init behind #[cfg(feature = "libc")].
- Sets default-features = false on hyperlight-guest-bin in simpleguest, dummyguest, and witguest

I am also strongly considering making cargo feature libc a non-default cargo feature of hyperlight-guest-bin, since I am guessing most people who write rust guests do not need hyperlight-libc, but would appreciate more thoughts/feedback on that.

Closes #1483 