### PR TITLE
Remove unused mapped_rgns field from memory manager

### DIFF
--- a/src/hyperlight_host/src/mem/mgr.rs
+++ b/src/hyperlight_host/src/mem/mgr.rs
@@ -145,8 +145,6 @@ pub(crate) struct SandboxMemoryManager<S: SharedMemory> {
     pub(crate) layout: SandboxMemoryLayout,
     /// Offset for the execution entrypoint from `load_addr`
     pub(crate) entrypoint: NextAction,
-    /// How many memory regions were mapped after sandbox creation
-    pub(crate) mapped_rgns: u64,
     /// Buffer for accumulating guest abort messages
     pub(crate) abort_buffer: Vec<u8>,
     /// Generation counter: how many snapshots have been taken from
@@ -287,7 +285,6 @@ where
             shared_mem,
             scratch_mem,
             entrypoint,
-            mapped_rgns: 0,
             abort_buffer: Vec::new(),
             snapshot_count: 0,
         }
@@ -366,7 +363,6 @@ impl SandboxMemoryManager<ExclusiveSharedMemory> {
             scratch_mem: hscratch,
             layout: self.layout,
             entrypoint: self.entrypoint,
-            mapped_rgns: self.mapped_rgns,
             abort_buffer: self.abort_buffer,
             snapshot_count: self.snapshot_count,
         };
@@ -375,7 +371,6 @@ impl SandboxMemoryManager<ExclusiveSharedMemory> {
             scratch_mem: gscratch,
             layout: self.layout,
             entrypoint: self.entrypoint,
-            mapped_rgns: self.mapped_rgns,
             abort_buffer: Vec::new(), // Guest doesn't need abort buffer
             snapshot_count: self.snapshot_count,
         };

--- a/src/hyperlight_host/src/sandbox/initialized_multi_use.rs
+++ b/src/hyperlight_host/src/sandbox/initialized_multi_use.rs
@@ -754,7 +754,6 @@ impl MultiUseSandbox {
         // Map first so overlaps are rejected before resetting the snapshot
         unsafe { self.vm.map_region(rgn) }.map_err(HyperlightVmError::MapRegion)?;
         self.snapshot = None;
-        self.mem_mgr.mapped_rgns += 1;
         Ok(())
     }
 
@@ -841,7 +840,6 @@ impl MultiUseSandbox {
         // On Linux the hypervisor holds a reference to the host mmap;
         // freeing it here would leave a dangling backing.
         prepared.mark_consumed();
-        self.mem_mgr.mapped_rgns += 1;
 
         // Record the mapping metadata in the PEB. If this fails the VM
         // still holds a valid mapping but the PEB won't list it — the

--- a/src/hyperlight_host/src/sandbox/uninitialized_evolve.rs
+++ b/src/hyperlight_host/src/sandbox/uninitialized_evolve.rs
@@ -116,7 +116,6 @@ pub(super) fn evolve_impl_multi_use(u_sbox: UninitializedSandbox) -> Result<Mult
         // UninitializedSandbox::map_file_cow.
         #[cfg(feature = "nanvix-unstable")]
         hshm.write_file_mapping_entry(prepared.guest_base, prepared.size as u64, &prepared.label)?;
-        hshm.mapped_rgns += 1;
     }
 
     vm.initialise(


### PR DESCRIPTION
Remove the unused mapped_rgns counter from SandboxMemoryManager. #742 replaced the old count-diff restore with Vec<MemoryRegion> set-difference and deleted every reader.