### PR TITLE
feat(virtq): add high-level packed virtqueue producer/consumer api

### DIFF
--- a/.github/workflows/dep_code_checks.yml
+++ b/.github/workflows/dep_code_checks.yml
@@ -95,6 +95,9 @@ jobs:
           just test-compilation-no-default-features debug
           just test-compilation-no-default-features release
 
+      - name: Run loom concurrency tests
+        run: just test-loom
+
   windows-checks:
     if: ${{ inputs.docs_only == 'false' }}
     timeout-minutes: 30

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -908,6 +908,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
 name = "flatbuffers"
 version = "25.12.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1464,8 +1470,13 @@ dependencies = [
  "arbitrary",
  "bitflags 2.13.0",
  "bytemuck",
+ "bytes",
+ "criterion",
+ "fixedbitset",
  "flatbuffers",
+ "hyperlight-testing",
  "log",
+ "loom",
  "quickcheck",
  "rand 0.10.1",
  "smallvec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ hyperlight-component-macro = { path = "src/hyperlight_component_macro", version 
 
 [workspace.lints.rust]
 unsafe_op_in_unsafe_fn = "deny"
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(loom)'] }
 
 # this will generate symbols for release builds
 # so is handy for debugging issues in release builds

--- a/Justfile
+++ b/Justfile
@@ -222,6 +222,10 @@ test target=default-target features="": (test-unit target features) (test-isolat
 test-unit target=default-target features="":
     {{ cargo-cmd }} test {{ if features =="" {''} else if features=="no-default-features" {"--no-default-features" } else {"--no-default-features -F " + features } }} --profile={{ if target == "debug" { "dev" } else { target } }} {{ target-triple-flag }} --lib
 
+# runs loom concurrency tests
+test-loom:
+    {{ set-env-command }}RUSTFLAGS='--cfg loom'; {{ cargo-cmd }} test --quiet -p hyperlight-common --lib {{ target-triple-flag }} virtq::concurrency::
+
 # runs tests that requires being run separately, for example due to global state
 test-isolated target=default-target features="" :
     {{ cargo-cmd }} test {{ if features =="" {''} else if features=="no-default-features" {"--no-default-features" } else {"--no-default-features -F " + features } }} --profile={{ if target == "debug" { "dev" } else { target } }} {{ target-triple-flag }} -p hyperlight-host --lib -- sandbox::uninitialized::tests::test_log_trace --exact --ignored

--- a/src/hyperlight_common/Cargo.toml
+++ b/src/hyperlight_common/Cargo.toml
@@ -19,6 +19,8 @@ arbitrary = {version = "1.4.2", optional = true, features = ["derive"]}
 anyhow = { version = "1.0.102", default-features = false }
 bitflags = "2.13.0"
 bytemuck = { version = "1.24", features = ["derive"] }
+bytes = { version = "1", default-features = false }
+fixedbitset = { version = "0.5.7", default-features = false }
 flatbuffers = { version = "25.12.19", default-features = false }
 log = "0.4.32"
 smallvec = "1.15.1"
@@ -39,9 +41,22 @@ nanvix-unstable = ["i686-guest"]
 guest-counter = []
 
 [dev-dependencies]
+criterion = "0.8.1"
+hyperlight-testing = { workspace = true }
 quickcheck = "1.0.3"
 rand = "0.10.1"
+
+[target.'cfg(loom)'.dev-dependencies]
+loom = "0.7"
 
 [lib]
 bench = false # see https://bheisler.github.io/criterion.rs/book/faq.html#cargo-bench-gives-unrecognized-option-errors-for-valid-command-line-options
 doctest = false # reduce noise in test output
+
+[[bench]]
+name = "buffer_pool"
+harness = false
+
+[[bench]]
+name = "virtq_api"
+harness = false

--- a/src/hyperlight_common/benches/buffer_pool.rs
+++ b/src/hyperlight_common/benches/buffer_pool.rs
@@ -1,0 +1,217 @@
+/*
+Copyright 2026  The Hyperlight Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use std::hint::black_box;
+
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use hyperlight_common::virtq::{BufferPool, BufferProvider, RecyclePool};
+
+// Helper to create a pool for benchmarking
+fn make_pool<const L: usize, const U: usize>(size: usize) -> BufferPool<L, U> {
+    let base = 0x10000;
+    BufferPool::<L, U>::new(base, size).unwrap()
+}
+
+// Single allocation performance
+fn bench_alloc_single(c: &mut Criterion) {
+    let mut group = c.benchmark_group("alloc_single");
+
+    for size in [64, 128, 256, 512, 1024, 1500, 4096].iter() {
+        group.throughput(Throughput::Elements(1));
+        group.bench_with_input(BenchmarkId::from_parameter(size), size, |b, &size| {
+            let pool = make_pool::<256, 4096>(4 * 1024 * 1024);
+            b.iter(|| {
+                let alloc = pool.alloc(black_box(size)).unwrap();
+                pool.dealloc(alloc.addr).unwrap();
+            });
+        });
+    }
+    group.finish();
+}
+
+// LIFO recycling
+fn bench_alloc_lifo(c: &mut Criterion) {
+    let mut group = c.benchmark_group("alloc_lifo");
+
+    for size in [256, 1500, 4096].iter() {
+        group.throughput(Throughput::Elements(100));
+        group.bench_with_input(BenchmarkId::from_parameter(size), size, |b, &size| {
+            let pool = make_pool::<256, 4096>(4 * 1024 * 1024);
+            b.iter(|| {
+                for _ in 0..100 {
+                    let alloc = pool.alloc(black_box(size)).unwrap();
+                    pool.dealloc(alloc.addr).unwrap();
+                }
+            });
+        });
+    }
+    group.finish();
+}
+
+// Fragmented allocation worst case
+fn bench_alloc_fragmented(c: &mut Criterion) {
+    let mut group = c.benchmark_group("alloc_fragmented");
+
+    group.bench_function("fragmented_256", |b| {
+        let pool = make_pool::<256, 4096>(4 * 1024 * 1024);
+
+        // Create fragmentation pattern: allocate many, free every other
+        let mut allocations = Vec::new();
+        for _ in 0..100 {
+            allocations.push(pool.alloc(128).unwrap());
+        }
+        for i in (0..100).step_by(2) {
+            pool.dealloc(allocations[i].addr).unwrap();
+        }
+
+        b.iter(|| {
+            let alloc = pool.alloc(black_box(256)).unwrap();
+            pool.dealloc(alloc.addr).unwrap();
+        });
+    });
+
+    group.finish();
+}
+
+// Free performance
+fn bench_free(c: &mut Criterion) {
+    let mut group = c.benchmark_group("free");
+
+    for size in [256, 1500, 4096].iter() {
+        group.bench_with_input(BenchmarkId::from_parameter(size), size, |b, &size| {
+            let pool = make_pool::<256, 4096>(4 * 1024 * 1024);
+            b.iter(|| {
+                let alloc = pool.alloc(size).unwrap();
+                pool.dealloc(black_box(alloc.addr)).unwrap();
+            });
+        });
+    }
+
+    group.finish();
+}
+
+// Free-list reuse
+fn bench_free_list_reuse(c: &mut Criterion) {
+    let mut group = c.benchmark_group("free_list_reuse");
+
+    // With cursor optimization (LIFO)
+    group.bench_function("lifo_pattern", |b| {
+        let pool = make_pool::<256, 4096>(4 * 1024 * 1024);
+        b.iter(|| {
+            let alloc = pool.alloc(256).unwrap();
+            pool.dealloc(alloc.addr).unwrap();
+            let alloc2 = pool.alloc(black_box(256)).unwrap();
+            pool.dealloc(alloc2.addr).unwrap();
+        });
+    });
+
+    // Without cursor benefit (FIFO-like)
+    group.bench_function("fifo_pattern", |b| {
+        let pool = make_pool::<256, 4096>(4 * 1024 * 1024);
+        let mut queue = Vec::new();
+
+        // Pre-fill queue
+        for _ in 0..10 {
+            queue.push(pool.alloc(256).unwrap());
+        }
+
+        b.iter(|| {
+            // FIFO: free oldest, allocate new
+            let old = queue.remove(0);
+            pool.dealloc(old.addr).unwrap();
+            queue.push(pool.alloc(black_box(256)).unwrap());
+        });
+    });
+
+    group.finish();
+}
+
+// Segmented logical payload allocation
+fn bench_segmented_payload(c: &mut Criterion) {
+    let mut group = c.benchmark_group("segmented_payload");
+
+    for payload_size in [8 * 1024usize, 64 * 1024, 256 * 1024] {
+        group.throughput(Throughput::Bytes(payload_size as u64));
+        group.bench_with_input(
+            BenchmarkId::from_parameter(payload_size),
+            &payload_size,
+            |b, &payload_size| {
+                let pool = make_pool::<256, 4096>(4 * 1024 * 1024);
+                b.iter(|| {
+                    let sgs = pool.alloc_sg(black_box(payload_size)).unwrap();
+                    for sg in sgs {
+                        pool.dealloc(sg.addr).unwrap();
+                    }
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+fn bench_recycle_pool(c: &mut Criterion) {
+    let mut group = c.benchmark_group("recycle_pool");
+
+    group.bench_function("alloc_dealloc_4096", |b| {
+        let pool = RecyclePool::new(0x80000, 4 * 1024 * 1024, 4096).unwrap();
+        b.iter(|| {
+            let alloc = pool.alloc(black_box(4096)).unwrap();
+            pool.dealloc(alloc.addr).unwrap();
+        });
+    });
+
+    group.bench_function("alloc_dealloc_128", |b| {
+        let pool = RecyclePool::new(0x80000, 4 * 1024 * 1024, 256).unwrap();
+        b.iter(|| {
+            let alloc = pool.alloc(black_box(128)).unwrap();
+            pool.dealloc(alloc.addr).unwrap();
+        });
+    });
+
+    group.bench_function("alloc_dealloc_1500", |b| {
+        let pool = RecyclePool::new(0x80000, 4 * 1024 * 1024, 4096).unwrap();
+        b.iter(|| {
+            let alloc = pool.alloc(black_box(1500)).unwrap();
+            pool.dealloc(alloc.addr).unwrap();
+        });
+    });
+
+    group.bench_function("alloc_sg_64k", |b| {
+        let pool = RecyclePool::new(0x80000, 4 * 1024 * 1024, 4096).unwrap();
+        b.iter(|| {
+            let sgs = pool.alloc_sg(black_box(64 * 1024)).unwrap();
+            for sg in sgs {
+                pool.dealloc(sg.addr).unwrap();
+            }
+        });
+    });
+
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_alloc_single,
+    bench_alloc_lifo,
+    bench_alloc_fragmented,
+    bench_free,
+    bench_free_list_reuse,
+    bench_segmented_payload,
+    bench_recycle_pool,
+);
+
+criterion_main!(benches);

--- a/src/hyperlight_common/benches/common/mod.rs
+++ b/src/hyperlight_common/benches/common/mod.rs
@@ -1,0 +1,272 @@
+/*
+Copyright 2026  The Hyperlight Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! Shared harness for the `virtq_api` benchmarks: an in-memory [`MemOps`]
+//! backend, a counting [`Notifier`], producer/consumer pair construction, pool
+//! factories, and request/response round-trip drivers.
+
+use std::cell::UnsafeCell;
+use std::hint::black_box;
+use std::num::NonZeroU16;
+use std::ptr;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU16, AtomicUsize, Ordering};
+
+use bytemuck::Pod;
+use hyperlight_common::virtq::{
+    BufferPool, BufferProvider, Descriptor, Layout, MemOps, Notifier, QueueStats, RecyclePool,
+    ReplyChain, UsedChain, VirtqConsumer, VirtqProducer,
+};
+
+pub const LOWER_SLOT: usize = 256;
+pub const UPPER_SLOT: usize = 4096;
+pub const POOL_SIZE: usize = 8 * 1024 * 1024;
+
+pub type RunBufferPool = BufferPool<LOWER_SLOT, UPPER_SLOT>;
+
+#[derive(Clone)]
+struct BenchMem {
+    inner: Arc<BenchMemInner>,
+}
+
+struct BenchMemInner {
+    storage: UnsafeCell<Vec<u8>>,
+    base_addr: u64,
+}
+
+unsafe impl Send for BenchMemInner {}
+unsafe impl Sync for BenchMemInner {}
+
+impl BenchMem {
+    fn new(size: usize) -> Self {
+        let storage = vec![0u8; size];
+        let base_addr = storage.as_ptr() as u64;
+        Self {
+            inner: Arc::new(BenchMemInner {
+                storage: UnsafeCell::new(storage),
+                base_addr,
+            }),
+        }
+    }
+
+    fn base_addr(&self) -> u64 {
+        self.inner.base_addr
+    }
+
+    fn ptr_for_addr(&self, addr: u64) -> *mut u8 {
+        let storage = unsafe { &mut *self.inner.storage.get() };
+        let offset = (addr - self.inner.base_addr) as usize;
+        storage.as_mut_ptr().wrapping_add(offset)
+    }
+}
+
+unsafe impl MemOps for BenchMem {
+    type Error = core::convert::Infallible;
+
+    fn read(&self, addr: u64, dst: &mut [u8]) -> Result<(), Self::Error> {
+        let src = self.ptr_for_addr(addr);
+        unsafe {
+            ptr::copy_nonoverlapping(src, dst.as_mut_ptr(), dst.len());
+        }
+        Ok(())
+    }
+
+    fn write(&self, addr: u64, src: &[u8]) -> Result<(), Self::Error> {
+        let dst = self.ptr_for_addr(addr);
+        unsafe {
+            ptr::copy_nonoverlapping(src.as_ptr(), dst, src.len());
+        }
+        Ok(())
+    }
+
+    fn read_val<T: Pod>(&self, addr: u64) -> Result<T, Self::Error> {
+        let ptr = self.ptr_for_addr(addr).cast::<T>();
+        Ok(unsafe { ptr::read_volatile(ptr) })
+    }
+
+    fn write_val<T: Pod>(&self, addr: u64, val: T) -> Result<(), Self::Error> {
+        let ptr = self.ptr_for_addr(addr).cast::<T>();
+        unsafe { ptr::write_volatile(ptr, val) };
+        Ok(())
+    }
+
+    fn load_acquire(&self, addr: u64) -> Result<u16, Self::Error> {
+        let ptr = self.ptr_for_addr(addr).cast::<AtomicU16>();
+        Ok(unsafe { (*ptr).load(Ordering::Acquire) })
+    }
+
+    fn store_release(&self, addr: u64, val: u16) -> Result<(), Self::Error> {
+        let ptr = self.ptr_for_addr(addr).cast::<AtomicU16>();
+        unsafe { (*ptr).store(val, Ordering::Release) };
+        Ok(())
+    }
+
+    unsafe fn as_slice(&self, addr: u64, len: usize) -> Result<&[u8], Self::Error> {
+        let ptr = self.ptr_for_addr(addr);
+        Ok(unsafe { core::slice::from_raw_parts(ptr, len) })
+    }
+
+    unsafe fn as_mut_slice(&self, addr: u64, len: usize) -> Result<&mut [u8], Self::Error> {
+        let ptr = self.ptr_for_addr(addr);
+        Ok(unsafe { core::slice::from_raw_parts_mut(ptr, len) })
+    }
+}
+
+#[derive(Clone)]
+struct BenchNotifier {
+    count: Arc<AtomicUsize>,
+}
+
+impl BenchNotifier {
+    fn new() -> Self {
+        Self {
+            count: Arc::new(AtomicUsize::new(0)),
+        }
+    }
+}
+
+impl Notifier for BenchNotifier {
+    fn notify(&self, _stats: QueueStats) {
+        self.count.fetch_add(1, Ordering::Relaxed);
+    }
+}
+
+/// A producer/consumer pair sharing one in-memory ring and pool.
+pub struct BenchPair<P> {
+    producer: VirtqProducer<BenchMem, BenchNotifier, P>,
+    consumer: VirtqConsumer<BenchMem, BenchNotifier>,
+}
+
+fn align_up(value: usize, align: usize) -> usize {
+    value.div_ceil(align) * align
+}
+
+/// Build a [`BenchPair`] with `descs` ring descriptors and a pool built by
+/// `make_pool`.
+pub fn make_pair<P>(descs: usize, make_pool: impl FnOnce(u64, usize) -> P) -> BenchPair<P>
+where
+    P: BufferProvider + Clone,
+{
+    let ring_size = Layout::query_size(descs);
+    let mem = BenchMem::new(ring_size + POOL_SIZE + 0x20000);
+    let ring_base = align_up(mem.base_addr() as usize, Descriptor::ALIGN) as u64;
+    let descs_nz = NonZeroU16::new(descs as u16).unwrap();
+
+    let layout = unsafe { Layout::from_base(ring_base, descs_nz).unwrap() };
+    let pool_base = align_up((ring_base + ring_size as u64 + 0x1000) as usize, UPPER_SLOT) as u64;
+    let pool = make_pool(pool_base, POOL_SIZE);
+
+    let notifier = BenchNotifier::new();
+    let producer = VirtqProducer::new(layout, mem.clone(), notifier.clone(), pool);
+    let consumer = VirtqConsumer::new(layout, mem, notifier);
+
+    BenchPair { producer, consumer }
+}
+
+pub fn run_buffer_pool(base: u64, size: usize) -> RunBufferPool {
+    BufferPool::new(base, size).unwrap()
+}
+
+pub fn fragmented_run_buffer_pool(base: u64, size: usize, payload_size: usize) -> RunBufferPool {
+    let pool = run_buffer_pool(base, size);
+    let payload_slots = payload_size.div_ceil(UPPER_SLOT);
+    let prefix_slots = 32;
+    let suffix_slots = 32;
+
+    let allocated: Vec<_> = (0..prefix_slots + payload_slots + suffix_slots)
+        .map(|_| pool.alloc(UPPER_SLOT).unwrap())
+        .collect();
+
+    for alloc in &allocated[prefix_slots..prefix_slots + payload_slots] {
+        pool.dealloc(alloc.addr).unwrap();
+    }
+
+    pool
+}
+
+pub fn recycle_pool(base: u64, size: usize) -> RecyclePool {
+    RecyclePool::new(base, size, UPPER_SLOT).unwrap()
+}
+
+pub fn fragmented_recycle_pool(base: u64, size: usize, payload_size: usize) -> RecyclePool {
+    let pool = recycle_pool(base, size);
+    let payload_slots = payload_size.div_ceil(UPPER_SLOT);
+    let allocated: Vec<_> = (0..payload_slots * 2 + 16)
+        .map(|_| pool.alloc(UPPER_SLOT).unwrap())
+        .collect();
+
+    for alloc in allocated.iter().step_by(2).take(payload_slots) {
+        pool.dealloc(alloc.addr).unwrap();
+    }
+
+    pool
+}
+
+/// Drive one read-only (fire-and-forget) chain through submit, consume, ack, and
+/// poll, returning the producer-observed used chain.
+pub fn readonly_roundtrip<P>(pair: &mut BenchPair<P>, payload: &[u8]) -> UsedChain
+where
+    P: BufferProvider + Clone + Send + 'static,
+{
+    let mut chain = pair
+        .producer
+        .chain()
+        .readable(payload.len())
+        .build()
+        .unwrap();
+
+    chain.write_all(payload).unwrap();
+    let token = pair.producer.submit(chain).unwrap();
+
+    let (recv, reply) = pair.consumer.poll(payload.len()).unwrap().unwrap();
+    black_box(recv.segments().segment_count());
+    pair.consumer.complete(reply).unwrap();
+
+    let used = pair.producer.poll().unwrap().unwrap();
+    debug_assert_eq!(used.token(), token);
+    used
+}
+
+/// Drive one request/response chain through submit, consume, write reply,
+/// complete, and poll, returning the producer-observed used chain.
+pub fn readwrite_roundtrip<P>(pair: &mut BenchPair<P>, request: &[u8], response: &[u8]) -> UsedChain
+where
+    P: BufferProvider + Clone + Send + 'static,
+{
+    let mut chain = pair
+        .producer
+        .chain()
+        .readable(request.len())
+        .writable(response.len())
+        .build()
+        .unwrap();
+
+    chain.write_all(request).unwrap();
+    let token = pair.producer.submit(chain).unwrap();
+
+    let (recv, reply) = pair.consumer.poll(request.len()).unwrap().unwrap();
+    black_box(recv.segments().segment_count());
+    let ReplyChain::Writable(mut writable) = reply else {
+        panic!("expected writable reply");
+    };
+
+    writable.write_all(response).unwrap();
+    pair.consumer.complete(writable).unwrap();
+
+    let used = pair.producer.poll().unwrap().unwrap();
+    debug_assert_eq!(used.token(), token);
+    used
+}

--- a/src/hyperlight_common/benches/virtq_api.rs
+++ b/src/hyperlight_common/benches/virtq_api.rs
@@ -1,0 +1,174 @@
+/*
+Copyright 2026  The Hyperlight Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use std::hint::black_box;
+
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use hyperlight_common::virtq::UsedChain;
+
+mod common;
+use common::*;
+
+fn bench_readonly_strategies(c: &mut Criterion) {
+    let mut group = c.benchmark_group("virtq_readonly_allocator_strategy");
+
+    for size in [8 * 1024usize, 64 * 1024, 256 * 1024] {
+        let payload = vec![0xA5u8; size];
+        group.throughput(Throughput::Bytes(size as u64));
+
+        group.bench_with_input(
+            BenchmarkId::new("buffer_pool_run", size),
+            &payload,
+            |b, payload| {
+                let mut pair = make_pair(128, run_buffer_pool);
+                b.iter(|| {
+                    let used = readonly_roundtrip(&mut pair, black_box(payload));
+                    debug_assert!(matches!(used, UsedChain::Ack(_)));
+                });
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("buffer_pool_run_fragmented", size),
+            &payload,
+            |b, payload| {
+                let mut pair = make_pair(128, |base, pool_size| {
+                    fragmented_run_buffer_pool(base, pool_size, payload.len())
+                });
+                b.iter(|| {
+                    let used = readonly_roundtrip(&mut pair, black_box(payload));
+                    debug_assert!(matches!(used, UsedChain::Ack(_)));
+                });
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("recycle_pool_segmented", size),
+            &payload,
+            |b, payload| {
+                let mut pair = make_pair(128, recycle_pool);
+                b.iter(|| {
+                    let used = readonly_roundtrip(&mut pair, black_box(payload));
+                    debug_assert!(matches!(used, UsedChain::Ack(_)));
+                });
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("recycle_pool_segmented_fragmented", size),
+            &payload,
+            |b, payload| {
+                let mut pair = make_pair(128, |base, pool_size| {
+                    fragmented_recycle_pool(base, pool_size, payload.len())
+                });
+                b.iter(|| {
+                    let used = readonly_roundtrip(&mut pair, black_box(payload));
+                    debug_assert!(matches!(used, UsedChain::Ack(_)));
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+fn bench_readwrite_strategies(c: &mut Criterion) {
+    let mut group = c.benchmark_group("virtq_readwrite_allocator_strategy");
+
+    for size in [8 * 1024usize, 64 * 1024, 256 * 1024] {
+        let request = vec![0x11u8; size];
+        let response = vec![0x22u8; size];
+        group.throughput(Throughput::Bytes((request.len() + response.len()) as u64));
+
+        group.bench_with_input(
+            BenchmarkId::new("buffer_pool_run", size),
+            &(request.clone(), response.clone()),
+            |b, (request, response)| {
+                let mut pair = make_pair(128, run_buffer_pool);
+                b.iter(|| {
+                    let used = readwrite_roundtrip(
+                        &mut pair,
+                        black_box(request.as_slice()),
+                        black_box(response.as_slice()),
+                    );
+                    black_box(used.segments().unwrap().segment_count());
+                });
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("buffer_pool_run_fragmented", size),
+            &(request.clone(), response.clone()),
+            |b, (request, response)| {
+                let mut pair = make_pair(128, |base, pool_size| {
+                    fragmented_run_buffer_pool(base, pool_size, request.len())
+                });
+                b.iter(|| {
+                    let used = readwrite_roundtrip(
+                        &mut pair,
+                        black_box(request.as_slice()),
+                        black_box(response.as_slice()),
+                    );
+                    black_box(used.segments().unwrap().segment_count());
+                });
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("recycle_pool_segmented", size),
+            &(request.clone(), response.clone()),
+            |b, (request, response)| {
+                let mut pair = make_pair(128, recycle_pool);
+                b.iter(|| {
+                    let used = readwrite_roundtrip(
+                        &mut pair,
+                        black_box(request.as_slice()),
+                        black_box(response.as_slice()),
+                    );
+                    black_box(used.segments().unwrap().segment_count());
+                });
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("recycle_pool_segmented_fragmented", size),
+            &(request, response),
+            |b, (request, response)| {
+                let mut pair = make_pair(128, |base, pool_size| {
+                    fragmented_recycle_pool(base, pool_size, request.len())
+                });
+                b.iter(|| {
+                    let used = readwrite_roundtrip(
+                        &mut pair,
+                        black_box(request.as_slice()),
+                        black_box(response.as_slice()),
+                    );
+                    black_box(used.segments().unwrap().segment_count());
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_readonly_strategies,
+    bench_readwrite_strategies,
+);
+
+criterion_main!(benches);

--- a/src/hyperlight_common/src/virtq/buffer.rs
+++ b/src/hyperlight_common/src/virtq/buffer.rs
@@ -1,0 +1,485 @@
+/*
+Copyright 2026  The Hyperlight Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! Buffer allocation traits and shared types for virtqueue buffer management.
+
+use alloc::rc::Rc;
+use alloc::sync::Arc;
+use alloc::vec::Vec;
+
+use bytes::{Buf, Bytes};
+use smallvec::{SmallVec, smallvec};
+use thiserror::Error;
+
+use super::access::MemOps;
+
+#[derive(Debug, Error, Copy, Clone)]
+pub enum AllocError {
+    #[error("Invalid region addr {0}")]
+    InvalidAlign(u64),
+    #[error("Invalid free addr {0} and size {1}")]
+    InvalidFree(u64, usize),
+    #[error("Invalid argument")]
+    InvalidArg,
+    #[error("Empty region")]
+    EmptyRegion,
+    #[error("No space available")]
+    NoSpace,
+    #[error("Requested size exceeds pool capacity")]
+    OutOfMemory,
+    #[error("Overflow")]
+    Overflow,
+}
+
+/// Allocation result
+#[derive(Debug, Clone, Copy)]
+pub struct Allocation {
+    /// Starting address of the allocation
+    pub addr: u64,
+    /// Capacity of the allocation in bytes, rounded up to the allocator's slot size.
+    pub len: usize,
+}
+
+/// Trait for buffer providers.
+pub trait BufferProvider {
+    /// Preferred maximum size of one allocation segment.
+    fn max_alloc_len(&self) -> usize {
+        usize::MAX
+    }
+
+    /// Allocate one buffer that can hold at least `len` bytes.
+    fn alloc(&self, len: usize) -> Result<Allocation, AllocError>;
+
+    /// Free a previously allocated segment by start address.
+    fn dealloc(&self, addr: u64) -> Result<(), AllocError>;
+
+    /// Reset the pool to initial state.
+    fn reset(&self) {}
+
+    /// Allocate scatter/gather segments for a logical payload of `total_len` bytes.
+    fn alloc_sg(&self, total_len: usize) -> Result<SmallVec<[Allocation; 4]>, AllocError> {
+        if total_len == 0 {
+            return Err(AllocError::InvalidArg);
+        }
+
+        let seg_cap = self.max_alloc_len();
+        if seg_cap == 0 {
+            return Err(AllocError::InvalidArg);
+        }
+
+        let mut rem = total_len;
+        let mut sgs = SmallVec::<[Allocation; 4]>::new();
+
+        while rem > 0 {
+            let len = rem.min(seg_cap);
+            match self.alloc(len) {
+                Ok(alloc) => {
+                    sgs.push(alloc);
+                    rem -= len;
+                }
+                Err(err) => {
+                    for sg in sgs {
+                        let _res = self.dealloc(sg.addr);
+                        debug_assert!(_res.is_ok(), "dealloc failed: {_res:?}");
+                    }
+                    return Err(err);
+                }
+            }
+        }
+
+        Ok(sgs)
+    }
+}
+
+impl<T: BufferProvider> BufferProvider for Rc<T> {
+    fn max_alloc_len(&self) -> usize {
+        (**self).max_alloc_len()
+    }
+    fn alloc(&self, len: usize) -> Result<Allocation, AllocError> {
+        (**self).alloc(len)
+    }
+    fn dealloc(&self, addr: u64) -> Result<(), AllocError> {
+        (**self).dealloc(addr)
+    }
+    fn reset(&self) {
+        (**self).reset()
+    }
+    fn alloc_sg(&self, total_len: usize) -> Result<SmallVec<[Allocation; 4]>, AllocError> {
+        (**self).alloc_sg(total_len)
+    }
+}
+
+impl<T: BufferProvider> BufferProvider for Arc<T> {
+    fn max_alloc_len(&self) -> usize {
+        (**self).max_alloc_len()
+    }
+    fn alloc(&self, len: usize) -> Result<Allocation, AllocError> {
+        (**self).alloc(len)
+    }
+    fn dealloc(&self, addr: u64) -> Result<(), AllocError> {
+        (**self).dealloc(addr)
+    }
+    fn reset(&self) {
+        (**self).reset()
+    }
+    fn alloc_sg(&self, total_len: usize) -> Result<SmallVec<[Allocation; 4]>, AllocError> {
+        (**self).alloc_sg(total_len)
+    }
+}
+
+/// Ordered byte segments that make up one virtqueue payload.
+///
+/// This is the high-level counterpart to the descriptor-oriented
+/// [`BufferChain`](super::BufferChain).
+#[derive(Debug, Clone, Default)]
+pub struct Segments(SmallVec<[Bytes; 4]>);
+
+impl Segments {
+    /// Build a segmented payload from ordered byte segments.
+    pub fn new(segments: impl IntoIterator<Item = Bytes>) -> Self {
+        Self(segments.into_iter().collect())
+    }
+
+    /// Build a single-segment payload.
+    pub fn single(segment: Bytes) -> Self {
+        Self(smallvec![segment])
+    }
+
+    pub(crate) fn from_smallvec(segments: SmallVec<[Bytes; 4]>) -> Self {
+        Self(segments)
+    }
+
+    /// Total payload length across all segments.
+    pub fn len(&self) -> usize {
+        self.0.iter().map(Bytes::len).sum()
+    }
+
+    /// Whether the payload contains zero bytes.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Number of byte segments.
+    pub fn segment_count(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Borrow all segments.
+    pub fn as_slice(&self) -> &[Bytes] {
+        &self.0
+    }
+
+    /// Iterate over segments.
+    pub fn iter(&self) -> impl Iterator<Item = &Bytes> {
+        self.0.iter()
+    }
+
+    /// Borrow this payload as a [`Buf`] cursor.
+    pub fn as_buf(&self) -> SegmentsBuf<'_> {
+        SegmentsBuf::new(&self.0, self.len())
+    }
+
+    /// Return this payload as contiguous bytes.
+    ///
+    /// This is O(1) for zero or one segment, and allocates/copies for multiple
+    /// segments.
+    pub fn to_bytes(&self) -> Bytes {
+        match self.0.as_slice() {
+            [] => Bytes::new(),
+            [segment] => segment.clone(),
+            _ => self.collect(&self.0, self.len()),
+        }
+    }
+
+    /// Consume this payload and return contiguous bytes.
+    ///
+    /// This is O(1) for zero or one segment, and allocates/copies for multiple
+    /// segments.
+    pub fn into_bytes(mut self) -> Bytes {
+        match self.0.len() {
+            0 => Bytes::new(),
+            1 => self.0.pop().unwrap_or_default(),
+            _ => self.collect(&self.0, self.len()),
+        }
+    }
+
+    fn collect(&self, sgs: &[Bytes], len: usize) -> Bytes {
+        let mut out = Vec::with_capacity(len);
+        out.extend(sgs.iter().flat_map(|seg| seg.iter().copied()));
+        Bytes::from(out)
+    }
+}
+
+/// Borrowed [`Buf`] cursor over [`Segments`].
+///
+/// Advancing the cursor does not mutate the underlying [`Segments`].
+#[derive(Debug, Clone)]
+pub struct SegmentsBuf<'a> {
+    segments: &'a [Bytes],
+    index: usize,
+    offset: usize,
+    remaining: usize,
+}
+
+impl<'a> SegmentsBuf<'a> {
+    fn new(segments: &'a [Bytes], len: usize) -> Self {
+        let mut this = Self {
+            segments,
+            index: 0,
+            offset: 0,
+            remaining: len,
+        };
+
+        this.skip_empty_segments();
+        this
+    }
+
+    fn skip_empty_segments(&mut self) {
+        while self.index < self.segments.len() && self.offset >= self.segments[self.index].len() {
+            self.index += 1;
+            self.offset = 0;
+        }
+    }
+}
+
+impl Buf for SegmentsBuf<'_> {
+    fn remaining(&self) -> usize {
+        self.remaining
+    }
+
+    fn chunk(&self) -> &[u8] {
+        if self.remaining == 0 {
+            return &[];
+        }
+
+        let segment = self.segments[self.index].as_ref();
+        &segment[self.offset..]
+    }
+
+    fn advance(&mut self, cnt: usize) {
+        assert!(cnt <= self.remaining, "cannot advance past remaining bytes");
+
+        self.remaining -= cnt;
+        let mut cnt = cnt;
+
+        while cnt > 0 {
+            let seg_rem = self.segments[self.index].len() - self.offset;
+            let n = seg_rem.min(cnt);
+            self.offset += n;
+            cnt -= n;
+            self.skip_empty_segments();
+        }
+
+        if self.remaining == 0 {
+            self.index = self.segments.len();
+            self.offset = 0;
+        }
+    }
+}
+
+/// The owner of a mapped buffer, ensuring its lifetime.
+///
+/// Holds an [`OwnedAlloc`] and provides direct access to the underlying
+/// shared memory via [`MemOps::as_slice`]. Implements `AsRef<[u8]>` so it
+/// can be used with [`Bytes::from_owner`](bytes::Bytes::from_owner) for
+/// zero-copy `Bytes` backed by shared memory.
+///
+/// When dropped, the allocation is returned to the pool.
+#[derive(Debug)]
+pub struct BufferOwner<P: BufferProvider, M: MemOps> {
+    pub(crate) mem: M,
+    pub(crate) alloc: OwnedAlloc<P>,
+    pub(crate) written: usize,
+}
+
+impl<P: BufferProvider, M: MemOps> AsRef<[u8]> for BufferOwner<P, M> {
+    fn as_ref(&self) -> &[u8] {
+        let alloc = self.alloc.allocation();
+        let len = self.written.min(alloc.len);
+        // Safety: BufferOwner keeps both the pool allocation and the M alive,
+        // so the memory region is valid.
+        match unsafe { self.mem.as_slice(alloc.addr, len) } {
+            Ok(slice) => slice,
+            Err(_) => {
+                debug_assert!(false, "BufferOwner direct slice failed");
+                &[]
+            }
+        }
+    }
+}
+
+/// Pool-owned allocation that is returned to the pool on drop.
+///
+/// Use [`into_raw`](Self::into_raw) to transfer ownership to a descriptor
+/// state that will deallocate the raw [`Allocation`] through another path.
+#[derive(Debug)]
+pub struct OwnedAlloc<P: BufferProvider> {
+    inner: Option<Inner<P>>,
+}
+
+#[derive(Debug)]
+struct Inner<P: BufferProvider> {
+    pool: P,
+    alloc: Allocation,
+}
+
+impl<P: BufferProvider> OwnedAlloc<P> {
+    /// Wrap an existing allocation with its owning pool.
+    pub fn new(pool: P, alloc: Allocation) -> Self {
+        Self {
+            inner: Some(Inner { pool, alloc }),
+        }
+    }
+
+    /// Allocate from `pool` and return an owning guard.
+    pub fn allocate(pool: P, len: usize) -> Result<Self, AllocError> {
+        let alloc = pool.alloc(len)?;
+        Ok(Self::new(pool, alloc))
+    }
+
+    /// The raw allocation currently owned by this guard.
+    // `inner` is `Some` for the whole lifetime of a live guard: it is only
+    // taken by `into_raw` which consumes `self` or on drop, so this access
+    // cannot fail.
+    #[allow(clippy::expect_used)]
+    pub fn allocation(&self) -> Allocation {
+        self.inner
+            .as_ref()
+            .map(|inner| inner.alloc)
+            .expect("OwnedAlloc::allocation called after ownership transfer")
+    }
+
+    /// Release ownership and return the raw allocation.
+    // `inner` is `Some` until ownership is released, and `into_raw` consumes
+    // `self`, so it can only ever observe `Some` here.
+    #[allow(clippy::expect_used)]
+    pub fn into_raw(mut self) -> Allocation {
+        self.inner
+            .take()
+            .map(|inner| inner.alloc)
+            .expect("OwnedAlloc::into_raw called after ownership transfer")
+    }
+}
+
+impl<P: BufferProvider> Drop for OwnedAlloc<P> {
+    fn drop(&mut self) {
+        if let Some(Inner { pool, alloc }) = self.inner.take() {
+            let result = pool.dealloc(alloc.addr);
+            debug_assert!(result.is_ok(), "OwnedAlloc drop dealloc failed: {result:?}");
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use bytes::Buf;
+
+    use super::*;
+
+    #[test]
+    fn segments_cursor_advances_across_segments() {
+        let segments = Segments::new([
+            Bytes::from_static(b"abc"),
+            Bytes::from_static(b"def"),
+            Bytes::from_static(b"ghi"),
+        ]);
+        let mut cursor = segments.as_buf();
+
+        assert_eq!(cursor.remaining(), 9);
+        assert_eq!(cursor.chunk(), b"abc");
+
+        cursor.advance(2);
+        assert_eq!(cursor.remaining(), 7);
+        assert_eq!(cursor.chunk(), b"c");
+
+        cursor.advance(1);
+        assert_eq!(cursor.chunk(), b"def");
+
+        cursor.advance(4);
+        assert_eq!(cursor.chunk(), b"hi");
+
+        cursor.advance(2);
+        assert_eq!(cursor.remaining(), 0);
+        assert_eq!(cursor.chunk(), b"");
+    }
+
+    #[test]
+    fn segments_cursor_skips_empty_segments() {
+        let segments = Segments::new([
+            Bytes::new(),
+            Bytes::from_static(b"ab"),
+            Bytes::new(),
+            Bytes::from_static(b"cd"),
+            Bytes::new(),
+        ]);
+        let mut cursor = segments.as_buf();
+
+        assert_eq!(cursor.remaining(), 4);
+        assert_eq!(cursor.chunk(), b"ab");
+
+        cursor.advance(2);
+        assert_eq!(cursor.remaining(), 2);
+        assert_eq!(cursor.chunk(), b"cd");
+
+        cursor.advance(2);
+        assert!(!cursor.has_remaining());
+        assert_eq!(cursor.chunk(), b"");
+    }
+
+    #[test]
+    fn segments_cursor_reads_split_header_without_collecting_all_segments() {
+        let segments = Segments::new([
+            Bytes::from_static(&[0x01, 0x02, 0x03]),
+            Bytes::from_static(&[0x04, 0x05]),
+            Bytes::from_static(&[0x06, 0x07, 0x08, 0xff]),
+        ]);
+        let mut cursor = segments.as_buf();
+        let mut header = [0u8; 8];
+
+        cursor.try_copy_to_slice(&mut header).unwrap();
+
+        assert_eq!(header, [0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08]);
+        assert_eq!(cursor.remaining(), 1);
+        assert_eq!(cursor.chunk(), &[0xff]);
+    }
+
+    #[test]
+    fn segments_cursor_copy_to_bytes_collects_only_requested_prefix() {
+        let segments = Segments::new([
+            Bytes::from_static(b"hello"),
+            Bytes::from_static(b" "),
+            Bytes::from_static(b"world"),
+        ]);
+        let mut cursor = segments.as_buf();
+
+        let prefix = cursor.copy_to_bytes(6);
+
+        assert_eq!(prefix.as_ref(), b"hello ");
+        assert_eq!(cursor.remaining(), 5);
+        assert_eq!(cursor.chunk(), b"world");
+    }
+
+    #[test]
+    fn segments_into_bytes_reuses_single_segment() {
+        let segment = Bytes::from(vec![1, 2, 3, 4]);
+        let ptr = segment.as_ptr();
+
+        let collected = Segments::single(segment).into_bytes();
+
+        assert_eq!(collected.as_ptr(), ptr);
+        assert_eq!(collected.as_ref(), &[1, 2, 3, 4]);
+    }
+}

--- a/src/hyperlight_common/src/virtq/concurrency.rs
+++ b/src/hyperlight_common/src/virtq/concurrency.rs
@@ -1,0 +1,540 @@
+/*
+Copyright 2026  The Hyperlight Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! Loom-based concurrency testing for the virtqueue implementation.
+//!
+//! Loom will explores all possible thread interleavings to find data races
+//! and other concurrency bugs. However, it has specific requirements that
+//! make our memory model more involved:
+//!
+//! ## Flag-Based Synchronization
+//!
+//! The virtqueue protocol uses flag-based synchronization:
+//! 1. Producer writes descriptor fields (addr, len, id), then writes flags with release semantics
+//! 2. Consumer reads flags with acquire semantics, then reads descriptor fields
+//!
+//! Loom  would see this as concurrent access to the same memory and report a race, even though
+//! acquire/release on flags provides proper synchronization.
+//!
+//! ## Shadow Atomics for Flags
+//!
+//! We maintain shadow atomics that loom tracks for synchronization:
+//!
+//! - `desc_flags`: One `AtomicU16` per descriptor for flags field
+//! - `drv_flags`: `AtomicU16` for driver event suppression flags
+//! - `dev_flags`: `AtomicU16` for device event suppression flags
+//!
+//! The `load_acquire`/`store_release` operations use these loom atomics, while
+//! `read`/`write` access the underlying data. All shared regions (descriptors,
+//! the event-suppression structs, and the pool) are held in
+//! `loom::cell::UnsafeCell`s, so loom also tracks every data access and verifies
+//! the flag-based synchronization actually orders them race-free.
+//!
+//! ## Memory Regions
+//!
+//! We use a `BTreeMap` to map addresses to memory regions:
+//! - `Desc(idx)`: Individual descriptors in the ring
+//! - `DrvEvt`: Driver event suppression structure
+//! - `DevEvt`: Device event suppression structure
+//! - `Pool`: Buffer pool for chain payload data
+
+use alloc::collections::BTreeMap;
+use alloc::sync::Arc;
+use alloc::vec;
+use core::num::NonZeroU16;
+
+use bytemuck::Zeroable;
+use loom::sync::atomic::{AtomicU16, AtomicUsize, Ordering};
+use loom::thread;
+
+use super::*;
+use crate::virtq::desc::Descriptor;
+use crate::virtq::pool::BufferPoolSync;
+
+#[derive(Debug)]
+pub struct MemErr;
+
+#[derive(Debug, Clone, Copy)]
+enum RegionKind {
+    Desc(usize),
+    DrvEvt,
+    DevEvt,
+    Pool,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct RegionInfo {
+    kind: RegionKind,
+    size: usize,
+}
+
+#[derive(Debug)]
+pub struct LoomMem {
+    // All shared regions live in `loom::cell::UnsafeCell` so loom tracks every
+    // data access and verifies it is race-free.
+    descs: Vec<loom::cell::UnsafeCell<Descriptor>>,
+    drv: loom::cell::UnsafeCell<EventSuppression>,
+    dev: loom::cell::UnsafeCell<EventSuppression>,
+    pool: loom::cell::UnsafeCell<Vec<u8>>,
+
+    desc_flags: Vec<AtomicU16>,
+    drv_flags: AtomicU16,
+    dev_flags: AtomicU16,
+
+    regions: BTreeMap<u64, RegionInfo>,
+    layout: Layout,
+}
+
+unsafe impl Sync for LoomMem {}
+unsafe impl Send for LoomMem {}
+
+impl LoomMem {
+    pub fn new(ring_base: u64, num_descs: usize, pool_base: u64, pool_size: usize) -> Self {
+        let descs_nz = NonZeroU16::new(num_descs as u16).unwrap();
+        let layout = unsafe { Layout::from_base(ring_base, descs_nz).unwrap() };
+
+        let descs: Vec<_> = (0..num_descs)
+            .map(|_| loom::cell::UnsafeCell::new(Descriptor::zeroed()))
+            .collect();
+        let desc_flags: Vec<_> = (0..num_descs).map(|_| AtomicU16::new(0)).collect();
+
+        let mut regions = BTreeMap::new();
+
+        // Register each descriptor as a separate region
+        for i in 0..num_descs {
+            let addr = layout.desc_table_addr() + (i * Descriptor::SIZE) as u64;
+            regions.insert(
+                addr,
+                RegionInfo {
+                    kind: RegionKind::Desc(i),
+                    size: Descriptor::SIZE,
+                },
+            );
+        }
+
+        regions.insert(
+            layout.drv_evt_addr(),
+            RegionInfo {
+                kind: RegionKind::DrvEvt,
+                size: EventSuppression::SIZE,
+            },
+        );
+
+        regions.insert(
+            layout.dev_evt_addr(),
+            RegionInfo {
+                kind: RegionKind::DevEvt,
+                size: EventSuppression::SIZE,
+            },
+        );
+
+        regions.insert(
+            pool_base,
+            RegionInfo {
+                kind: RegionKind::Pool,
+                size: pool_size,
+            },
+        );
+
+        Self {
+            descs,
+            drv: loom::cell::UnsafeCell::new(EventSuppression::zeroed()),
+            dev: loom::cell::UnsafeCell::new(EventSuppression::zeroed()),
+            pool: loom::cell::UnsafeCell::new(vec![0u8; pool_size]),
+            desc_flags,
+            drv_flags: AtomicU16::new(0),
+            dev_flags: AtomicU16::new(0),
+            regions,
+            layout,
+        }
+    }
+
+    pub fn layout(&self) -> Layout {
+        self.layout
+    }
+
+    fn region(&self, addr: u64) -> Option<(RegionInfo, usize)> {
+        let (&base, &info) = self.regions.range(..=addr).next_back()?;
+        let offset = (addr - base) as usize;
+
+        if offset < info.size {
+            Some((info, offset))
+        } else {
+            None
+        }
+    }
+}
+
+unsafe impl MemOps for LoomMem {
+    type Error = MemErr;
+
+    fn read(&self, addr: u64, dst: &mut [u8]) -> Result<(), Self::Error> {
+        let (info, offset) = self.region(addr).ok_or(MemErr)?;
+
+        match info.kind {
+            RegionKind::Desc(idx) => {
+                self.descs[idx].with(|p| {
+                    let bytes = bytemuck::bytes_of(unsafe { &*p });
+                    dst.copy_from_slice(&bytes[offset..offset + dst.len()]);
+                });
+            }
+            RegionKind::DrvEvt => {
+                self.drv.with(|p| {
+                    let bytes = bytemuck::bytes_of(unsafe { &*p });
+                    dst.copy_from_slice(&bytes[offset..offset + dst.len()]);
+                });
+            }
+            RegionKind::DevEvt => {
+                self.dev.with(|p| {
+                    let bytes = bytemuck::bytes_of(unsafe { &*p });
+                    dst.copy_from_slice(&bytes[offset..offset + dst.len()]);
+                });
+            }
+            RegionKind::Pool => {
+                self.pool.with(|buf| {
+                    dst.copy_from_slice(&(unsafe { &*buf })[offset..offset + dst.len()]);
+                });
+            }
+        }
+        Ok(())
+    }
+
+    fn write(&self, addr: u64, src: &[u8]) -> Result<(), Self::Error> {
+        let (info, offset) = self.region(addr).ok_or(MemErr)?;
+
+        match info.kind {
+            RegionKind::Desc(idx) => {
+                self.descs[idx].with_mut(|p| {
+                    let bytes = bytemuck::bytes_of_mut(unsafe { &mut *p });
+                    bytes[offset..offset + src.len()].copy_from_slice(src);
+                });
+            }
+            RegionKind::DrvEvt => {
+                self.drv.with_mut(|p| {
+                    let bytes = bytemuck::bytes_of_mut(unsafe { &mut *p });
+                    bytes[offset..offset + src.len()].copy_from_slice(src);
+                });
+            }
+            RegionKind::DevEvt => {
+                self.dev.with_mut(|p| {
+                    let bytes = bytemuck::bytes_of_mut(unsafe { &mut *p });
+                    bytes[offset..offset + src.len()].copy_from_slice(src);
+                });
+            }
+            RegionKind::Pool => {
+                self.pool.with_mut(|buf| {
+                    (unsafe { &mut *buf })[offset..offset + src.len()].copy_from_slice(src);
+                });
+            }
+        }
+        Ok(())
+    }
+
+    fn load_acquire(&self, addr: u64) -> Result<u16, Self::Error> {
+        let (info, _offset) = self.region(addr).ok_or(MemErr)?;
+
+        Ok(match info.kind {
+            RegionKind::Desc(idx) => self.desc_flags[idx].load(Ordering::Acquire),
+            RegionKind::DrvEvt => self.drv_flags.load(Ordering::Acquire),
+            RegionKind::DevEvt => self.dev_flags.load(Ordering::Acquire),
+            RegionKind::Pool => return Err(MemErr),
+        })
+    }
+
+    fn store_release(&self, addr: u64, val: u16) -> Result<(), Self::Error> {
+        let (info, _offset) = self.region(addr).ok_or(MemErr)?;
+
+        match info.kind {
+            RegionKind::Desc(idx) => self.desc_flags[idx].store(val, Ordering::Release),
+            RegionKind::DrvEvt => self.drv_flags.store(val, Ordering::Release),
+            RegionKind::DevEvt => self.dev_flags.store(val, Ordering::Release),
+            RegionKind::Pool => return Err(MemErr),
+        }
+        Ok(())
+    }
+
+    unsafe fn as_slice(&self, addr: u64, len: usize) -> Result<&[u8], Self::Error> {
+        let (info, offset) = self.region(addr).ok_or(MemErr)?;
+
+        match info.kind {
+            RegionKind::Pool => {
+                let end = offset.checked_add(len).ok_or(MemErr)?;
+                if end > info.size {
+                    return Err(MemErr);
+                }
+                // Safety: pool memory is a contiguous Vec<u8>; caller ensures
+                // no concurrent writes for the lifetime of the returned slice.
+                Ok(self.pool.get().with(|buf| unsafe { &(&*buf)[offset..end] }))
+            }
+            _ => Err(MemErr),
+        }
+    }
+
+    unsafe fn as_mut_slice(&self, addr: u64, len: usize) -> Result<&mut [u8], Self::Error> {
+        let (info, offset) = self.region(addr).ok_or(MemErr)?;
+
+        match info.kind {
+            RegionKind::Pool => {
+                let end = offset.checked_add(len).ok_or(MemErr)?;
+                if end > info.size {
+                    return Err(MemErr);
+                }
+                Ok(self
+                    .pool
+                    .get_mut()
+                    .with(|buf| unsafe { &mut (&mut *buf)[offset..end] }))
+            }
+            _ => Err(MemErr),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct Notify {
+    kicks: AtomicUsize,
+}
+
+impl Notify {
+    pub fn new() -> Self {
+        Self {
+            kicks: AtomicUsize::new(0),
+        }
+    }
+}
+
+impl Notifier for Arc<Notify> {
+    fn notify(&self, _stats: QueueStats) {
+        self.kicks.fetch_add(1, Ordering::Relaxed);
+    }
+}
+
+#[test]
+fn virtq_ping_pong() {
+    loom::model(|| {
+        let ring_base = 0x10000;
+        let pool_base = 0x40000;
+        let pool_size = 0x10000;
+
+        let mem = Arc::new(LoomMem::new(ring_base, 8, pool_base, pool_size));
+        let pool = BufferPoolSync::<256, 4096>::new(pool_base, pool_size).unwrap();
+        let notify = Arc::new(Notify::new());
+
+        let mut prod = VirtqProducer::new(mem.layout(), mem.clone(), notify.clone(), pool);
+        let mut cons = VirtqConsumer::new(mem.layout(), mem.clone(), notify.clone());
+
+        let t_prod = thread::spawn(move || {
+            let mut se = prod.chain().readable(4).writable(32).build().unwrap();
+            se.write_all(b"ping").unwrap();
+            let tok = prod.submit(se).unwrap();
+            loop {
+                if let Some(r) = prod.poll().unwrap() {
+                    assert_eq!(r.token(), tok);
+                    assert_eq!(r.to_bytes().unwrap().as_ref(), b"pong");
+                    break;
+                }
+                thread::yield_now();
+            }
+        });
+
+        let t_cons = thread::spawn(move || {
+            let (recv, reply) = loop {
+                if let Some(r) = cons.poll(1024).unwrap() {
+                    break r;
+                }
+                thread::yield_now();
+            };
+            assert_eq!(recv.to_bytes().as_ref(), b"ping");
+            let ReplyChain::Writable(mut wc) = reply else {
+                panic!("expected writable reply");
+            };
+            wc.write_all(b"pong").unwrap();
+            cons.complete(wc).unwrap();
+        });
+
+        t_prod.join().unwrap();
+        t_cons.join().unwrap();
+    });
+}
+
+#[test]
+fn virtq_ack_only() {
+    loom::model(|| {
+        let ring_base = 0x10000;
+        let pool_base = 0x40000;
+        let pool_size = 0x10000;
+
+        let mem = Arc::new(LoomMem::new(ring_base, 4, pool_base, pool_size));
+        let pool = BufferPoolSync::<256, 4096>::new(pool_base, pool_size).unwrap();
+        let notify = Arc::new(Notify::new());
+
+        let mut prod = VirtqProducer::new(mem.layout(), mem.clone(), notify.clone(), pool);
+        let mut cons = VirtqConsumer::new(mem.layout(), mem.clone(), notify.clone());
+
+        let t_prod = thread::spawn(move || {
+            let mut se = prod.chain().readable(4).build().unwrap();
+            se.write_all(b"ping").unwrap();
+            let tok = prod.submit(se).unwrap();
+            loop {
+                if let Some(r) = prod.poll().unwrap() {
+                    assert!(matches!(r, UsedChain::Ack(t) if t == tok));
+                    break;
+                }
+                thread::yield_now();
+            }
+        });
+
+        let t_cons = thread::spawn(move || {
+            let (recv, reply) = loop {
+                if let Some(r) = cons.poll(1024).unwrap() {
+                    break r;
+                }
+                thread::yield_now();
+            };
+            assert_eq!(recv.to_bytes().as_ref(), b"ping");
+            assert!(matches!(reply, ReplyChain::Ack(_)));
+            cons.complete(reply).unwrap();
+        });
+
+        t_prod.join().unwrap();
+        t_cons.join().unwrap();
+    });
+}
+
+#[test]
+fn virtq_out_of_order_completions() {
+    loom::model(|| {
+        let ring_base = 0x10000;
+        let pool_base = 0x40000;
+        let pool_size = 0x10000;
+
+        let mem = Arc::new(LoomMem::new(ring_base, 8, pool_base, pool_size));
+        let pool = BufferPoolSync::<256, 4096>::new(pool_base, pool_size).unwrap();
+        let notify = Arc::new(Notify::new());
+
+        let mut prod = VirtqProducer::new(mem.layout(), mem.clone(), notify.clone(), pool);
+        let mut cons = VirtqConsumer::new(mem.layout(), mem.clone(), notify.clone());
+        let submitted = Arc::new(AtomicUsize::new(0));
+        let submitted_for_consumer = submitted.clone();
+
+        let t_prod = thread::spawn(move || {
+            let mut first = prod.chain().readable(5).writable(8).build().unwrap();
+            first.write_all(b"first").unwrap();
+            let tok1 = prod.submit(first).unwrap();
+
+            let mut second = prod.chain().readable(6).writable(8).build().unwrap();
+            second.write_all(b"second").unwrap();
+            let tok2 = prod.submit(second).unwrap();
+            submitted.store(1, Ordering::Release);
+
+            let mut got_first = false;
+            let mut got_second = false;
+            while !(got_first && got_second) {
+                if let Some(r) = prod.poll().unwrap() {
+                    let token = r.token();
+                    let bytes = r.to_bytes().unwrap();
+                    if token == tok1 {
+                        assert!(bytes.is_empty());
+                        got_first = true;
+                    } else if token == tok2 {
+                        assert!(bytes.is_empty());
+                        got_second = true;
+                    } else {
+                        panic!("unexpected token");
+                    }
+                } else {
+                    thread::yield_now();
+                }
+            }
+        });
+
+        let t_cons = thread::spawn(move || {
+            while submitted_for_consumer.load(Ordering::Acquire) == 0 {
+                thread::yield_now();
+            }
+
+            let (recv1, reply1) = loop {
+                if let Some(r) = cons.poll(1024).unwrap() {
+                    break r;
+                }
+                thread::yield_now();
+            };
+            assert_eq!(recv1.to_bytes().as_ref(), b"first");
+
+            let (recv2, reply2) = loop {
+                if let Some(r) = cons.poll(1024).unwrap() {
+                    break r;
+                }
+                thread::yield_now();
+            };
+            assert_eq!(recv2.to_bytes().as_ref(), b"second");
+
+            let ReplyChain::Writable(second) = reply2 else {
+                panic!("expected writable reply");
+            };
+            cons.complete(second).unwrap();
+
+            let ReplyChain::Writable(first) = reply1 else {
+                panic!("expected writable reply");
+            };
+            cons.complete(first).unwrap();
+        });
+
+        t_prod.join().unwrap();
+        t_cons.join().unwrap();
+    });
+}
+
+/// Exercise concurrent access to an event-suppression structure.
+///
+/// The producer publishing a chain reads the device event-suppression struct
+/// (in `should_notify_device`) at the same time the consumer reconfigures that
+/// same struct via `set_avail_suppression`. Descriptor mode writes the
+/// `off_wrap` payload, so this stresses the flag-first event-suppression read:
+/// the notify decision must acquire the flags before touching `off_wrap`, or the
+/// read races the consumer's publish. Loom verifies no such race exists.
+#[test]
+fn virtq_event_suppression_reconfig() {
+    loom::model(|| {
+        let ring_base = 0x10000;
+        let pool_base = 0x40000;
+        let pool_size = 0x10000;
+
+        let mem = Arc::new(LoomMem::new(ring_base, 4, pool_base, pool_size));
+        let pool = BufferPoolSync::<256, 4096>::new(pool_base, pool_size).unwrap();
+        let notify = Arc::new(Notify::new());
+
+        let mut prod = VirtqProducer::new(mem.layout(), mem.clone(), notify.clone(), pool);
+        let mut cons = VirtqConsumer::new(mem.layout(), mem.clone(), notify.clone());
+
+        // Descriptor-mode suppression writes the `off_wrap` field that the
+        // producer's notify decision may read concurrently.
+        let cursor = cons.avail_cursor();
+
+        let t_cons = thread::spawn(move || {
+            cons.set_avail_suppression(SuppressionKind::Descriptor(cursor))
+                .unwrap();
+        });
+
+        let t_prod = thread::spawn(move || {
+            let mut se = prod.chain().readable(4).build().unwrap();
+            se.write_all(b"ping").unwrap();
+            prod.submit(se).unwrap();
+        });
+
+        t_cons.join().unwrap();
+        t_prod.join().unwrap();
+    });
+}

--- a/src/hyperlight_common/src/virtq/consumer.rs
+++ b/src/hyperlight_common/src/virtq/consumer.rs
@@ -1,0 +1,857 @@
+/*
+Copyright 2026  The Hyperlight Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use alloc::vec;
+
+use bytes::Bytes;
+use fixedbitset::FixedBitSet;
+use smallvec::SmallVec;
+
+use super::*;
+
+type WritableElems = SmallVec<[BufferElement; 2]>;
+
+/// Payload received from the producer, safely copied out of shared memory.
+///
+/// Created by [`VirtqConsumer::poll`]. Device-readable segments are eagerly
+/// copied during poll using [`MemOps::read`] (volatile on the host side), so
+/// accessing data requires no unsafe code and no references into shared
+/// memory. Segment boundaries are preserved in [`Segments`].
+#[derive(Debug, Clone)]
+pub struct RecvChain {
+    token: Token,
+    segments: Segments,
+}
+
+impl RecvChain {
+    /// The token identifying this chain.
+    pub fn token(&self) -> Token {
+        self.token
+    }
+
+    /// The chain payload as ordered byte segments.
+    pub fn segments(&self) -> &Segments {
+        &self.segments
+    }
+
+    /// Consume the chain, taking ownership of the segments.
+    pub fn into_segments(self) -> Segments {
+        self.segments
+    }
+
+    /// Return the chain payload as contiguous bytes.
+    ///
+    /// Returns empty [`Bytes`] when the chain has no readable buffers.
+    pub fn to_bytes(&self) -> Bytes {
+        self.segments.to_bytes()
+    }
+
+    /// Consume the chain and return the payload as contiguous bytes.
+    pub fn into_bytes(self) -> Bytes {
+        self.segments.into_bytes()
+    }
+}
+
+/// Consumer-side chain reply, either writable or ack-only.
+///
+/// Created by [`VirtqConsumer::poll`]. Must be submitted back via
+/// [`VirtqConsumer::complete`] to release the descriptor.
+#[must_use = "dropping without completing leaks the descriptor"]
+pub enum ReplyChain<M: MemOps> {
+    /// Reply with writable buffer capacity.
+    /// Use the `write*` methods on [`WritableChain`] to fill the
+    /// response buffer.
+    Writable(WritableChain<M>),
+    /// Ack-only reply (for chains with only readable buffers). No response buffer.
+    /// Just pass back to [`VirtqConsumer::complete`] to acknowledge.
+    Ack(AckChain),
+}
+
+impl<M: MemOps> ReplyChain<M> {
+    /// The token identifying this reply.
+    pub fn token(&self) -> Token {
+        match self {
+            ReplyChain::Writable(wc) => wc.token(),
+            ReplyChain::Ack(ack) => ack.token(),
+        }
+    }
+
+    /// Number of bytes written (0 for Ack).
+    pub fn written(&self) -> usize {
+        match self {
+            ReplyChain::Writable(wc) => wc.written,
+            ReplyChain::Ack(_) => 0,
+        }
+    }
+
+    /// Convert into the writable form.
+    ///
+    /// Returns the [`AckChain`] unchanged as `Err` for ack-only replies, so the
+    /// completion capability is never silently dropped.
+    pub fn into_writable(self) -> Result<WritableChain<M>, AckChain> {
+        match self {
+            ReplyChain::Writable(wc) => Ok(wc),
+            ReplyChain::Ack(ack) => Err(ack),
+        }
+    }
+}
+
+/// A reply chain with writable buffer capacity.
+///
+/// # Example
+///
+/// ```ignore
+/// if let ReplyChain::Writable(mut wc) = reply {
+///     wc.write_all(b"response data")?;
+///     consumer.complete(wc)?;
+/// }
+/// ```
+#[must_use = "dropping without completing leaks the descriptor"]
+pub struct WritableChain<M: MemOps> {
+    mem: M,
+    token: Token,
+    elems: WritableElems,
+    capacity: usize,
+    written: usize,
+}
+
+impl<M: MemOps> WritableChain<M> {
+    fn new(mem: M, token: Token, elems: WritableElems) -> Self {
+        let capacity = elems.iter().map(|elem| elem.len as usize).sum();
+        Self {
+            mem,
+            token,
+            elems,
+            capacity,
+            written: 0,
+        }
+    }
+
+    /// The token identifying this writable reply.
+    pub fn token(&self) -> Token {
+        self.token
+    }
+
+    /// Total reply capacity in bytes.
+    pub fn capacity(&self) -> usize {
+        self.capacity
+    }
+
+    /// Number of bytes written so far.
+    pub fn written(&self) -> usize {
+        self.written
+    }
+
+    /// Remaining reply capacity.
+    pub fn remaining(&self) -> usize {
+        self.capacity() - self.written()
+    }
+
+    /// Write bytes into writable buffers, returning how many were written.
+    ///
+    /// Appends at the current write position. If `buf` is larger than the
+    /// remaining capacity, writes as many bytes as will fit (partial write).
+    /// Segmentation is intentionally hidden; host-side writes must go through
+    /// [`MemOps::write`].
+    ///
+    /// # Errors
+    ///
+    /// - [`VirtqError::MemoryWriteError`] - underlying MemOps write failed
+    pub fn write(&mut self, buf: &[u8]) -> Result<usize, VirtqError> {
+        let written = write_elements(&self.mem, &self.elems, self.written, buf)
+            .map_err(|_| VirtqError::MemoryWriteError)?;
+        self.written += written;
+        Ok(written)
+    }
+
+    /// Write the entire buffer or return an error.
+    ///
+    /// # Errors
+    ///
+    /// - [`VirtqError::ReplyTooLarge`] - buf exceeds remaining capacity
+    /// - [`VirtqError::MemoryWriteError`] - underlying MemOps write failed
+    pub fn write_all(&mut self, buf: &[u8]) -> Result<&mut Self, VirtqError> {
+        if buf.len() > self.remaining() {
+            return Err(VirtqError::ReplyTooLarge);
+        }
+
+        let written = self.write(buf)?;
+        debug_assert_eq!(written, buf.len());
+        Ok(self)
+    }
+
+    /// Rewind the write cursor to the beginning.
+    ///
+    /// Previously written bytes in shared memory are not zeroed; the
+    /// `written` count is simply reset to 0.
+    pub fn rewind(&mut self) {
+        self.written = 0;
+    }
+}
+
+/// An ack-only reply for chains with no writable buffers.
+///
+/// No response buffer - just pass back to [`VirtqConsumer::complete`]
+/// to acknowledge processing and release the descriptor.
+/// This wrapper keeps ack replies as a must-use completion capability instead
+/// of exposing a bare token that could be accidentally ignored.
+#[must_use = "dropping without completing leaks the descriptor"]
+pub struct AckChain {
+    token: Token,
+}
+
+impl AckChain {
+    fn new(token: Token) -> Self {
+        Self { token }
+    }
+
+    pub fn token(&self) -> Token {
+        self.token
+    }
+}
+
+/// A high-level virtqueue consumer (device side).
+///
+/// The consumer receives chains from the producer (driver), processes them,
+/// and sends back replies. This is typically used on the device/host side.
+///
+/// # Example
+///
+/// ```ignore
+/// let mut consumer = VirtqConsumer::new(layout, mem, notifier);
+///
+/// // Poll and process
+/// while let Some((chain, reply)) = consumer.poll(MAX_RECV_LEN)? {
+///     let data = chain.to_bytes();
+///     match reply {
+///         ReplyChain::Writable(mut wc) => {
+///             let response = handle_request(data);
+///             wc.write_all(&response)?;
+///             consumer.complete(wc)?;
+///         }
+///         ReplyChain::Ack(ack) => {
+///             consumer.complete(ack)?;
+///         }
+///     }
+/// }
+///
+/// // Or defer completions
+/// let mut pending = Vec::new();
+/// while let Some((chain, reply)) = consumer.poll(MAX_RECV_LEN)? {
+///     pending.push((process(chain), reply));
+/// }
+///
+/// for (result, reply) in pending {
+///     // ... complete later ...
+///     consumer.complete(reply)?;
+/// }
+/// ```
+pub struct VirtqConsumer<M, N> {
+    inner: RingConsumer<M>,
+    notifier: N,
+    inflight: FixedBitSet,
+    next_token: u32,
+}
+
+impl<M: MemOps + Clone, N: Notifier> VirtqConsumer<M, N> {
+    /// Create a new virtqueue consumer.
+    ///
+    /// # Arguments
+    ///
+    /// * `layout` - Ring memory layout
+    /// * `mem` - Memory ops implementation for reading/writing to shared memory
+    /// * `notifier` - Callback for notifying the driver about replies
+    pub fn new(layout: Layout, mem: M, notifier: N) -> Self {
+        let inner = RingConsumer::new(layout, mem);
+        let inflight = FixedBitSet::with_capacity(inner.len());
+
+        Self {
+            inner,
+            notifier,
+            inflight,
+            next_token: 0,
+        }
+    }
+
+    /// Poll for a single incoming chain from the driver.
+    ///
+    /// Returns a [`RecvChain`] (copied data) and a [`ReplyChain`] (writable reply
+    /// capacity or ack token). Both are independent owned values with no borrow
+    /// on the consumer.
+    ///
+    /// On [`VirtqError::BadChain`], [`VirtqError::PayloadTooLarge`], and
+    /// [`VirtqError::MemoryReadError`] the descriptor is returned to the driver
+    /// (completed with zero length) before the error is propagated, so a
+    /// rejected chain does not leak.
+    ///
+    /// # Arguments
+    ///
+    /// * `max_recv_len` - Maximum receive payload size to copy. Payloads larger
+    ///   than this return [`VirtqError::PayloadTooLarge`].
+    ///
+    /// # Errors
+    ///
+    /// - [`VirtqError::BadChain`] - Descriptor chain format not recognized
+    /// - [`VirtqError::InvalidState`] - Descriptor ID collision (driver bug)
+    /// - [`VirtqError::MemoryReadError`] - Failed to read chain payload from shared memory
+    pub fn poll(
+        &mut self,
+        max_recv_len: usize,
+    ) -> Result<Option<(RecvChain, ReplyChain<M>)>, VirtqError> {
+        let (id, chain) = match self.inner.poll_available() {
+            Ok(x) => x,
+            Err(RingError::WouldBlock) => return Ok(None),
+            Err(e) => return Err(e.into()),
+        };
+
+        let readables = chain.readables();
+        let writables = chain.writables();
+        if readables.is_empty() && writables.is_empty() {
+            return Err(self.abort_chain(id, VirtqError::BadChain));
+        }
+
+        let recv_len = readables
+            .iter()
+            .fold(0usize, |acc, elem| acc.saturating_add(elem.len as usize));
+
+        // Reserve the inflight slot
+        let id_idx = id as usize;
+        if id_idx >= self.inflight.len() {
+            return Err(VirtqError::InvalidState);
+        }
+
+        if self.inflight.contains(id_idx) {
+            return Err(VirtqError::InvalidState);
+        }
+
+        self.inflight.insert(id_idx);
+        let token = Token {
+            seq: self.next_token,
+            id,
+        };
+        self.next_token = self.next_token.wrapping_add(1);
+
+        if recv_len > max_recv_len {
+            return Err(self.abort_chain(
+                id,
+                VirtqError::PayloadTooLarge {
+                    recv: recv_len,
+                    limit: max_recv_len,
+                },
+            ));
+        }
+
+        // Copy chain payload from shared memory
+        let data = match self.read_elements(readables) {
+            Ok(d) => d,
+            Err(e) => return Err(self.abort_chain(id, e)),
+        };
+
+        let chain = RecvChain {
+            token,
+            segments: data,
+        };
+
+        let reply = if !writables.is_empty() {
+            let mem = self.inner.mem().clone();
+            let writable = WritableChain::new(mem, token, writables.iter().copied().collect());
+            ReplyChain::Writable(writable)
+        } else {
+            let ack = AckChain::new(token);
+            ReplyChain::Ack(ack)
+        };
+
+        Ok(Some((chain, reply)))
+    }
+
+    /// Submit a reply/ack for a received chain back to the ring.
+    ///
+    /// Accepts both [`WritableChain`] (with written byte count) and
+    /// [`AckChain`] (zero-length) via the [`ReplyChain`] enum.
+    /// Clears the inflight slot and notifies the producer if event
+    /// suppression allows.
+    pub fn complete(&mut self, reply: impl Into<ReplyChain<M>>) -> Result<(), VirtqError> {
+        let reply = reply.into();
+        let id = reply.token().id;
+        let written = reply.written() as u32;
+
+        let id_idx = id as usize;
+        let slot_set = id_idx < self.inflight.len() && self.inflight.contains(id_idx);
+        if !slot_set {
+            return Err(VirtqError::InvalidState);
+        }
+
+        self.inflight.set(id_idx, false);
+
+        if self.inner.submit_used_with_notify(id, written)? {
+            self.notifier.notify(QueueStats {
+                num_free: self.inner.num_free(),
+                num_inflight: self.inner.num_inflight(),
+            });
+        }
+
+        Ok(())
+    }
+
+    /// Return a consumed descriptor to the driver with zero written length.
+    ///
+    /// The ring's `poll_available` removes the descriptor from the available
+    /// ring before [`poll`](Self::poll) validates the chain.
+    fn abort_chain(&mut self, id: u16, err: VirtqError) -> VirtqError {
+        let id_idx = id as usize;
+        if id_idx < self.inflight.len() {
+            self.inflight.set(id_idx, false);
+        }
+
+        // Best effort: failing to return the descriptor means the ring is
+        // already in an unrecoverable state, so surface the original error.
+        if let Ok(true) = self.inner.submit_used_with_notify(id, 0) {
+            self.notifier.notify(QueueStats {
+                num_free: self.inner.num_free(),
+                num_inflight: self.inner.num_inflight(),
+            });
+        }
+
+        err
+    }
+
+    /// Get the current available cursor position.
+    ///
+    /// Returns the position where the next available descriptor will be
+    /// consumed. Useful for setting up descriptor-based event suppression.
+    #[inline]
+    pub fn avail_cursor(&self) -> RingCursor {
+        self.inner.avail_cursor()
+    }
+
+    /// Get the current used cursor position.
+    ///
+    /// Returns the position where the next used descriptor will be written.
+    /// Useful for setting up descriptor-based event suppression.
+    #[inline]
+    pub fn used_cursor(&self) -> RingCursor {
+        self.inner.used_cursor()
+    }
+
+    /// Configure event suppression for available buffer notifications.
+    ///
+    /// This controls when the driver (producer) signals us about new buffers:
+    ///
+    /// - [`SuppressionKind::Enable`] - Always signal (default) - good for latency
+    /// - [`SuppressionKind::Disable`] - Never signal - caller must poll
+    /// - [`SuppressionKind::Descriptor`] - Signal only at specific cursor position
+    ///
+    /// # Example: Polling Mode
+    /// ```ignore
+    /// consumer.set_avail_suppression(SuppressionKind::Disable)?;
+    /// loop {
+    ///     while let Some((chain, reply)) = consumer.poll(1024)? {
+    ///         process(chain, reply);
+    ///     }
+    ///     // ... do other work ...
+    /// }
+    /// ```
+    pub fn set_avail_suppression(&mut self, kind: SuppressionKind) -> Result<(), VirtqError> {
+        match kind {
+            SuppressionKind::Enable => self.inner.enable_avail_notifications()?,
+            SuppressionKind::Disable => self.inner.disable_avail_notifications()?,
+            SuppressionKind::Descriptor(cursor) => self
+                .inner
+                .enable_avail_notifications_desc(cursor.head(), cursor.wrap())?,
+        }
+        Ok(())
+    }
+
+    /// Read readable buffer elements from shared memory into `Bytes`.
+    fn read_elements(&self, elems: &[BufferElement]) -> Result<Segments, VirtqError> {
+        let mut segments = SmallVec::<[Bytes; 4]>::new();
+
+        for elem in elems {
+            let mut buf = vec![0u8; elem.len as usize];
+            self.inner
+                .mem()
+                .read(elem.addr, &mut buf)
+                .map_err(|_| VirtqError::MemoryReadError)?;
+            segments.push(Bytes::from(buf));
+        }
+
+        Ok(Segments::from_smallvec(segments))
+    }
+
+    /// Reset ring and inflight state to initial values.
+    pub fn reset(&mut self) {
+        self.inner.reset();
+        self.inflight.clear();
+    }
+}
+
+fn write_elements<M: MemOps>(
+    mem: &M,
+    elems: &[BufferElement],
+    offset: usize,
+    buf: &[u8],
+) -> Result<usize, M::Error> {
+    let capacity: usize = elems.iter().map(|elem| elem.len as usize).sum();
+    let mut src = &buf[..buf.len().min(capacity.saturating_sub(offset))];
+    let mut written = 0;
+    let mut skip = offset;
+
+    for elem in elems {
+        if src.is_empty() {
+            break;
+        }
+
+        let elem_len = elem.len as usize;
+        if skip >= elem_len {
+            skip -= elem_len;
+            continue;
+        }
+
+        let elem_offset = skip;
+        skip = 0;
+        let n = (elem_len - elem_offset).min(src.len());
+        let addr = elem.addr + elem_offset as u64;
+
+        mem.write(addr, &src[..n])?;
+
+        written += n;
+        src = &src[n..];
+    }
+
+    Ok(written)
+}
+
+impl<M: MemOps> From<WritableChain<M>> for ReplyChain<M> {
+    fn from(wc: WritableChain<M>) -> Self {
+        ReplyChain::Writable(wc)
+    }
+}
+
+impl<M: MemOps> From<AckChain> for ReplyChain<M> {
+    fn from(ack: AckChain) -> Self {
+        ReplyChain::Ack(ack)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::virtq::ring::tests::{make_producer, make_ring};
+    use crate::virtq::test_utils::*;
+
+    fn poll_data(
+        consumer: &mut VirtqConsumer<crate::virtq::ring::tests::TestMem, TestNotifier>,
+    ) -> (RecvChain, ReplyChain<crate::virtq::ring::tests::TestMem>) {
+        consumer.poll(1024).unwrap().unwrap()
+    }
+
+    #[test]
+    fn test_write_only_recv_is_empty() {
+        let ring = make_ring(16);
+        let (mut producer, mut consumer, _notifier) = make_test_producer(&ring);
+
+        let se = producer.chain().writable(16).build().unwrap();
+        producer.submit(se).unwrap();
+
+        let (recv, reply) = poll_data(&mut consumer);
+        assert!(recv.to_bytes().is_empty());
+        assert!(matches!(reply, ReplyChain::Writable(_)));
+
+        if let ReplyChain::Writable(mut wc) = reply {
+            wc.write_all(b"response").unwrap();
+            consumer.complete(wc).unwrap();
+        }
+    }
+
+    #[test]
+    fn test_read_only_ack_reply() {
+        let ring = make_ring(16);
+        let (mut producer, mut consumer, _notifier) = make_test_producer(&ring);
+
+        let mut se = producer.chain().readable(16).build().unwrap();
+        se.write_all(b"hello").unwrap();
+        producer.submit(se).unwrap();
+
+        let (recv, reply) = poll_data(&mut consumer);
+        assert_eq!(recv.to_bytes().as_ref(), b"hello");
+        assert!(matches!(reply, ReplyChain::Ack(_)));
+
+        consumer.complete(reply).unwrap();
+    }
+
+    #[test]
+    fn test_readwrite_round_trip() {
+        let ring = make_ring(16);
+        let (mut producer, mut consumer, _notifier) = make_test_producer(&ring);
+
+        let mut se = producer.chain().readable(32).writable(64).build().unwrap();
+        se.write_all(b"hello world").unwrap();
+        producer.submit(se).unwrap();
+
+        let (recv, reply) = poll_data(&mut consumer);
+        assert_eq!(recv.to_bytes().as_ref(), b"hello world");
+
+        if let ReplyChain::Writable(mut wc) = reply {
+            assert_eq!(wc.capacity(), 64);
+            assert_eq!(wc.written(), 0);
+            assert_eq!(wc.remaining(), 64);
+            wc.write_all(b"response").unwrap();
+            assert_eq!(wc.written(), 8);
+            assert_eq!(wc.remaining(), 56);
+            consumer.complete(wc).unwrap();
+        } else {
+            panic!("expected Writable reply for recv+reply chain");
+        }
+    }
+
+    #[test]
+    fn test_writable_partial_write() {
+        let ring = make_ring(16);
+        let (mut producer, mut consumer, _notifier) = make_test_producer(&ring);
+
+        let se = producer.chain().writable(8).build().unwrap();
+        producer.submit(se).unwrap();
+
+        let (_recv, reply) = poll_data(&mut consumer);
+
+        if let ReplyChain::Writable(mut wc) = reply {
+            let n = wc.write(b"hello world!").unwrap();
+            assert_eq!(n, 8);
+            assert_eq!(wc.remaining(), 0);
+            consumer.complete(wc).unwrap();
+        } else {
+            panic!("expected Writable");
+        }
+    }
+
+    #[test]
+    fn test_writable_write_all_too_large() {
+        let ring = make_ring(16);
+        let (mut producer, mut consumer, _notifier) = make_test_producer(&ring);
+
+        let se = producer.chain().writable(4).build().unwrap();
+        producer.submit(se).unwrap();
+        let (_recv, reply) = poll_data(&mut consumer);
+
+        if let ReplyChain::Writable(mut wc) = reply {
+            let err = wc.write_all(b"too long").err().unwrap();
+            assert!(matches!(err, VirtqError::ReplyTooLarge));
+        } else {
+            panic!("expected Writable");
+        }
+    }
+
+    #[test]
+    fn test_poll_too_large_returns_payload_error() {
+        let ring = make_ring(16);
+        let (mut producer, mut consumer, _notifier) = make_test_producer(&ring);
+
+        let mut se = producer.chain().readable(8).writable(16).build().unwrap();
+        se.write_all(b"too much").unwrap();
+        producer.submit(se).unwrap();
+
+        assert!(matches!(
+            consumer.poll(4),
+            Err(VirtqError::PayloadTooLarge { recv: 8, limit: 4 })
+        ));
+    }
+
+    #[test]
+    fn test_poll_too_large_returns_descriptor() {
+        let ring = make_ring(16);
+        let (mut producer, mut consumer, _notifier) = make_test_producer(&ring);
+
+        let mut se = producer.chain().readable(8).writable(16).build().unwrap();
+        se.write_all(b"too much").unwrap();
+        let token = producer.submit(se).unwrap();
+
+        // Oversized payload is rejected, but the descriptor must be returned to
+        // the driver so the ring slot is not leaked.
+        assert!(matches!(
+            consumer.poll(4),
+            Err(VirtqError::PayloadTooLarge { recv: 8, limit: 4 })
+        ));
+
+        // The producer can reclaim the rejected chain; the queue is not wedged.
+        let used = producer.poll().unwrap().unwrap();
+        assert_eq!(used.token(), token);
+
+        // A subsequent normal exchange still round-trips end to end.
+        let se2 = producer.chain().writable(16).build().unwrap();
+        producer.submit(se2).unwrap();
+        let (_recv, reply) = poll_data(&mut consumer);
+        consumer.complete(reply).unwrap();
+        assert!(producer.poll().unwrap().is_some());
+    }
+
+    #[test]
+    fn test_writable_chain_writes_single_segment() {
+        let ring = make_ring(16);
+        let (mut producer, mut consumer, _notifier) = make_test_producer(&ring);
+
+        let se = producer.chain().writable(16).build().unwrap();
+        producer.submit(se).unwrap();
+        let (_recv, reply) = poll_data(&mut consumer);
+
+        let ReplyChain::Writable(mut wc) = reply else {
+            panic!("expected Writable");
+        };
+        wc.write_all(b"hello").unwrap();
+        consumer.complete(wc).unwrap();
+
+        let used = producer.poll().unwrap().unwrap();
+        assert_eq!(used.to_bytes().unwrap().as_ref(), b"hello");
+    }
+
+    #[test]
+    fn test_writable_rewind() {
+        let ring = make_ring(16);
+        let (mut producer, mut consumer, _notifier) = make_test_producer(&ring);
+
+        let se = producer.chain().writable(16).build().unwrap();
+        producer.submit(se).unwrap();
+
+        let (_recv, reply) = poll_data(&mut consumer);
+
+        if let ReplyChain::Writable(mut wc) = reply {
+            wc.write_all(b"first").unwrap();
+            assert_eq!(wc.written(), 5);
+            wc.rewind();
+            assert_eq!(wc.written(), 0);
+            assert_eq!(wc.remaining(), 16);
+            wc.write_all(b"second").unwrap();
+            assert_eq!(wc.written(), 6);
+            consumer.complete(wc).unwrap();
+        } else {
+            panic!("expected Writable");
+        }
+    }
+
+    #[test]
+    fn test_writable_reply_scatters_across_segments() {
+        let ring = make_ring(16);
+        let mem = ring.mem();
+        let mut ring_producer = make_producer(&ring);
+        let mut consumer = VirtqConsumer::new(ring.layout(), mem.clone(), TestNotifier::new());
+
+        let base = mem.base_addr() + Layout::query_size(ring.len()) as u64 + 0x100;
+        let chain = BufferChainBuilder::new()
+            .writable(base, 4)
+            .writable(base + 4, 4)
+            .build()
+            .unwrap();
+        let id = ring_producer.submit_available(&chain).unwrap();
+
+        let (recv, reply) = poll_data(&mut consumer);
+        assert!(recv.to_bytes().is_empty());
+
+        let ReplyChain::Writable(mut wc) = reply else {
+            panic!("expected Writable");
+        };
+        assert_eq!(wc.capacity(), 8);
+        wc.write_all(b"abcdefgh").unwrap();
+        assert_eq!(wc.written(), 8);
+        consumer.complete(wc).unwrap();
+
+        let mut first = [0u8; 4];
+        let mut second = [0u8; 4];
+        mem.read(base, &mut first).unwrap();
+        mem.read(base + 4, &mut second).unwrap();
+        assert_eq!(&first, b"abcd");
+        assert_eq!(&second, b"efgh");
+
+        let used = ring_producer.poll_used().unwrap();
+        assert_eq!(used.id, id);
+        assert_eq!(used.len, 8);
+    }
+
+    #[test]
+    fn test_multiple_pending_replies() {
+        let ring = make_ring(16);
+        let (mut producer, mut consumer, _notifier) = make_test_producer(&ring);
+
+        let se1 = producer.chain().writable(16).build().unwrap();
+        producer.submit(se1).unwrap();
+        let se2 = producer.chain().writable(16).build().unwrap();
+        producer.submit(se2).unwrap();
+
+        let (_e1, c1) = poll_data(&mut consumer);
+        let (_e2, c2) = poll_data(&mut consumer);
+
+        // Complete in reverse order
+        consumer.complete(c2).unwrap();
+        consumer.complete(c1).unwrap();
+    }
+
+    #[test]
+    fn test_recv_into_bytes() {
+        let ring = make_ring(16);
+        let (mut producer, mut consumer, _notifier) = make_test_producer(&ring);
+
+        let mut se = producer.chain().readable(16).build().unwrap();
+        se.write_all(b"abc").unwrap();
+        producer.submit(se).unwrap();
+
+        let (recv, reply) = poll_data(&mut consumer);
+        let data = recv.into_bytes();
+        assert_eq!(data.as_ref(), b"abc");
+        consumer.complete(reply).unwrap();
+    }
+
+    #[test]
+    fn test_virtq_consumer_reset() {
+        let ring = make_ring(16);
+        let (mut producer, mut consumer, _notifier) = make_test_producer(&ring);
+
+        // Submit and poll (but do not complete)
+        let se = producer.chain().writable(16).build().unwrap();
+        producer.submit(se).unwrap();
+
+        let (_recv, reply) = poll_data(&mut consumer);
+        assert!(consumer.inflight.count_ones(..) > 0);
+
+        // Complete first so we do not leak
+        consumer.complete(reply).unwrap();
+
+        consumer.reset();
+
+        assert_eq!(consumer.inflight.count_ones(..), 0);
+        assert_eq!(consumer.inner.num_inflight(), 0);
+    }
+
+    #[test]
+    fn test_virtq_consumer_reset_clears_inflight() {
+        let ring = make_ring(16);
+        let (mut producer, mut consumer, _notifier) = make_test_producer(&ring);
+
+        // Submit two entries and poll both
+        let se1 = producer.chain().writable(16).build().unwrap();
+        producer.submit(se1).unwrap();
+        let se2 = producer.chain().writable(16).build().unwrap();
+        producer.submit(se2).unwrap();
+
+        let (_e1, c1) = poll_data(&mut consumer);
+        let (_e2, c2) = poll_data(&mut consumer);
+        // Complete both before reset
+        consumer.complete(c1).unwrap();
+        consumer.complete(c2).unwrap();
+
+        consumer.reset();
+
+        assert_eq!(consumer.inflight.count_ones(..), 0);
+        assert_eq!(consumer.inner.num_inflight(), 0);
+    }
+}

--- a/src/hyperlight_common/src/virtq/consumer.rs
+++ b/src/hyperlight_common/src/virtq/consumer.rs
@@ -386,7 +386,7 @@ impl<M: MemOps + Clone, N: Notifier> VirtqConsumer<M, N> {
     pub fn complete(&mut self, reply: impl Into<ReplyChain<M>>) -> Result<(), VirtqError> {
         let reply = reply.into();
         let id = reply.token().id;
-        let written = reply.written() as u32;
+        let written = u32::try_from(reply.written()).map_err(|_| VirtqError::ReplyTooLarge)?;
 
         let id_idx = id as usize;
         let slot_set = id_idx < self.inflight.len() && self.inflight.contains(id_idx);

--- a/src/hyperlight_common/src/virtq/desc.rs
+++ b/src/hyperlight_common/src/virtq/desc.rs
@@ -46,6 +46,26 @@ bitflags! {
     }
 }
 
+impl DescFlags {
+    /// Was a descriptor carrying these flags made available by the driver in
+    /// the round identified by `wrap`?
+    #[inline]
+    pub fn is_avail(self, wrap: bool) -> bool {
+        let avail = self.contains(DescFlags::AVAIL);
+        let used = self.contains(DescFlags::USED);
+        avail == wrap && used != wrap
+    }
+
+    /// Was a descriptor carrying these flags marked used by the device in the
+    /// round identified by `wrap`?
+    #[inline]
+    pub fn is_used(self, wrap: bool) -> bool {
+        let avail = self.contains(DescFlags::AVAIL);
+        let used = self.contains(DescFlags::USED);
+        avail == wrap && used == wrap
+    }
+}
+
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Pod, Zeroable, PartialEq, Eq, Hash)]
 pub struct Descriptor {
@@ -96,19 +116,13 @@ impl Descriptor {
     /// Did the driver make this descriptor available in the current driver round?
     #[inline]
     pub fn is_avail(&self, wrap: bool) -> bool {
-        let f = self.flags();
-        let avail = f.contains(DescFlags::AVAIL);
-        let used = f.contains(DescFlags::USED);
-        avail == wrap && used != wrap
+        self.flags().is_avail(wrap)
     }
 
     /// Did the device mark this descriptor used in the current device round?
     #[inline]
     pub fn is_used(&self, wrap: bool) -> bool {
-        let f = self.flags();
-        let avail = f.contains(DescFlags::AVAIL);
-        let used = f.contains(DescFlags::USED);
-        avail == wrap && used == wrap
+        self.flags().is_used(wrap)
     }
 
     /// Is this descriptor writable by the device?
@@ -151,26 +165,6 @@ impl Descriptor {
         }
     }
 
-    /// Read a descriptor from memory with acquire semantics for flags
-    /// This is the primary synchronization point for consuming descriptors.
-    ///
-    /// # Invariant
-    ///
-    /// The caller must ensure that `base` is valid for reads of Descriptor
-    pub fn read_acquire<M: MemOps>(mem: &M, addr: u64) -> Result<Self, M::Error> {
-        let flags = mem.load_acquire(addr + Self::FLAGS_OFFSET as u64)?;
-        let addr_val: u64 = mem.read_val(addr + Self::ADDR_OFFSET as u64)?;
-        let len: u32 = mem.read_val(addr + Self::LEN_OFFSET as u64)?;
-        let id: u16 = mem.read_val(addr + Self::ID_OFFSET as u64)?;
-
-        Ok(Self {
-            addr: addr_val,
-            len,
-            id,
-            flags,
-        })
-    }
-
     /// Write a descriptor to memory with release semantics for flags at the given base pointer
     ///
     /// This is the primary synchronization point for publishing descriptors.
@@ -185,6 +179,28 @@ impl Descriptor {
         // Flags written last with release semantics
         mem.store_release(addr + Self::FLAGS_OFFSET as u64, self.flags)?;
         Ok(())
+    }
+
+    /// Acquire-load only the flags word - the packed-ring publish point -
+    /// without reading the descriptor body.
+    pub fn read_flags_acquire<M: MemOps>(mem: &M, addr: u64) -> Result<DescFlags, M::Error> {
+        let flags = mem.load_acquire(addr + Self::FLAGS_OFFSET as u64)?;
+        Ok(DescFlags::from_bits_truncate(flags))
+    }
+
+    /// Read the descriptor body (`addr`/`len`/`id`) and combine it with flags
+    /// already obtained from [`load_flags_acquire`](Self::load_flags_acquire).
+    pub fn read_body<M: MemOps>(mem: &M, addr: u64, flags: DescFlags) -> Result<Self, M::Error> {
+        let addr_val: u64 = mem.read_val(addr + Self::ADDR_OFFSET as u64)?;
+        let len: u32 = mem.read_val(addr + Self::LEN_OFFSET as u64)?;
+        let id: u16 = mem.read_val(addr + Self::ID_OFFSET as u64)?;
+
+        Ok(Self {
+            addr: addr_val,
+            len,
+            id,
+            flags: flags.bits(),
+        })
     }
 }
 

--- a/src/hyperlight_common/src/virtq/desc.rs
+++ b/src/hyperlight_common/src/virtq/desc.rs
@@ -189,7 +189,7 @@ impl Descriptor {
     }
 
     /// Read the descriptor body (`addr`/`len`/`id`) and combine it with flags
-    /// already obtained from [`load_flags_acquire`](Self::load_flags_acquire).
+    /// already obtained from [`read_flags_acquire`](Self::read_flags_acquire).
     pub fn read_body<M: MemOps>(mem: &M, addr: u64, flags: DescFlags) -> Result<Self, M::Error> {
         let addr_val: u64 = mem.read_val(addr + Self::ADDR_OFFSET as u64)?;
         let len: u32 = mem.read_val(addr + Self::LEN_OFFSET as u64)?;

--- a/src/hyperlight_common/src/virtq/event.rs
+++ b/src/hyperlight_common/src/virtq/event.rs
@@ -96,16 +96,31 @@ impl EventSuppression {
             (off & Self::DESC_EVENT_OFF_MASK) | if wrap { Self::DESC_EVENT_WRAP } else { 0 };
     }
 
-    /// Create an `EventSuppression` from a raw pointer with acquire semantics.
+    /// Acquire-load only the flags word - the publish point - without reading
+    /// the `off_wrap` payload.
     ///
     /// # Invariant
     ///
-    /// The caller must ensure that `base` is a valid pointer to an EventSuppression.
-    pub fn read_acquire<M: MemOps>(mem: &M, addr: u64) -> Result<Self, M::Error> {
+    /// The caller must ensure that `addr` is a valid pointer to an EventSuppression.
+    pub fn read_flags_acquire<M: MemOps>(mem: &M, addr: u64) -> Result<EventFlags, M::Error> {
         // Atomic Acquire load of flags (publish point)
         let flags = mem.load_acquire(addr + Self::FLAGS_OFFSET as u64)?;
+        Ok(EventFlags::from_bits_truncate(flags))
+    }
+
+    /// Read the `off_wrap` payload and combine it with flags already obtained
+    /// from [`read_flags_acquire`](Self::read_flags_acquire).
+    ///
+    /// # Invariant
+    ///
+    /// The caller must ensure that `addr` is a valid pointer to an EventSuppression.
+    pub fn read_body<M: MemOps>(mem: &M, addr: u64, flags: EventFlags) -> Result<Self, M::Error> {
         let off_wrap: u16 = mem.read_val(addr + Self::WRAP_OFFSET as u64)?;
-        Ok(Self { off_wrap, flags })
+
+        Ok(Self {
+            off_wrap,
+            flags: flags.bits(),
+        })
     }
 
     /// Write an `EventSuppression` to a raw pointer with release semantics.

--- a/src/hyperlight_common/src/virtq/mod.rs
+++ b/src/hyperlight_common/src/virtq/mod.rs
@@ -14,13 +14,19 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-//! Packed Virtqueue - Ring Primitives
+//! Packed Virtqueue Implementation
 //!
-//! This module provides low-level ring primitives for virtio packed virtqueues,
-//! implementing the VIRTIO 1.1+ packed ring format with proper memory ordering
-//! and event suppression support.
+//! This module provides a high-level API for virtio packed virtqueues, built on top of
+//! the lower-level ring primitives. It implements the VIRTIO 1.1+ packed ring format
+//! with proper memory ordering and event suppression support.
 //!
 //! # Architecture
+//!
+//! The implementation is split into layers:
+//!
+//! - **High-level API** ([`VirtqProducer`], [`VirtqConsumer`]): Manages buffer allocation,
+//!   chain lifecycle, and notification decisions. This is the recommended API
+//!   for most use cases.
 //!
 //! - **Ring primitives** ([`RingProducer`], [`RingConsumer`]): Low-level descriptor ring
 //!   operations with explicit buffer chain management. Use this when you need full control
@@ -29,10 +35,116 @@ limitations under the License.
 //! - **Descriptor and event types** ([`Descriptor`], [`EventSuppression`]): Raw virtio
 //!   data structures for direct memory manipulation.
 //!
-//! - **Memory access** ([`MemOps`]): Trait abstracting memory read/write operations,
-//!   allowing the ring to work with different memory backends (host vs guest).
+//! # Quick Start
+//!
+//! ## Single Readable/Writable Chain
+//!
+//! ```ignore
+//! // Producer (driver) side - build and submit a send chain
+//! let mut chain = producer.chain()
+//!     .readable(64)
+//!     .writable(128)
+//!     .build()?;
+//! chain.write_all(b"request data")?;
+//! let token = producer.submit(chain)?;
+//! // ... wait for notification ...
+//! if let Some(used) = producer.poll()? {
+//!     match used {
+//!         UsedChain::Data(_, segments) => process(segments),
+//!         UsedChain::Ack(_) => {}
+//!     }
+//! }
+//!
+//! // Consumer (device) side - receive a chain and reply/ack it
+//! if let Some((chain, reply)) = consumer.poll(max_recv_len)? {
+//!     let request = chain.to_bytes();
+//!     match reply {
+//!         ReplyChain::Writable(mut wc) => {
+//!             let response = handle(request);
+//!             wc.write_all(&response)?;
+//!             consumer.complete(wc)?;
+//!         }
+//!         ReplyChain::Ack(ack) => {
+//!             consumer.complete(ack)?;
+//!         }
+//!     }
+//! }
+//!
+//! // Multiple pending completions (no borrow on consumer)
+//! let mut pending = Vec::new();
+//! while let Some((chain, reply)) = consumer.poll(max_recv_len)? {
+//!     pending.push((process(chain), reply));
+//! }
+//! for (result, reply) in pending {
+//!     consumer.complete(reply)?;
+//! }
+//! ```
+//!
+//! ## Multiple Chains
+//!
+//! Each submit checks event suppression and notifies independently. Use
+//! [`VirtqProducer::batch`] when a higher-level protocol wants to publish
+//! multiple chains and kick the queue once.
+//!
+//! ```ignore
+//! let mut batch = producer.batch();
+//! for data in entries {
+//!     let mut chain = batch.chain()
+//!         .readable(data.len())
+//!         .writable(64)
+//!         .build()?;
+//!     chain.write_all(data)?;
+//!     batch.submit(chain)?;
+//! }
+//! batch.finish()?;
+//! ```
+//!
+//! ## Completion Batching with Event Suppression
+//!
+//! To receive a single notification when multiple requests complete:
+//!
+//! ```ignore
+//! // Submit chains
+//! for data in entries {
+//!     let mut chain = producer.chain()
+//!         .readable(data.len())
+//!         .writable(64)
+//!         .build()?;
+//!     chain.write_all(data)?;
+//!     producer.submit(chain)?;
+//! }
+//!
+//! // Tell device: "notify me only after completing past this cursor"
+//! let cursor = producer.used_cursor();
+//! producer.set_used_suppression(SuppressionKind::Descriptor(cursor))?;
+//!
+//! // Wait for single notification, then drain all responses
+//! producer.drain(|used| {
+//!     if let UsedChain::Data(token, data) = used {
+//!         handle_response(token, data);
+//!     }
+//! })?;
+//! ```
+//!
+//! # Event Suppression
+//!
+//! Both sides can control when they want to be notified using [`SuppressionKind`]:
+//!
+//! - [`SuppressionKind::Enable`]: Always notify (default, lowest latency)
+//! - [`SuppressionKind::Disable`]: Never notify (polling mode, lowest overhead)
+//! - [`SuppressionKind::Descriptor`]: Notify at specific ring position (batching)
+//!
+//! See [`VirtqProducer::set_used_suppression`] and [`VirtqConsumer::set_avail_suppression`].
 //!
 //! # Low-Level API
+//!
+//! For advanced use cases, the ring module exposes lower-level primitives:
+//!
+//! - [`RingProducer`] / [`RingConsumer`]: Direct ring access with [`BufferChain`] submission
+//! - [`BufferChainBuilder`]: Construct scatter-gather buffer lists
+//! - [`RingCursor`]: Track ring positions for event suppression
+//!
+//! Example using low-level API:
 //!
 //! ```ignore
 //! let chain = BufferChainBuilder::new()
@@ -48,16 +160,88 @@ limitations under the License.
 //! ```
 
 mod access;
+mod buffer;
+mod consumer;
 mod desc;
 mod event;
+pub mod msg;
+mod pool;
+mod producer;
 mod ring;
+
+#[cfg(all(test, loom))]
+mod concurrency;
 
 use core::num::NonZeroU16;
 
 pub use access::*;
+pub use buffer::*;
+pub use consumer::*;
 pub use desc::*;
 pub use event::*;
+pub use pool::*;
+pub use producer::*;
 pub use ring::*;
+use thiserror::Error;
+
+/// A trait for notifying the consumer about virtqueue events.
+pub trait Notifier {
+    fn notify(&self, stats: QueueStats);
+}
+
+/// Errors that can occur in the virtqueue operations.
+#[derive(Error, Debug)]
+pub enum VirtqError {
+    #[error("Ring error: {0}")]
+    RingError(RingError),
+    #[error("Allocation error: {0}")]
+    Alloc(AllocError),
+    #[error("Ring or pool temporarily full")]
+    Backpressure,
+    #[error("Allocation exceeds pool capacity")]
+    OutOfMemory,
+    #[error("Invalid chain received")]
+    BadChain,
+    #[error("Payload data too large: received {recv} bytes, limit {limit} bytes")]
+    PayloadTooLarge { recv: usize, limit: usize },
+    #[error("Reply data too large for allocated buffer")]
+    ReplyTooLarge,
+    #[error("Internal state error")]
+    InvalidState,
+    #[error("Memory write error")]
+    MemoryWriteError,
+    #[error("Memory read error")]
+    MemoryReadError,
+    #[error("No payload segment in this chain")]
+    NoPayloadSegment,
+}
+
+impl VirtqError {
+    /// Check if this error is transient or unrecoverable.
+    #[inline(always)]
+    pub fn is_transient(&self) -> bool {
+        matches!(self, Self::Backpressure)
+    }
+}
+
+impl From<RingError> for VirtqError {
+    fn from(e: RingError) -> Self {
+        match e {
+            RingError::WouldBlock => Self::Backpressure,
+            other => Self::RingError(other),
+        }
+    }
+}
+
+impl From<AllocError> for VirtqError {
+    fn from(e: AllocError) -> Self {
+        match e {
+            AllocError::NoSpace => Self::Backpressure,
+            AllocError::OutOfMemory => Self::OutOfMemory,
+            other => Self::Alloc(other),
+        }
+    }
+}
 
 /// Layout of a packed virtqueue ring in shared memory.
 ///
@@ -166,6 +350,53 @@ impl Layout {
     }
 }
 
+/// Statistics about the current virtqueue state.
+///
+/// Provided to the [`Notifier`] when sending notifications, allowing
+/// the notifier to make decisions based on queue pressure.
+#[derive(Debug, Clone, Copy)]
+pub struct QueueStats {
+    /// Number of free descriptor slots available.
+    pub num_free: usize,
+    /// Number of descriptors currently in-flight (submitted but not completed).
+    pub num_inflight: usize,
+}
+
+/// Event suppression mode for controlling when notifications are sent.
+///
+/// This configures when the other side should signal (interrupt/kick) us
+/// about new data. Used to optimize batching and reduce interrupt overhead.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SuppressionKind {
+    /// Always signal after each operation (default behavior).
+    Enable,
+    /// Never signal.
+    Disable,
+    /// Signal only when reaching a specific descriptor position.
+    Descriptor(RingCursor),
+}
+
+/// A token representing a sent chain in the virtqueue.
+///
+/// Tokens uniquely identify in-flight requests and are used to correlate
+/// requests with their responses.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct Token {
+    /// Monotonically increasing generation counter.
+    pub seq: u32,
+    /// Descriptor ID this token maps to.
+    pub id: u16,
+}
+
+impl From<BufferElement> for Allocation {
+    fn from(value: BufferElement) -> Self {
+        Allocation {
+            addr: value.addr,
+            len: value.len as usize,
+        }
+    }
+}
+
 const _: () = {
     #[allow(clippy::unwrap_used)]
     const fn verify_layout(num_descs: usize) {
@@ -219,3 +450,668 @@ const _: () = {
     verify_layout(512);
     verify_layout(1024);
 };
+
+/// Shared test utilities for virtqueue tests.
+#[cfg(test)]
+pub(crate) mod test_utils {
+    use alloc::collections::BTreeMap;
+    use alloc::sync::Arc;
+    use core::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+    use std::sync::Mutex;
+
+    use super::*;
+    use crate::virtq::ring::tests::{OwnedRing, TestMem};
+
+    /// Simple notifier that tracks notification count.
+    #[derive(Debug, Clone)]
+    pub(crate) struct TestNotifier {
+        pub(crate) count: Arc<AtomicUsize>,
+    }
+
+    impl TestNotifier {
+        pub(crate) fn new() -> Self {
+            Self {
+                count: Arc::new(AtomicUsize::new(0)),
+            }
+        }
+
+        pub(crate) fn notification_count(&self) -> usize {
+            self.count.load(Ordering::Relaxed)
+        }
+    }
+
+    impl Notifier for TestNotifier {
+        fn notify(&self, _stats: QueueStats) {
+            self.count.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    /// Simple test buffer pool that allocates from a range.
+    #[derive(Clone)]
+    pub(crate) struct TestPool {
+        base: u64,
+        next: Arc<AtomicU64>,
+        size: usize,
+        max_alloc_len: usize,
+        allocations: Arc<Mutex<BTreeMap<u64, usize>>>,
+    }
+
+    impl TestPool {
+        pub(crate) fn new(base: u64, size: usize) -> Self {
+            Self {
+                base,
+                next: Arc::new(AtomicU64::new(base)),
+                size,
+                max_alloc_len: usize::MAX,
+                allocations: Arc::new(Mutex::new(BTreeMap::new())),
+            }
+        }
+
+        pub(crate) fn new_with_max_alloc_len(base: u64, size: usize, max_alloc_len: usize) -> Self {
+            Self {
+                base,
+                next: Arc::new(AtomicU64::new(base)),
+                size,
+                max_alloc_len,
+                allocations: Arc::new(Mutex::new(BTreeMap::new())),
+            }
+        }
+    }
+
+    impl BufferProvider for TestPool {
+        fn max_alloc_len(&self) -> usize {
+            self.max_alloc_len
+        }
+
+        fn alloc(&self, len: usize) -> Result<Allocation, AllocError> {
+            if len == 0 {
+                return Err(AllocError::InvalidArg);
+            }
+
+            let addr = self.next.fetch_add(len as u64, Ordering::Relaxed);
+            let end = addr + len as u64;
+            if end > self.base + self.size as u64 {
+                return Err(AllocError::NoSpace);
+            }
+            self.allocations
+                .lock()
+                .expect("poisoned mutex")
+                .insert(addr, len);
+            Ok(Allocation { addr, len })
+        }
+
+        fn dealloc(&self, addr: u64) -> Result<(), AllocError> {
+            self.allocations
+                .lock()
+                .expect("poisoned mutex")
+                .remove(&addr)
+                .map(|_| ())
+                .ok_or(AllocError::InvalidFree(addr, 0))
+        }
+    }
+
+    type TestProducer = VirtqProducer<TestMem, TestNotifier, TestPool>;
+    type TestConsumer = VirtqConsumer<TestMem, TestNotifier>;
+
+    /// Create test infrastructure: a producer, consumer, and notifier backed
+    /// by the supplied [`OwnedRing`].
+    pub(crate) fn make_test_producer(
+        ring: &OwnedRing,
+    ) -> (TestProducer, TestConsumer, TestNotifier) {
+        let layout = ring.layout();
+        let mem = ring.mem();
+
+        // Pool needs to be in memory accessible via mem - use memory after ring layout
+        let pool_base = mem.base_addr() + Layout::query_size(ring.len()) as u64 + 0x100;
+        let pool = TestPool::new(pool_base, 0x8000);
+        let notifier = TestNotifier::new();
+
+        let producer = VirtqProducer::new(layout, mem.clone(), notifier.clone(), pool);
+        let consumer = VirtqConsumer::new(layout, mem, notifier.clone());
+
+        (producer, consumer, notifier)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::sync::Arc;
+    use core::sync::atomic::{AtomicUsize, Ordering};
+
+    use super::*;
+    use crate::virtq::ring::tests::{TestMem, make_ring};
+    use crate::virtq::test_utils::*;
+
+    /// Helper: build and submit a readable+writable chain using the chain() builder.
+    fn send_readwrite(
+        producer: &mut VirtqProducer<TestMem, TestNotifier, TestPool>,
+        entry_data: &[u8],
+        used_cap: usize,
+    ) -> Token {
+        let mut se = producer
+            .chain()
+            .readable(entry_data.len())
+            .writable(used_cap)
+            .build()
+            .unwrap();
+        se.write_all(entry_data).unwrap();
+        producer.submit(se).unwrap()
+    }
+
+    fn poll_received(
+        consumer: &mut VirtqConsumer<TestMem, TestNotifier>,
+    ) -> (RecvChain, ReplyChain<TestMem>) {
+        consumer.poll(1024).unwrap().unwrap()
+    }
+
+    #[test]
+    fn test_submit_notifies() {
+        let ring = make_ring(16);
+        let (mut producer, mut consumer, notifier) = make_test_producer(&ring);
+
+        let initial_count = notifier.notification_count();
+
+        let token = send_readwrite(&mut producer, b"hello", 64);
+        assert!(notifier.notification_count() > initial_count);
+
+        let (recv, _reply) = poll_received(&mut consumer);
+        assert_eq!(recv.token(), token);
+    }
+
+    #[test]
+    fn test_multiple_submits() {
+        let ring = make_ring(16);
+        let (mut producer, mut consumer, _notifier) = make_test_producer(&ring);
+
+        let tok1 = send_readwrite(&mut producer, b"request1", 64);
+        let tok2 = send_readwrite(&mut producer, b"request2", 64);
+        let tok3 = send_readwrite(&mut producer, b"request3", 64);
+
+        // Consumer sees all requests
+        for _ in 0..3 {
+            let (_recv, reply) = poll_received(&mut consumer);
+            consumer.complete(reply).unwrap();
+        }
+
+        // All completions available
+        let used1 = producer.poll().unwrap().unwrap();
+        let used2 = producer.poll().unwrap().unwrap();
+        let used3 = producer.poll().unwrap().unwrap();
+        assert!(
+            [used1.token(), used2.token(), used3.token()].contains(&tok1)
+                && [used1.token(), used2.token(), used3.token()].contains(&tok2)
+                && [used1.token(), used2.token(), used3.token()].contains(&tok3)
+        );
+    }
+
+    #[test]
+    fn test_completion_batching_with_suppression() {
+        let ring = make_ring(16);
+        let (mut producer, mut consumer, _notifier) = make_test_producer(&ring);
+
+        // Submit entries
+        let tok1 = send_readwrite(&mut producer, b"req1", 64);
+        let tok2 = send_readwrite(&mut producer, b"req2", 64);
+        let tok3 = send_readwrite(&mut producer, b"req3", 64);
+
+        // Set up reply batching via used suppression
+        let cursor = producer.used_cursor();
+        producer
+            .set_used_suppression(SuppressionKind::Descriptor(cursor))
+            .unwrap();
+
+        // Consumer processes requests
+        for _ in 0..3 {
+            let (_recv, reply) = poll_received(&mut consumer);
+            let ReplyChain::Writable(mut wc) = reply else {
+                panic!("expected writable reply");
+            };
+            wc.write_all(b"used-data").unwrap();
+            consumer.complete(wc).unwrap();
+        }
+
+        // Producer can drain all responses
+        let mut responses = Vec::new();
+        producer
+            .drain(|reply| {
+                responses.push(reply.token());
+            })
+            .unwrap();
+
+        assert_eq!(responses.len(), 3);
+        assert!(responses.contains(&tok1));
+        assert!(responses.contains(&tok2));
+        assert!(responses.contains(&tok3));
+    }
+
+    #[test]
+    fn test_notifier_receives_context() {
+        #[derive(Debug, Clone)]
+        struct CtxNotifier {
+            last_num_free: Arc<AtomicUsize>,
+            last_num_inflight: Arc<AtomicUsize>,
+            count: Arc<AtomicUsize>,
+        }
+
+        impl Notifier for CtxNotifier {
+            fn notify(&self, stats: QueueStats) {
+                self.last_num_free.store(stats.num_free, Ordering::Relaxed);
+                self.last_num_inflight
+                    .store(stats.num_inflight, Ordering::Relaxed);
+                self.count.fetch_add(1, Ordering::Relaxed);
+            }
+        }
+
+        let ring = make_ring(16);
+        let layout = ring.layout();
+        let mem = ring.mem();
+        let pool_base = mem.base_addr() + Layout::query_size(ring.len()) as u64 + 0x100;
+        let pool = TestPool::new(pool_base, 0x8000);
+        let notifier = CtxNotifier {
+            last_num_free: Arc::new(AtomicUsize::new(0)),
+            last_num_inflight: Arc::new(AtomicUsize::new(0)),
+            count: Arc::new(AtomicUsize::new(0)),
+        };
+
+        let mut producer = VirtqProducer::new(layout, mem, notifier.clone(), pool);
+
+        let mut se = producer.chain().readable(4).writable(32).build().unwrap();
+        se.write_all(b"test").unwrap();
+        producer.submit(se).unwrap();
+        assert_eq!(notifier.count.load(Ordering::Relaxed), 1);
+        assert!(notifier.last_num_inflight.load(Ordering::Relaxed) > 0);
+    }
+
+    #[test]
+    fn test_chain_batch() {
+        let ring = make_ring(16);
+        let (mut producer, mut consumer, notifier) = make_test_producer(&ring);
+
+        let initial_count = notifier.notification_count();
+
+        // First readable chain
+        let mut se1 = producer.chain().readable(64).writable(128).build().unwrap();
+        se1.write_all(b"first-ent").unwrap();
+        let _tok1 = producer.submit(se1).unwrap();
+
+        // Write-based recv
+        let mut se2 = producer.chain().readable(64).writable(64).build().unwrap();
+        se2.write_all(b"copy-ent").unwrap();
+        let _tok2 = producer.submit(se2).unwrap();
+
+        // Completion-only chain
+        let se3 = producer.chain().writable(32).build().unwrap();
+        let tok3 = producer.submit(se3).unwrap();
+
+        // Each submit may notify independently
+        assert!(notifier.notification_count() > initial_count);
+
+        // Consumer sees all three entries
+        let (recv1, reply1) = poll_received(&mut consumer);
+        assert_eq!(recv1.to_bytes().as_ref(), b"first-ent");
+        consumer.complete(reply1).unwrap();
+
+        let (recv2, reply2) = poll_received(&mut consumer);
+        assert_eq!(recv2.to_bytes().as_ref(), b"copy-ent");
+        consumer.complete(reply2).unwrap();
+
+        let (_recv3, reply3) = poll_received(&mut consumer);
+        let ReplyChain::Writable(mut wc) = reply3 else {
+            panic!("expected writable reply");
+        };
+        wc.write_all(b"resp").unwrap();
+        consumer.complete(wc).unwrap();
+
+        // Drain completions
+        let _ = producer.poll().unwrap().unwrap();
+        let _ = producer.poll().unwrap().unwrap();
+
+        let used = producer.poll().unwrap().unwrap();
+        assert_eq!(used.token(), tok3);
+        assert_eq!(used.to_bytes().unwrap().as_ref(), b"resp");
+    }
+
+    #[test]
+    fn test_chain_write_send() {
+        let ring = make_ring(16);
+        let (mut producer, mut consumer, _notifier) = make_test_producer(&ring);
+
+        let mut se = producer.chain().readable(64).writable(128).build().unwrap();
+        se.write_all(b"hello").unwrap();
+        let token = producer.submit(se).unwrap();
+
+        // Consumer sees the data
+        let (recv, reply) = poll_received(&mut consumer);
+        assert_eq!(recv.token(), token);
+        assert_eq!(recv.to_bytes().as_ref(), b"hello");
+
+        // Write response
+        let ReplyChain::Writable(mut wc) = reply else {
+            panic!("expected writable reply");
+        };
+        wc.write_all(b"world").unwrap();
+        consumer.complete(wc).unwrap();
+        let used = producer.poll().unwrap().unwrap();
+        assert_eq!(used.to_bytes().unwrap().as_ref(), b"world");
+    }
+
+    #[test]
+    fn test_full_round_trip() {
+        let ring = make_ring(16);
+        let (mut producer, mut consumer, _notifier) = make_test_producer(&ring);
+
+        // Send an recv
+        let token = send_readwrite(&mut producer, b"round-trip-recv", 128);
+
+        // Consumer receives and responds
+        let (recv, reply) = poll_received(&mut consumer);
+        assert_eq!(recv.token(), token);
+        assert_eq!(recv.to_bytes().as_ref(), b"round-trip-recv");
+
+        let ReplyChain::Writable(mut wc) = reply else {
+            panic!("expected writable reply");
+        };
+        assert!(wc.capacity() >= 128);
+        wc.write_all(b"round-trip-rsp").unwrap();
+        consumer.complete(wc).unwrap();
+
+        // Producer gets the reply
+        let used = producer.poll().unwrap().unwrap();
+        assert_eq!(used.token(), token);
+        assert_eq!(used.to_bytes().unwrap().as_ref(), b"round-trip-rsp");
+    }
+
+    #[test]
+    fn test_cancel_submits_zero_length() {
+        let ring = make_ring(16);
+        let (mut producer, mut consumer, _notifier) = make_test_producer(&ring);
+
+        let token = send_readwrite(&mut producer, b"recv-data", 64);
+
+        let (_recv, reply) = poll_received(&mut consumer);
+        consumer.complete(reply).unwrap();
+
+        let used = producer.poll().unwrap().unwrap();
+        assert_eq!(used.token(), token);
+        assert_eq!(used.to_bytes().unwrap().len(), 0);
+        assert!(used.to_bytes().unwrap().is_empty());
+    }
+
+    #[test]
+    fn test_hold_reply_and_complete() {
+        let ring = make_ring(16);
+        let (mut producer, mut consumer, _notifier) = make_test_producer(&ring);
+
+        let token = send_readwrite(&mut producer, b"deferred", 64);
+
+        // Poll and hold the reply
+        let (recv, reply) = poll_received(&mut consumer);
+        assert_eq!(recv.token(), token);
+        assert_eq!(recv.to_bytes().as_ref(), b"deferred");
+
+        let ReplyChain::Writable(mut wc) = reply else {
+            panic!("expected writable reply");
+        };
+        wc.write_all(b"deferred-used").unwrap();
+        consumer.complete(wc).unwrap();
+
+        let used = producer.poll().unwrap().unwrap();
+        assert_eq!(used.token(), token);
+        assert_eq!(used.to_bytes().unwrap().as_ref(), b"deferred-used");
+    }
+
+    #[test]
+    fn test_concurrent_pending_replies() {
+        let ring = make_ring(16);
+        let (mut producer, mut consumer, _notifier) = make_test_producer(&ring);
+
+        let tok1 = send_readwrite(&mut producer, b"first", 64);
+        let tok2 = send_readwrite(&mut producer, b"second", 64);
+
+        // Poll both
+        let (recv1, reply1) = poll_received(&mut consumer);
+        assert_eq!(recv1.token(), tok1);
+        assert_eq!(recv1.to_bytes().as_ref(), b"first");
+
+        let (recv2, reply2) = poll_received(&mut consumer);
+        assert_eq!(recv2.token(), tok2);
+        assert_eq!(recv2.to_bytes().as_ref(), b"second");
+
+        // Complete second first (out of order)
+        let ReplyChain::Writable(mut wc2) = reply2 else {
+            panic!("expected writable");
+        };
+        wc2.write_all(b"resp2").unwrap();
+        consumer.complete(wc2).unwrap();
+
+        let ReplyChain::Writable(mut wc1) = reply1 else {
+            panic!("expected writable");
+        };
+        wc1.write_all(b"resp1").unwrap();
+        consumer.complete(wc1).unwrap();
+
+        let used1 = producer.poll().unwrap().unwrap();
+        let used2 = producer.poll().unwrap().unwrap();
+        let mut responses: Vec<_> = vec![
+            (used1.token(), used1.to_bytes().unwrap().to_vec()),
+            (used2.token(), used2.to_bytes().unwrap().to_vec()),
+        ];
+        responses.sort_by_key(|(t, _)| t.seq);
+
+        let expected_first = responses.iter().find(|(t, _)| *t == tok1).unwrap();
+        let expected_second = responses.iter().find(|(t, _)| *t == tok2).unwrap();
+        assert_eq!(&expected_first.1[..], b"resp1");
+        assert_eq!(&expected_second.1[..], b"resp2");
+    }
+
+    /// Helper: submit a read-only chain (readable data, no writable reply).
+    fn send_readonly(
+        producer: &mut VirtqProducer<TestMem, TestNotifier, TestPool>,
+        entry_data: &[u8],
+    ) -> Token {
+        let mut se = producer.chain().readable(entry_data.len()).build().unwrap();
+        se.write_all(entry_data).unwrap();
+        producer.submit(se).unwrap()
+    }
+
+    #[test]
+    fn test_reclaim_frees_ring_slots() {
+        let ring = make_ring(4);
+        let (mut producer, mut consumer, _) = make_test_producer(&ring);
+
+        // Fill the ring with ReadOnly entries
+        send_readonly(&mut producer, b"a");
+        send_readonly(&mut producer, b"b");
+        send_readonly(&mut producer, b"c");
+        send_readonly(&mut producer, b"d");
+
+        // Ring is now full - next submit should fail with Backpressure
+        let mut se = producer.chain().readable(1).build().unwrap();
+        se.write_all(b"e").unwrap();
+        let res = producer.submit(se);
+        assert!(
+            matches!(res, Err(VirtqError::Backpressure)),
+            "expected Backpressure from full ring"
+        );
+
+        // Consumer acks all entries
+        while let Some(result) = consumer.poll(1024).unwrap() {
+            let (_, reply) = result;
+            consumer.complete(reply).unwrap();
+        }
+
+        // Reclaim should free ring slots without losing data
+        let count = producer.reclaim().unwrap();
+        assert_eq!(count, 4, "expected 4 reclaimed entries");
+
+        // Ring should have space now
+        send_readonly(&mut producer, b"e");
+    }
+
+    #[test]
+    fn test_reclaim_buffers_rw_completions() {
+        let ring = make_ring(4);
+        let (mut producer, mut consumer, _) = make_test_producer(&ring);
+
+        // Submit a ReadWrite recv
+        let tok = send_readwrite(&mut producer, b"request", 64);
+
+        // Consumer processes and writes response
+        let (_, reply) = poll_received(&mut consumer);
+        let ReplyChain::Writable(mut wc) = reply else {
+            panic!("expected writable");
+        };
+        wc.write_all(b"response-data").unwrap();
+        consumer.complete(wc).unwrap();
+
+        // Reclaim buffers the reply (doesn't discard it)
+        let count = producer.reclaim().unwrap();
+        assert_eq!(count, 1);
+
+        // poll() should return the buffered reply
+        let used = producer.poll().unwrap().unwrap();
+        assert_eq!(used.token(), tok);
+        assert_eq!(used.to_bytes().unwrap().as_ref(), b"response-data");
+    }
+
+    #[test]
+    fn test_reclaim_discards_readonly_completions() {
+        let ring = make_ring(8);
+        let (mut producer, mut consumer, _) = make_test_producer(&ring);
+
+        // Submit 3 entries: RO, RW, RO
+        let _tok_ro1 = send_readonly(&mut producer, b"log1");
+        let tok_rw = send_readwrite(&mut producer, b"call", 64);
+        let _tok_ro2 = send_readonly(&mut producer, b"log2");
+
+        // Consumer processes all 3
+        let (_, reply1) = poll_received(&mut consumer);
+        consumer.complete(reply1).unwrap(); // ack RO
+
+        let (_, reply2) = poll_received(&mut consumer);
+        let ReplyChain::Writable(mut wc) = reply2 else {
+            panic!("expected writable");
+        };
+        wc.write_all(b"result").unwrap();
+        consumer.complete(wc).unwrap(); // complete RW
+
+        let (_, reply3) = poll_received(&mut consumer);
+        consumer.complete(reply3).unwrap(); // ack RO
+
+        // Reclaim all 3 - RO completions are discarded, only RW is buffered
+        let count = producer.reclaim().unwrap();
+        assert_eq!(count, 3);
+
+        // poll() returns only the RW reply
+        let used = producer.poll().unwrap().unwrap();
+        assert_eq!(used.token(), tok_rw);
+        assert_eq!(used.to_bytes().unwrap().as_ref(), b"result");
+
+        // No more - RO completions were discarded
+        assert!(producer.poll().unwrap().is_none());
+    }
+
+    #[test]
+    fn test_reclaim_mixed_with_poll() {
+        let ring = make_ring(8);
+        let (mut producer, mut consumer, _) = make_test_producer(&ring);
+
+        // Submit and complete 2 entries
+        send_readonly(&mut producer, b"x");
+        let tok_rw = send_readwrite(&mut producer, b"y", 64);
+
+        let (_, reply1) = poll_received(&mut consumer);
+        consumer.complete(reply1).unwrap();
+
+        let (_, reply2) = poll_received(&mut consumer);
+        let ReplyChain::Writable(mut wc) = reply2 else {
+            panic!("expected writable");
+        };
+        wc.write_all(b"reply").unwrap();
+        consumer.complete(wc).unwrap();
+
+        // poll() consumes first recv directly from ring
+        let used1 = producer.poll().unwrap().unwrap();
+        assert!(matches!(used1, UsedChain::Ack(_)));
+
+        // reclaim() buffers second recv
+        let count = producer.reclaim().unwrap();
+        assert_eq!(count, 1);
+
+        // poll() returns the buffered one
+        let used2 = producer.poll().unwrap().unwrap();
+        assert_eq!(used2.token(), tok_rw);
+        assert_eq!(used2.to_bytes().unwrap().as_ref(), b"reply");
+    }
+
+    /// reclaim + submit must not cause token collisions.
+    #[test]
+    fn test_reclaim_submit_no_token_collision() {
+        let ring = make_ring(8);
+        let (mut producer, mut consumer, _) = make_test_producer(&ring);
+
+        // Submit and complete a ReadOnly recv
+        let tok_old = send_readonly(&mut producer, b"log");
+
+        let (_, reply) = poll_received(&mut consumer);
+        consumer.complete(reply).unwrap();
+
+        let count = producer.reclaim().unwrap();
+        assert_eq!(count, 1);
+
+        // Submit a new ReadWrite recv - may reuse the same descriptor ID
+        let tok_new = send_readwrite(&mut producer, b"call", 64);
+
+        // Tokens must differ even if the descriptor ID was recycled
+        assert_ne!(
+            tok_old, tok_new,
+            "tokens must be unique across reclaim/submit cycles"
+        );
+
+        // Complete the ReadWrite recv
+        let (_, reply) = poll_received(&mut consumer);
+        let ReplyChain::Writable(mut wc) = reply else {
+            panic!("expected writable");
+        };
+        wc.write_all(b"result").unwrap();
+        consumer.complete(wc).unwrap();
+
+        // Poll returns only the RW reply (RO was discarded by reclaim)
+        let used = producer.poll().unwrap().unwrap();
+        assert_eq!(used.token(), tok_new);
+        assert_eq!(used.to_bytes().unwrap().as_ref(), b"result");
+
+        // No stale RO reply in the queue
+        assert!(producer.poll().unwrap().is_none());
+    }
+
+    /// Verify that repeated oneshot submit/reclaim cycles do not accumulate pending completions.
+    #[test]
+    fn test_reclaim_readonly_does_not_leak_pending() {
+        let ring = make_ring(4);
+        let (mut producer, mut consumer, _) = make_test_producer(&ring);
+
+        for _ in 0..10 {
+            // Fill the ring
+            for _ in 0..4 {
+                send_readonly(&mut producer, b"msg");
+            }
+
+            // Consumer acks all
+            while let Some(result) = consumer.poll(1024).unwrap() {
+                let (_, reply) = result;
+                consumer.complete(reply).unwrap();
+            }
+
+            // Reclaim frees ring slots; empty completions are discarded
+            let count = producer.reclaim().unwrap();
+            assert_eq!(count, 4);
+
+            // No completions should be buffered in pending
+            assert!(
+                producer.poll().unwrap().is_none(),
+                "pending should be empty after reclaiming RO entries"
+            );
+        }
+    }
+}

--- a/src/hyperlight_common/src/virtq/msg.rs
+++ b/src/hyperlight_common/src/virtq/msg.rs
@@ -1,0 +1,120 @@
+/*
+Copyright 2026  The Hyperlight Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! Wire format header for all virtqueue messages.
+//!
+//! Every payload on both the G2H and H2G queues starts with this
+//! fixed 8-byte header, enabling message type discrimination and
+//! request/response correlation.
+
+use bitflags::bitflags;
+
+/// Message types for the virtqueue wire protocol.
+#[repr(u8)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MsgKind {
+    /// A function call request (FunctionCall payload follows).
+    Request = 0x01,
+    /// A function call response (FunctionCallResult payload follows).
+    Response = 0x02,
+    /// A stream data chunk.
+    StreamChunk = 0x03,
+    /// End-of-stream marker.
+    StreamEnd = 0x04,
+    /// Cancel a pending request.
+    Cancel = 0x05,
+    /// A guest log message (GuestLogData payload follows).
+    Log = 0x06,
+}
+
+impl TryFrom<u8> for MsgKind {
+    type Error = u8;
+
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        match value {
+            0x01 => Ok(Self::Request),
+            0x02 => Ok(Self::Response),
+            0x03 => Ok(Self::StreamChunk),
+            0x04 => Ok(Self::StreamEnd),
+            0x05 => Ok(Self::Cancel),
+            0x06 => Ok(Self::Log),
+            other => Err(other),
+        }
+    }
+}
+
+bitflags! {
+    #[repr(transparent)]
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+    pub struct MsgFlags: u8 {
+        /// More descriptors follow for this message.
+        const MORE = 1 << 0;
+    }
+}
+
+/// Wire header for all virtqueue messages
+#[derive(Debug, Clone, Copy, bytemuck::Pod, bytemuck::Zeroable)]
+#[repr(C)]
+pub struct VirtqMsgHeader {
+    /// Discriminates the message type.
+    pub kind: u8,
+    /// Per-message flags (see [`MsgFlags`]).
+    pub flags: u8,
+    /// Caller-assigned correlation ID. Responses echo the request's ID.
+    pub req_id: u16,
+    /// Byte length of the payload following this header in this descriptor.
+    pub payload_len: u32,
+}
+
+impl VirtqMsgHeader {
+    pub const SIZE: usize = core::mem::size_of::<Self>();
+
+    /// Create a new message header with no flags set.
+    pub const fn new(kind: MsgKind, req_id: u16, payload_len: u32) -> Self {
+        Self {
+            kind: kind as u8,
+            flags: 0,
+            req_id,
+            payload_len,
+        }
+    }
+
+    /// Create a new header with flags.
+    pub const fn with_flags(kind: MsgKind, flags: MsgFlags, req_id: u16, payload_len: u32) -> Self {
+        Self {
+            kind: kind as u8,
+            flags: flags.bits(),
+            req_id,
+            payload_len,
+        }
+    }
+
+    /// Parse the kind field into a [`MsgKind`] enum.
+    pub fn msg_kind(&self) -> Result<MsgKind, u8> {
+        MsgKind::try_from(self.kind)
+    }
+
+    /// Interpret the raw flags field as [`MsgFlags`].
+    pub fn msg_flags(&self) -> MsgFlags {
+        MsgFlags::from_bits_truncate(self.flags)
+    }
+
+    /// Returns true if [`MsgFlags::MORE`] is set, indicating more
+    /// descriptors follow for this message.
+    pub const fn has_more(&self) -> bool {
+        self.flags & MsgFlags::MORE.bits() != 0
+    }
+}

--- a/src/hyperlight_common/src/virtq/pool.rs
+++ b/src/hyperlight_common/src/virtq/pool.rs
@@ -47,40 +47,33 @@ use smallvec::SmallVec;
 
 use super::buffer::{AllocError, Allocation, BufferProvider};
 
-/// Wrapper asserting `Send + Sync` for an inner value that is only ever
-/// accessed from a single thread.
+/// Wrapper asserting `Send` for an inner value that is only ever accessed from
+/// a single thread.
 ///
 /// [`BufferPool`] and [`RecyclePool`] hold their state in an `Rc<RefCell<..>>`,
 /// which is neither `Send` nor `Sync`. Their allocations are exposed as
 /// zero-copy reply payloads through
 /// [`Bytes::from_owner`](bytes::Bytes::from_owner), whose owner bound is
-/// `Send + Sync + 'static`; this wrapper exists solely so the pools can satisfy
-/// that bound.
+/// `Send + 'static`; this wrapper exists solely so the pools can satisfy that
+/// bound.
 ///
 /// # Safety
 ///
-/// The `Send`/`Sync` assertions are only sound while the wrapped value - and
-/// every `Bytes` handed out from it - stays on a single thread. Hyperlight
-/// guests are single-threaded, so this holds for guest-side use. It is unsound
-/// to move a pool (or a reply `Bytes`) to another thread, e.g. by using these
-/// pools with a producer/consumer on the multi-threaded host.
+/// The `Send` assertion is only sound while the wrapped value - and every
+/// `Bytes` handed out from it - stays on a single thread. Hyperlight guests are
+/// single-threaded, so this holds for guest-side use. It is unsound to move a
+/// pool (or a reply `Bytes`) to another thread, e.g. by using these pools with a
+/// producer/consumer on the multi-threaded host.
 #[derive(Debug)]
-pub(super) struct SyncWrap<T>(pub(super) T);
+struct SendWrap<T>(T);
 
-// SAFETY: only sound for single-threaded (guest-side) access; see the
-// type-level invariant on `SyncWrap`.
-unsafe impl<T> Send for SyncWrap<T> {}
-// SAFETY: only sound for single-threaded (guest-side) access; see the
-// type-level invariant on `SyncWrap`.
-unsafe impl<T> Sync for SyncWrap<T> {}
-
-impl<T: Clone> Clone for SyncWrap<T> {
+impl<T: Clone> Clone for SendWrap<T> {
     fn clone(&self) -> Self {
         Self(self.0.clone())
     }
 }
 
-impl<T> Deref for SyncWrap<T> {
+impl<T> Deref for SendWrap<T> {
     type Target = T;
     fn deref(&self) -> &T {
         &self.0
@@ -269,12 +262,13 @@ impl<const N: usize> Slab<N> {
 }
 
 #[inline]
-fn align_up(val: usize, align: usize) -> usize {
-    assert!(align > 0);
-    if val == 0 {
-        return 0;
+fn align_up(val: usize, align: usize) -> Result<usize, AllocError> {
+    if align == 0 {
+        return Err(AllocError::InvalidArg);
     }
-    val.div_ceil(align) * align
+
+    val.checked_next_multiple_of(align)
+        .ok_or(AllocError::Overflow)
 }
 
 #[derive(Debug)]
@@ -283,10 +277,14 @@ struct Inner<const L: usize, const U: usize> {
     upper: Slab<U>,
 }
 
+// SAFETY: only sound for single-threaded (guest-side) access; see the
+// type-level invariant on `SendWrap`.
+unsafe impl<const L: usize, const U: usize> Send for SendWrap<Rc<RefCell<Inner<L, U>>>> {}
+
 /// Two tier buffer pool with small and large slabs.
 #[derive(Debug, Clone)]
 pub struct BufferPool<const L: usize = 256, const U: usize = 4096> {
-    inner: SyncWrap<Rc<RefCell<Inner<L, U>>>>,
+    inner: SendWrap<Rc<RefCell<Inner<L, U>>>>,
 }
 
 impl<const L: usize, const U: usize> BufferPool<L, U> {
@@ -294,7 +292,7 @@ impl<const L: usize, const U: usize> BufferPool<L, U> {
     pub fn new(base_addr: u64, region_len: usize) -> Result<Self, AllocError> {
         let inner = Inner::<L, U>::new(base_addr, region_len)?;
         Ok(Self {
-            inner: SyncWrap(Rc::new(RefCell::new(inner))),
+            inner: SendWrap(Rc::new(RefCell::new(inner))),
         })
     }
 }
@@ -333,28 +331,27 @@ impl<const L: usize, const U: usize> Inner<L, U> {
     pub fn new(base_addr: u64, region_len: usize) -> Result<Self, AllocError> {
         const LOWER_FRACTION: usize = 8;
 
-        let region_end = (base_addr as usize)
-            .checked_add(region_len)
-            .ok_or(AllocError::Overflow)? as u64;
+        let base = usize::try_from(base_addr).map_err(|_| AllocError::Overflow)?;
+        let region_end = base.checked_add(region_len).ok_or(AllocError::Overflow)?;
 
-        let lower_base = align_up(base_addr as usize, L) as u64;
+        let lower_base = align_up(base, L)?;
         let usable = region_end
             .checked_sub(lower_base)
-            .ok_or(AllocError::EmptyRegion)? as usize;
+            .ok_or(AllocError::EmptyRegion)?;
 
         let lower_region = usable / LOWER_FRACTION;
-        let lower = Slab::<L>::new(lower_base, lower_region)?;
+        let lower = Slab::<L>::new(lower_base as u64, lower_region)?;
 
         let upper_base = lower_base
-            .checked_add(lower.capacity() as u64)
+            .checked_add(lower.capacity())
             .ok_or(AllocError::Overflow)?;
 
-        let upper_base = align_up(upper_base as usize, U) as u64;
+        let upper_base = align_up(upper_base, U)?;
         let upper_region = region_end
             .checked_sub(upper_base)
-            .ok_or(AllocError::EmptyRegion)? as usize;
+            .ok_or(AllocError::EmptyRegion)?;
 
-        let upper = Slab::<U>::new(upper_base, upper_region)?;
+        let upper = Slab::<U>::new(upper_base as u64, upper_region)?;
         Ok(Self { lower, upper })
     }
 
@@ -464,6 +461,10 @@ struct RecycleList {
     /// One bit per slot index; set means the slot is currently handed out.
     allocated: FixedBitSet,
 }
+
+// SAFETY: only sound for single-threaded (guest-side) access; see the
+// type-level invariant on `SendWrap`.
+unsafe impl Send for SendWrap<Rc<RefCell<RecycleList>>> {}
 
 impl RecycleList {
     fn new(base_addr: u64, region_len: usize, slot_size: usize) -> Result<Self, AllocError> {
@@ -604,24 +605,29 @@ impl RecycleList {
 /// `ceil(total_len / slot_size)` fixed-size segments.
 #[derive(Clone)]
 pub struct RecyclePool {
-    inner: SyncWrap<Rc<RefCell<RecycleList>>>,
+    inner: SendWrap<Rc<RefCell<RecycleList>>>,
 }
 
 impl RecyclePool {
     /// Create a recycling pool of `slot_size`-byte slots over a fixed region.
     ///
-    /// The base address is aligned up to `slot_size`; the slot count is
-    /// `region_len / slot_size`.
+    /// The base address is aligned up to `slot_size`; the slot count is based
+    /// on the remaining usable region after alignment.
     pub fn new(base_addr: u64, region_len: usize, slot_size: usize) -> Result<Self, AllocError> {
         if slot_size == 0 {
             return Err(AllocError::InvalidArg);
         }
 
-        let aligned = align_up(base_addr as usize, slot_size) as u64;
-        let list = RecycleList::new(aligned, region_len, slot_size)?;
+        let base = usize::try_from(base_addr).map_err(|_| AllocError::Overflow)?;
+        let region_end = base.checked_add(region_len).ok_or(AllocError::Overflow)?;
+        let aligned = align_up(base, slot_size)?;
+        let usable = region_end
+            .checked_sub(aligned)
+            .ok_or(AllocError::EmptyRegion)?;
+        let list = RecycleList::new(aligned as u64, usable, slot_size)?;
 
         Ok(Self {
-            inner: SyncWrap(Rc::new(RefCell::new(list))),
+            inner: SendWrap(Rc::new(RefCell::new(list))),
         })
     }
 
@@ -692,7 +698,7 @@ mod tests {
     use super::*;
 
     fn make_pool<const L: usize, const U: usize>(size: usize) -> BufferPool<L, U> {
-        let base = align_up(0x10000, L.max(U)) as u64;
+        let base = align_up(0x10000, L.max(U)).unwrap() as u64;
         BufferPool::<L, U>::new(base, size).unwrap()
     }
 
@@ -831,12 +837,25 @@ mod tests {
 
     #[test]
     fn test_align_up_helper() {
-        assert_eq!(align_up(0, 256), 0);
-        assert_eq!(align_up(1, 256), 256);
-        assert_eq!(align_up(256, 256), 256);
-        assert_eq!(align_up(257, 256), 512);
-        assert_eq!(align_up(511, 256), 512);
-        assert_eq!(align_up(512, 256), 512);
+        assert_eq!(align_up(0, 256).unwrap(), 0);
+        assert_eq!(align_up(1, 256).unwrap(), 256);
+        assert_eq!(align_up(256, 256).unwrap(), 256);
+        assert_eq!(align_up(257, 256).unwrap(), 512);
+        assert_eq!(align_up(511, 256).unwrap(), 512);
+        assert_eq!(align_up(512, 256).unwrap(), 512);
+        assert!(matches!(align_up(1, 0), Err(AllocError::InvalidArg)));
+        assert!(matches!(
+            align_up(usize::MAX, 256),
+            Err(AllocError::Overflow)
+        ));
+    }
+
+    #[test]
+    fn test_recycle_pool_alignment_subtracts_padding() {
+        let pool = RecyclePool::new(0x80001, 8192, 4096).unwrap();
+
+        assert_eq!(pool.base_addr(), 0x81000);
+        assert_eq!(pool.count(), 1);
     }
 
     // Edge case: allocation exactly at boundary
@@ -1201,7 +1220,7 @@ mod fuzz {
     }
 
     fn run_scenario(s: Scenario) -> bool {
-        let base = align_up(0x10000, 4096) as u64;
+        let base = align_up(0x10000, 4096).unwrap() as u64;
         let pool = match BufferPool::<256, 4096>::new(base, s.pool_size) {
             Ok(p) => p,
             Err(_) => return true,

--- a/src/hyperlight_common/src/virtq/pool.rs
+++ b/src/hyperlight_common/src/virtq/pool.rs
@@ -102,7 +102,7 @@ impl<const N: usize> Slab<N> {
         let used_slots = FixedBitSet::with_capacity(num_slots);
         let run_starts = FixedBitSet::with_capacity(num_slots);
 
-        if base_addr % (N as u64) != 0 {
+        if !base_addr.is_multiple_of(N as u64) {
             return Err(AllocError::InvalidAlign(base_addr));
         }
         if num_slots == 0 {
@@ -133,7 +133,7 @@ impl<const N: usize> Slab<N> {
         }
 
         let off = (addr - self.base_addr) as usize;
-        if off % N != 0 {
+        if !off.is_multiple_of(N) {
             return Err(AllocError::InvalidFree(addr, len));
         }
 
@@ -505,7 +505,7 @@ impl RecycleList {
         }
 
         let off = addr - self.base_addr;
-        if off % self.slot_size as u64 != 0 {
+        if !off.is_multiple_of(self.slot_size as u64) {
             return Err(AllocError::InvalidFree(addr, 0));
         }
 

--- a/src/hyperlight_common/src/virtq/pool.rs
+++ b/src/hyperlight_common/src/virtq/pool.rs
@@ -1,0 +1,1332 @@
+/*
+Copyright 2026  The Hyperlight Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+//! Buffer pool implementations for virtqueue buffer management.
+//!
+//! This module provides concrete buffer allocators:
+//!
+//! - [`BufferPool`] - a two-tier run allocator for variable-sized allocations.
+//! - [`RecyclePool`] - a single-tier fixed-slot free-list recycler for bounded
+//!   descriptor segments.
+//!
+//! All implement [`BufferProvider`] from the [`super::buffer`] module.
+//!
+//! # BufferPool design
+//!
+//! `BufferPool` is a variable-sized run allocator.
+//!
+//! # Two-tier layout
+//!
+//! [`BufferPool`] divides the underlying region into two slabs with different
+//! slot sizes:
+//!
+//! - The lower tier (default `L = 256`) is intended for *smaller allocations* -
+//!   control messages, descriptor metadata, and other small structures. Small
+//!   allocations first try this tier.
+//! - The upper tier (default `U = 4096`) uses page sized slots and is intended
+//!   for larger contiguous buffers.
+
+use alloc::rc::Rc;
+use core::cell::RefCell;
+use core::ops::Deref;
+
+use fixedbitset::FixedBitSet;
+use smallvec::SmallVec;
+
+use super::buffer::{AllocError, Allocation, BufferProvider};
+
+/// Wrapper asserting `Send + Sync` for an inner value that is only ever
+/// accessed from a single thread.
+///
+/// [`BufferPool`] and [`RecyclePool`] hold their state in an `Rc<RefCell<..>>`,
+/// which is neither `Send` nor `Sync`. Their allocations are exposed as
+/// zero-copy reply payloads through
+/// [`Bytes::from_owner`](bytes::Bytes::from_owner), whose owner bound is
+/// `Send + Sync + 'static`; this wrapper exists solely so the pools can satisfy
+/// that bound.
+///
+/// # Safety
+///
+/// The `Send`/`Sync` assertions are only sound while the wrapped value - and
+/// every `Bytes` handed out from it - stays on a single thread. Hyperlight
+/// guests are single-threaded, so this holds for guest-side use. It is unsound
+/// to move a pool (or a reply `Bytes`) to another thread, e.g. by using these
+/// pools with a producer/consumer on the multi-threaded host.
+#[derive(Debug)]
+pub(super) struct SyncWrap<T>(pub(super) T);
+
+// SAFETY: only sound for single-threaded (guest-side) access; see the
+// type-level invariant on `SyncWrap`.
+unsafe impl<T> Send for SyncWrap<T> {}
+// SAFETY: only sound for single-threaded (guest-side) access; see the
+// type-level invariant on `SyncWrap`.
+unsafe impl<T> Sync for SyncWrap<T> {}
+
+impl<T: Clone> Clone for SyncWrap<T> {
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
+
+impl<T> Deref for SyncWrap<T> {
+    type Target = T;
+    fn deref(&self) -> &T {
+        &self.0
+    }
+}
+
+#[derive(Debug, Clone)]
+struct Slab<const N: usize> {
+    base_addr: u64,
+    used_slots: FixedBitSet,
+    run_starts: FixedBitSet,
+    last_free_run: Option<Allocation>,
+}
+
+impl<const N: usize> Slab<N> {
+    fn new(base_addr: u64, region_len: usize) -> Result<Self, AllocError> {
+        let usable = region_len - (region_len % N);
+        let num_slots = usable / N;
+        let used_slots = FixedBitSet::with_capacity(num_slots);
+        let run_starts = FixedBitSet::with_capacity(num_slots);
+
+        if base_addr % (N as u64) != 0 {
+            return Err(AllocError::InvalidAlign(base_addr));
+        }
+        if num_slots == 0 {
+            return Err(AllocError::EmptyRegion);
+        }
+
+        Ok(Self {
+            base_addr,
+            used_slots,
+            run_starts,
+            last_free_run: None,
+        })
+    }
+
+    fn addr_of(&self, slot_idx: usize) -> Option<u64> {
+        self.base_addr
+            .checked_add((slot_idx as u64).checked_mul(N as u64)?)
+    }
+
+    fn slot_of(&self, addr: u64) -> usize {
+        let off = (addr - self.base_addr) as usize;
+        off / N
+    }
+
+    fn checked_slot_of(&self, addr: u64, len: usize) -> Result<usize, AllocError> {
+        if addr < self.base_addr {
+            return Err(AllocError::InvalidFree(addr, len));
+        }
+
+        let off = (addr - self.base_addr) as usize;
+        if off % N != 0 {
+            return Err(AllocError::InvalidFree(addr, len));
+        }
+
+        let slot = off / N;
+        if slot >= self.used_slots.len() {
+            return Err(AllocError::InvalidFree(addr, len));
+        }
+
+        Ok(slot)
+    }
+
+    fn live_run_slots_at(&self, start: usize) -> Option<usize> {
+        if start >= self.used_slots.len()
+            || !self.used_slots.contains(start)
+            || !self.run_starts.contains(start)
+        {
+            return None;
+        }
+
+        let mut end = start + 1;
+        while end < self.used_slots.len()
+            && self.used_slots.contains(end)
+            && !self.run_starts.contains(end)
+        {
+            end += 1;
+        }
+
+        Some(end - start)
+    }
+
+    fn maybe_invalidate_last_run(&mut self, alloc: Allocation) {
+        if let Some(run) = &self.last_free_run {
+            let new_end = alloc.addr + alloc.len as u64;
+            let run_end = run.addr + run.len as u64;
+
+            if alloc.addr < run_end && run.addr < new_end {
+                self.last_free_run = None;
+            }
+        }
+    }
+
+    fn find_slots(&mut self, slots_num: usize) -> Option<usize> {
+        debug_assert!(slots_num > 0);
+
+        if let Some(alloc) = self.last_free_run
+            && alloc.len >= slots_num * N
+        {
+            let pos = self.slot_of(alloc.addr);
+            let _ = self.last_free_run.take();
+            return Some(pos);
+        }
+
+        let total = self.used_slots.len();
+        self.used_slots.zeroes().find(|&next_free| {
+            let end = next_free + slots_num;
+            end <= total && self.used_slots.count_zeroes(next_free..end) == slots_num
+        })
+    }
+
+    fn alloc(&mut self, len: usize) -> Result<Allocation, AllocError> {
+        if len == 0 {
+            return Err(AllocError::InvalidArg);
+        }
+
+        let total = self.used_slots.len();
+        let need_slots = len.div_ceil(N);
+        if need_slots > total {
+            return Err(AllocError::OutOfMemory);
+        }
+
+        let idx = self.find_slots(need_slots).ok_or(AllocError::NoSpace)?;
+        self.used_slots.insert_range(idx..idx + need_slots);
+        self.run_starts.insert(idx);
+        let addr = self.addr_of(idx).ok_or(AllocError::Overflow)?;
+
+        let alloc = Allocation {
+            addr,
+            len: need_slots * N,
+        };
+
+        self.maybe_invalidate_last_run(alloc);
+        Ok(alloc)
+    }
+
+    fn dealloc_addr(&mut self, addr: u64) -> Result<(), AllocError> {
+        let start = self.checked_slot_of(addr, 0)?;
+        let run_slots = self
+            .live_run_slots_at(start)
+            .ok_or(AllocError::InvalidFree(addr, 0))?;
+        self.dealloc_run(start, run_slots, addr)
+    }
+
+    fn dealloc_run(&mut self, start: usize, run_slots: usize, addr: u64) -> Result<(), AllocError> {
+        let len = run_slots * N;
+        self.used_slots.remove_range(start..start + run_slots);
+        self.run_starts.set(start, false);
+        self.last_free_run = Some(Allocation { addr, len });
+        Ok(())
+    }
+
+    fn allocation_len(&self, addr: u64) -> Result<usize, AllocError> {
+        let start = self.checked_slot_of(addr, 0)?;
+        let run_slots = self
+            .live_run_slots_at(start)
+            .ok_or(AllocError::InvalidFree(addr, 0))?;
+        Ok(run_slots * N)
+    }
+
+    fn capacity(&self) -> usize {
+        self.used_slots.len() * N
+    }
+
+    fn range(&self) -> core::ops::Range<u64> {
+        self.base_addr..self.base_addr + self.capacity() as u64
+    }
+
+    fn contains(&self, addr: u64) -> bool {
+        self.range().contains(&addr)
+    }
+
+    fn reset(&mut self) {
+        self.used_slots.clear();
+        self.run_starts.clear();
+        self.last_free_run = None;
+    }
+}
+
+#[cfg(test)]
+impl<const N: usize> Slab<N> {
+    fn free_bytes(&self) -> usize {
+        (self.used_slots.len() - self.used_slots.count_ones(..)) * N
+    }
+}
+
+#[inline]
+fn align_up(val: usize, align: usize) -> usize {
+    assert!(align > 0);
+    if val == 0 {
+        return 0;
+    }
+    val.div_ceil(align) * align
+}
+
+#[derive(Debug)]
+struct Inner<const L: usize, const U: usize> {
+    lower: Slab<L>,
+    upper: Slab<U>,
+}
+
+/// Two tier buffer pool with small and large slabs.
+#[derive(Debug, Clone)]
+pub struct BufferPool<const L: usize = 256, const U: usize = 4096> {
+    inner: SyncWrap<Rc<RefCell<Inner<L, U>>>>,
+}
+
+impl<const L: usize, const U: usize> BufferPool<L, U> {
+    /// Create a new buffer pool over a fixed region.
+    pub fn new(base_addr: u64, region_len: usize) -> Result<Self, AllocError> {
+        let inner = Inner::<L, U>::new(base_addr, region_len)?;
+        Ok(Self {
+            inner: SyncWrap(Rc::new(RefCell::new(inner))),
+        })
+    }
+}
+
+impl BufferPool {
+    /// Upper slab slot size in bytes.
+    pub const fn upper_slot_size() -> usize {
+        4096
+    }
+
+    /// Lower slab slot size in bytes.
+    pub const fn lower_slot_size() -> usize {
+        256
+    }
+}
+
+#[cfg(all(test, loom))]
+#[derive(Debug, Clone)]
+pub struct BufferPoolSync<const L: usize = 256, const U: usize = 4096> {
+    inner: std::sync::Arc<std::sync::Mutex<Inner<L, U>>>,
+}
+
+#[cfg(all(test, loom))]
+impl<const L: usize, const U: usize> BufferPoolSync<L, U> {
+    /// Create a new buffer pool over a fixed region.
+    pub fn new(base_addr: u64, region_len: usize) -> Result<Self, AllocError> {
+        let inner = Inner::<L, U>::new(base_addr, region_len)?;
+        Ok(Self {
+            inner: std::sync::Arc::new(std::sync::Mutex::new(inner)),
+        })
+    }
+}
+
+impl<const L: usize, const U: usize> Inner<L, U> {
+    /// Create a new buffer pool over a fixed region.
+    pub fn new(base_addr: u64, region_len: usize) -> Result<Self, AllocError> {
+        const LOWER_FRACTION: usize = 8;
+
+        let region_end = (base_addr as usize)
+            .checked_add(region_len)
+            .ok_or(AllocError::Overflow)? as u64;
+
+        let lower_base = align_up(base_addr as usize, L) as u64;
+        let usable = region_end
+            .checked_sub(lower_base)
+            .ok_or(AllocError::EmptyRegion)? as usize;
+
+        let lower_region = usable / LOWER_FRACTION;
+        let lower = Slab::<L>::new(lower_base, lower_region)?;
+
+        let upper_base = lower_base
+            .checked_add(lower.capacity() as u64)
+            .ok_or(AllocError::Overflow)?;
+
+        let upper_base = align_up(upper_base as usize, U) as u64;
+        let upper_region = region_end
+            .checked_sub(upper_base)
+            .ok_or(AllocError::EmptyRegion)? as usize;
+
+        let upper = Slab::<U>::new(upper_base, upper_region)?;
+        Ok(Self { lower, upper })
+    }
+
+    /// Allocate at least `len` bytes.
+    pub fn alloc(&mut self, len: usize) -> Result<Allocation, AllocError> {
+        if len <= L {
+            match self.lower.alloc(len) {
+                Ok(alloc) => return Ok(alloc),
+                Err(AllocError::NoSpace) => {}
+                Err(e) => return Err(e),
+            }
+        }
+
+        // fallback to upper slab
+        self.upper.alloc(len)
+    }
+
+    /// Free a previously allocated block by its start address.
+    pub fn dealloc_addr(&mut self, addr: u64) -> Result<(), AllocError> {
+        if self.lower.contains(addr) {
+            self.lower.dealloc_addr(addr)
+        } else {
+            self.upper.dealloc_addr(addr)
+        }
+    }
+
+    /// Capacity of a live allocation by its start address.
+    pub fn allocation_len(&self, addr: u64) -> Result<usize, AllocError> {
+        if self.lower.contains(addr) {
+            self.lower.allocation_len(addr)
+        } else {
+            self.upper.allocation_len(addr)
+        }
+    }
+}
+
+impl<const L: usize, const U: usize> BufferProvider for BufferPool<L, U> {
+    fn max_alloc_len(&self) -> usize {
+        U
+    }
+
+    fn alloc(&self, len: usize) -> Result<Allocation, AllocError> {
+        self.inner.borrow_mut().alloc(len)
+    }
+
+    fn alloc_sg(&self, total_len: usize) -> Result<SmallVec<[Allocation; 4]>, AllocError> {
+        Ok(smallvec::smallvec![self.alloc(total_len)?])
+    }
+
+    fn dealloc(&self, addr: u64) -> Result<(), AllocError> {
+        self.inner.borrow_mut().dealloc_addr(addr)
+    }
+
+    fn reset(&self) {
+        let mut inner = self.inner.borrow_mut();
+        inner.lower.reset();
+        inner.upper.reset();
+    }
+}
+
+impl<const L: usize, const U: usize> BufferPool<L, U> {
+    /// Free a previously allocated block by its start address.
+    pub fn dealloc_addr(&self, addr: u64) -> Result<(), AllocError> {
+        self.inner.borrow_mut().dealloc_addr(addr)
+    }
+
+    /// Capacity of a live allocation by its start address.
+    pub fn allocation_len(&self, addr: u64) -> Result<usize, AllocError> {
+        self.inner.borrow().allocation_len(addr)
+    }
+}
+
+#[cfg(all(test, loom))]
+impl<const L: usize, const U: usize> BufferProvider for BufferPoolSync<L, U> {
+    fn max_alloc_len(&self) -> usize {
+        U
+    }
+
+    fn alloc(&self, len: usize) -> Result<Allocation, AllocError> {
+        self.inner.lock().expect("poisoned mutex").alloc(len)
+    }
+
+    fn alloc_sg(&self, total_len: usize) -> Result<SmallVec<[Allocation; 4]>, AllocError> {
+        Ok(smallvec::smallvec![self.alloc(total_len)?])
+    }
+
+    fn dealloc(&self, addr: u64) -> Result<(), AllocError> {
+        self.inner
+            .lock()
+            .expect("poisoned mutex")
+            .dealloc_addr(addr)
+    }
+}
+
+/// Single-tier fixed-slot free list.
+///
+/// Tracks a fixed set of equal-sized buffer slots. Allocation pops a free slot
+/// and deallocation returns it, both O(1). A [`FixedBitSet`] records which slots
+/// are currently allocated, so double frees and frees of unknown addresses are
+/// rejected without scanning the free list.
+struct RecycleList {
+    base_addr: u64,
+    slot_size: usize,
+    count: usize,
+    /// Free slot addresses, popped/pushed LIFO.
+    free: SmallVec<[u64; 64]>,
+    /// One bit per slot index; set means the slot is currently handed out.
+    allocated: FixedBitSet,
+}
+
+impl RecycleList {
+    fn new(base_addr: u64, region_len: usize, slot_size: usize) -> Result<Self, AllocError> {
+        if slot_size == 0 {
+            return Err(AllocError::InvalidArg);
+        }
+
+        let count = region_len / slot_size;
+        if count == 0 {
+            return Err(AllocError::EmptyRegion);
+        }
+
+        let mut free = SmallVec::with_capacity(count);
+        for i in 0..count {
+            free.push(base_addr + (i * slot_size) as u64);
+        }
+
+        Ok(Self {
+            base_addr,
+            slot_size,
+            count,
+            free,
+            allocated: FixedBitSet::with_capacity(count),
+        })
+    }
+
+    fn end(&self) -> u64 {
+        self.base_addr + (self.count * self.slot_size) as u64
+    }
+
+    fn contains(&self, addr: u64) -> bool {
+        (self.base_addr..self.end()).contains(&addr)
+    }
+
+    /// Validate that `addr` names a slot start within the region.
+    fn slot_of(&self, addr: u64) -> Result<usize, AllocError> {
+        if !self.contains(addr) {
+            return Err(AllocError::InvalidFree(addr, 0));
+        }
+
+        let off = addr - self.base_addr;
+        if off % self.slot_size as u64 != 0 {
+            return Err(AllocError::InvalidFree(addr, 0));
+        }
+
+        Ok((off / self.slot_size as u64) as usize)
+    }
+
+    /// Validate that `addr` is a live (currently allocated) slot start.
+    fn live_slot_of(&self, addr: u64) -> Result<usize, AllocError> {
+        let slot = self.slot_of(addr)?;
+        if !self.allocated.contains(slot) {
+            return Err(AllocError::InvalidFree(addr, 0));
+        }
+        Ok(slot)
+    }
+
+    fn alloc(&mut self, len: usize) -> Result<Allocation, AllocError> {
+        if len == 0 {
+            return Err(AllocError::InvalidArg);
+        }
+        if len > self.slot_size {
+            return Err(AllocError::OutOfMemory);
+        }
+
+        let addr = self.free.pop().ok_or(AllocError::NoSpace)?;
+        // Safety of the index: `addr` came from `free`, which only ever holds
+        // valid slot starts.
+        self.allocated
+            .insert(((addr - self.base_addr) / self.slot_size as u64) as usize);
+
+        Ok(Allocation {
+            addr,
+            len: self.slot_size,
+        })
+    }
+
+    fn dealloc_addr(&mut self, addr: u64) -> Result<(), AllocError> {
+        let slot = self.live_slot_of(addr)?;
+        self.allocated.set(slot, false);
+        self.free.push(addr);
+        Ok(())
+    }
+
+    fn allocation_len(&self, addr: u64) -> Result<usize, AllocError> {
+        self.live_slot_of(addr)?;
+        Ok(self.slot_size)
+    }
+
+    /// Rebuild state so that exactly the addresses in `allocated` are marked
+    /// live and every other slot is free.
+    ///
+    /// On error the pool is left in an indeterminate state and should be
+    /// [`reset`](Self::reset) before reuse.
+    fn restore_allocated(&mut self, allocated: &[u64]) -> Result<(), AllocError> {
+        self.allocated.clear();
+        for &addr in allocated {
+            let slot = self.slot_of(addr)?;
+            if self.allocated.contains(slot) {
+                return Err(AllocError::InvalidFree(addr, self.slot_size));
+            }
+            self.allocated.insert(slot);
+        }
+        self.rebuild_free();
+        Ok(())
+    }
+
+    fn reset(&mut self) {
+        self.allocated.clear();
+        self.rebuild_free();
+    }
+
+    /// Repopulate the free list with every slot whose allocated bit is clear.
+    fn rebuild_free(&mut self) {
+        self.free.clear();
+        for i in 0..self.count {
+            if !self.allocated.contains(i) {
+                self.free.push(self.base_addr + (i * self.slot_size) as u64);
+            }
+        }
+    }
+
+    fn slot_addr(&self, index: usize) -> Option<u64> {
+        (index < self.count).then(|| self.base_addr + (index * self.slot_size) as u64)
+    }
+
+    fn num_free(&self) -> usize {
+        self.free.len()
+    }
+}
+
+/// A recycling buffer provider with fixed-size slots.
+///
+/// Holds a fixed set of equal-sized buffer addresses in a free list. Alloc and
+/// dealloc are O(1). It is intended for bounded scatter/gather descriptor
+/// segments that are pre-allocated and recycled after use:
+/// [`alloc_sg`](BufferProvider::alloc_sg) splits a logical payload into
+/// `ceil(total_len / slot_size)` fixed-size segments.
+#[derive(Clone)]
+pub struct RecyclePool {
+    inner: SyncWrap<Rc<RefCell<RecycleList>>>,
+}
+
+impl RecyclePool {
+    /// Create a recycling pool of `slot_size`-byte slots over a fixed region.
+    ///
+    /// The base address is aligned up to `slot_size`; the slot count is
+    /// `region_len / slot_size`.
+    pub fn new(base_addr: u64, region_len: usize, slot_size: usize) -> Result<Self, AllocError> {
+        if slot_size == 0 {
+            return Err(AllocError::InvalidArg);
+        }
+
+        let aligned = align_up(base_addr as usize, slot_size) as u64;
+        let list = RecycleList::new(aligned, region_len, slot_size)?;
+
+        Ok(Self {
+            inner: SyncWrap(Rc::new(RefCell::new(list))),
+        })
+    }
+
+    /// Rebuild pool state so that every address in `allocated` is removed from
+    /// the free list, matching externally known inflight state.
+    pub fn restore_allocated(&self, allocated: &[u64]) -> Result<(), AllocError> {
+        self.inner.borrow_mut().restore_allocated(allocated)
+    }
+
+    /// Compute the address of slot `index`.
+    ///
+    /// Returns `None` if `index >= count`.
+    pub fn slot_addr(&self, index: usize) -> Option<u64> {
+        self.inner.borrow().slot_addr(index)
+    }
+
+    /// Number of free slots.
+    pub fn num_free(&self) -> usize {
+        self.inner.borrow().num_free()
+    }
+
+    /// Free a previously allocated slot by address.
+    pub fn dealloc_addr(&self, addr: u64) -> Result<(), AllocError> {
+        self.inner.borrow_mut().dealloc_addr(addr)
+    }
+
+    /// Capacity of a live allocation by its start address.
+    pub fn allocation_len(&self, addr: u64) -> Result<usize, AllocError> {
+        self.inner.borrow().allocation_len(addr)
+    }
+
+    /// Base address of the pool region.
+    pub fn base_addr(&self) -> u64 {
+        self.inner.borrow().base_addr
+    }
+
+    /// Slot size in bytes.
+    pub fn slot_size(&self) -> usize {
+        self.inner.borrow().slot_size
+    }
+
+    /// Number of slots in the pool.
+    pub fn count(&self) -> usize {
+        self.inner.borrow().count
+    }
+}
+
+impl BufferProvider for RecyclePool {
+    fn max_alloc_len(&self) -> usize {
+        self.inner.borrow().slot_size
+    }
+
+    fn alloc(&self, len: usize) -> Result<Allocation, AllocError> {
+        self.inner.borrow_mut().alloc(len)
+    }
+
+    fn dealloc(&self, addr: u64) -> Result<(), AllocError> {
+        self.inner.borrow_mut().dealloc_addr(addr)
+    }
+
+    fn reset(&self) {
+        self.inner.borrow_mut().reset()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_pool<const L: usize, const U: usize>(size: usize) -> BufferPool<L, U> {
+        let base = align_up(0x10000, L.max(U)) as u64;
+        BufferPool::<L, U>::new(base, size).unwrap()
+    }
+
+    fn make_recycle_pool(slot_count: usize, slot_size: usize) -> RecyclePool {
+        let base = 0x80000u64;
+        RecyclePool::new(base, slot_count * slot_size, slot_size).unwrap()
+    }
+
+    #[test]
+    fn test_pool_new_success() {
+        let pool = BufferPool::<256, 4096>::new(0x10000, 1024 * 1024).unwrap();
+        assert!(pool.inner.borrow().lower.capacity() > 0);
+        assert!(pool.inner.borrow().upper.capacity() > 0);
+    }
+
+    #[test]
+    fn test_pool_alloc_small_to_lower() {
+        let pool = make_pool::<256, 4096>(1024 * 1024);
+        let alloc = pool.alloc(128).unwrap();
+
+        // Should come from lower slab
+        assert!(pool.inner.borrow().lower.contains(alloc.addr));
+        assert_eq!(alloc.len, 256);
+    }
+
+    #[test]
+    fn test_pool_alloc_large_to_upper() {
+        let pool = make_pool::<256, 4096>(1024 * 1024);
+        let alloc = pool.alloc(1500).unwrap();
+
+        // Should come from upper slab
+        assert!(pool.inner.borrow().upper.contains(alloc.addr));
+        assert_eq!(alloc.len, 4096);
+    }
+
+    #[test]
+    fn test_pool_alloc_fallback_to_upper() {
+        let pool = make_pool::<256, 4096>(1024 * 1024);
+
+        // Fill lower slab completely
+        let mut allocations = Vec::new();
+        while pool.inner.borrow().lower.free_bytes() > 0 {
+            allocations.push(pool.inner.borrow_mut().lower.alloc(256).unwrap());
+        }
+
+        // Small allocation should fallback to upper slab
+        let alloc = pool.alloc(128).unwrap();
+        assert!(pool.inner.borrow().upper.contains(alloc.addr));
+    }
+
+    #[test]
+    fn test_pool_free_from_lower() {
+        let pool = make_pool::<256, 4096>(1024 * 1024);
+        let alloc = pool.alloc(128).unwrap();
+
+        let free_before = pool.inner.borrow().lower.free_bytes();
+        pool.dealloc(alloc.addr).unwrap();
+        assert_eq!(
+            pool.inner.borrow().lower.free_bytes(),
+            free_before + alloc.len
+        );
+    }
+
+    #[test]
+    fn test_pool_free_from_upper() {
+        let pool = make_pool::<256, 4096>(1024 * 1024);
+        let alloc = pool.alloc(1500).unwrap();
+
+        let free_before = pool.inner.borrow().upper.free_bytes();
+        pool.dealloc(alloc.addr).unwrap();
+        assert_eq!(
+            pool.inner.borrow().upper.free_bytes(),
+            free_before + alloc.len
+        );
+    }
+
+    #[test]
+    fn test_pool_stress_many_allocations() {
+        let pool = make_pool::<256, 4096>(4 * 1024 * 1024);
+        let mut allocations = Vec::new();
+
+        // Allocate many buffers
+        for i in 0..100 {
+            let size = if i % 2 == 0 { 128 } else { 1500 };
+            allocations.push(pool.alloc(size).unwrap());
+        }
+
+        // Free half of them
+        for i in (0..100).step_by(2) {
+            pool.dealloc(allocations[i].addr).unwrap();
+        }
+
+        // Should be able to allocate again
+        for i in 0..50 {
+            let size = if i % 2 == 0 { 128 } else { 1500 };
+            let _alloc = pool.alloc(size).unwrap();
+        }
+    }
+
+    #[test]
+    fn test_pool_mixed_workload() {
+        let pool = make_pool::<256, 4096>(2 * 1024 * 1024);
+
+        // Simulate virtio-net workload
+        let desc_buf = pool.alloc(64).unwrap(); // Control message
+        let rx_buf1 = pool.alloc(1500).unwrap(); // MTU packet
+        let rx_buf2 = pool.alloc(1500).unwrap(); // MTU packet
+        let tx_buf = pool.alloc(4096).unwrap(); // Large buffer
+
+        // Free and reallocate
+        pool.dealloc(rx_buf1.addr).unwrap();
+        let rx_buf3 = pool.alloc(1500).unwrap();
+
+        // Should reuse freed buffer (LIFO)
+        assert_eq!(rx_buf3.addr, rx_buf1.addr);
+
+        pool.dealloc(desc_buf.addr).unwrap();
+        pool.dealloc(rx_buf2.addr).unwrap();
+        pool.dealloc(rx_buf3.addr).unwrap();
+        pool.dealloc(tx_buf.addr).unwrap();
+    }
+
+    #[test]
+    fn test_pool_zero_allocation_error() {
+        let pool = make_pool::<256, 4096>(1024 * 1024);
+        let result = pool.alloc(0);
+        assert!(matches!(result, Err(AllocError::InvalidArg)));
+    }
+
+    #[test]
+    fn test_pool_too_large_allocation() {
+        let pool = make_pool::<256, 4096>(1024 * 1024);
+        let result = pool.alloc(2 * 1024 * 1024); // Larger than pool
+        assert!(matches!(result, Err(AllocError::OutOfMemory)));
+    }
+
+    #[test]
+    fn test_align_up_helper() {
+        assert_eq!(align_up(0, 256), 0);
+        assert_eq!(align_up(1, 256), 256);
+        assert_eq!(align_up(256, 256), 256);
+        assert_eq!(align_up(257, 256), 512);
+        assert_eq!(align_up(511, 256), 512);
+        assert_eq!(align_up(512, 256), 512);
+    }
+
+    // Edge case: allocation exactly at boundary
+    #[test]
+    fn test_pool_boundary_allocation() {
+        let pool = make_pool::<256, 4096>(1024 * 1024);
+
+        // Allocate exactly at boundary
+        let alloc = pool.alloc(256).unwrap();
+        assert!(pool.inner.borrow().lower.contains(alloc.addr));
+
+        // Allocate just over boundary
+        let alloc2 = pool.alloc(257).unwrap();
+        assert!(pool.inner.borrow().upper.contains(alloc2.addr));
+    }
+
+    #[test]
+    fn test_buffer_pool_reset_returns_to_initial_state() {
+        let pool = make_pool::<256, 4096>(0x20000);
+
+        // Allocate from both tiers
+        let a1 = pool.inner.borrow_mut().alloc(128).unwrap();
+        let a2 = pool.inner.borrow_mut().alloc(4096).unwrap();
+        assert!(a1.len > 0);
+        assert!(a2.len > 0);
+
+        pool.reset();
+
+        let inner = pool.inner.borrow();
+        assert_eq!(inner.lower.free_bytes(), inner.lower.capacity());
+        assert_eq!(inner.upper.free_bytes(), inner.upper.capacity());
+    }
+
+    #[test]
+    fn test_buffer_pool_reset_allows_reallocation() {
+        let pool = make_pool::<256, 4096>(0x20000);
+
+        // Fill up some allocations
+        let mut allocs = Vec::new();
+        for _ in 0..5 {
+            allocs.push(pool.inner.borrow_mut().alloc(256).unwrap());
+        }
+
+        pool.reset();
+
+        // Should be able to allocate as if fresh
+        let a = pool.inner.borrow_mut().alloc(256).unwrap();
+        assert!(a.len > 0);
+    }
+
+    #[test]
+    fn test_pool_dealloc_addr_routes_to_correct_tier() {
+        let pool = make_pool::<256, 4096>(0x20000);
+        let lower = pool.alloc(128).unwrap();
+        let upper = pool.alloc(1024).unwrap();
+
+        assert_eq!(pool.allocation_len(lower.addr).unwrap(), 256);
+        assert_eq!(pool.allocation_len(upper.addr).unwrap(), 4096);
+
+        pool.dealloc_addr(lower.addr).unwrap();
+        pool.dealloc_addr(upper.addr).unwrap();
+    }
+
+    #[test]
+    fn test_buffer_pool_alloc_sg_uses_one_contiguous_run() {
+        let pool = make_pool::<256, 4096>(0x20000);
+        let sgs = pool.alloc_sg(4096 * 2 + 1).unwrap();
+
+        assert_eq!(sgs.len(), 1);
+        assert_eq!(sgs[0].len, 4096 * 3);
+
+        for sg in sgs {
+            pool.dealloc(sg.addr).unwrap();
+        }
+    }
+
+    #[test]
+    fn test_buffer_pool_alloc_sg_large_run() {
+        let pool = make_pool::<256, 4096>(0x20000);
+        let sgs = pool.alloc_sg(8192).unwrap();
+
+        assert_eq!(sgs.len(), 1);
+        assert_eq!(sgs[0].len, 8192);
+
+        for sg in sgs {
+            pool.dealloc(sg.addr).unwrap();
+        }
+    }
+
+    #[test]
+    fn test_recycle_pool_alloc_sg_splits() {
+        let pool = make_recycle_pool(8, 4096);
+        let sgs = pool.alloc_sg(4096 * 2 + 1).unwrap();
+
+        assert_eq!(sgs.len(), 3);
+        assert_eq!(sgs[0].len, 4096);
+        assert_eq!(sgs[1].len, 4096);
+        assert_eq!(sgs[2].len, 4096);
+
+        for sg in sgs {
+            pool.dealloc(sg.addr).unwrap();
+        }
+    }
+
+    #[test]
+    fn test_recycle_pool_restore_allocated_removes_from_free_list() {
+        let pool = make_recycle_pool(4, 4096);
+        assert_eq!(pool.num_free(), 4);
+
+        let addrs = [0x80000, 0x81000]; // slots 0 and 1
+        pool.restore_allocated(&addrs).unwrap();
+        assert_eq!(pool.num_free(), 2);
+
+        // Allocating should only return the two remaining slots
+        let a1 = pool.alloc(4096).unwrap();
+        let a2 = pool.alloc(4096).unwrap();
+        assert!(pool.alloc(4096).is_err());
+
+        // The allocated addresses should be the non-restored ones
+        let mut got = [a1.addr, a2.addr];
+        got.sort();
+        assert_eq!(got, [0x82000, 0x83000]);
+    }
+
+    #[test]
+    fn test_recycle_pool_restore_allocated_invalid_addr_returns_error() {
+        let pool = make_recycle_pool(4, 4096);
+        let result = pool.restore_allocated(&[0xDEAD]);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_recycle_pool_restore_allocated_then_dealloc_roundtrip() {
+        let pool = make_recycle_pool(4, 4096);
+        let addr = 0x81000u64;
+
+        pool.restore_allocated(&[addr]).unwrap();
+        assert_eq!(pool.num_free(), 3);
+
+        // Dealloc the restored address
+        pool.dealloc(addr).unwrap();
+        assert_eq!(pool.num_free(), 4);
+    }
+
+    #[test]
+    fn test_recycle_pool_restore_allocated_all_slots() {
+        let pool = make_recycle_pool(4, 4096);
+        let addrs: Vec<u64> = (0..4).map(|i| 0x80000 + i * 4096).collect();
+
+        pool.restore_allocated(&addrs).unwrap();
+        assert_eq!(pool.num_free(), 0);
+        assert!(pool.alloc(4096).is_err());
+    }
+
+    #[test]
+    fn test_recycle_pool_restore_allocated_empty_list_is_noop() {
+        let pool = make_recycle_pool(4, 4096);
+        pool.restore_allocated(&[]).unwrap();
+        assert_eq!(pool.num_free(), 4);
+    }
+
+    #[test]
+    fn test_recycle_pool_restore_allocated_resets_first() {
+        let pool = make_recycle_pool(4, 4096);
+
+        // Allocate some slots
+        let _ = pool.alloc(4096).unwrap();
+        let _ = pool.alloc(4096).unwrap();
+        assert_eq!(pool.num_free(), 2);
+
+        // restore_allocated resets then removes - so 4 - 1 = 3
+        pool.restore_allocated(&[0x80000]).unwrap();
+        assert_eq!(pool.num_free(), 3);
+    }
+
+    #[test]
+    fn test_recycle_pool_dealloc_out_of_range() {
+        let pool = make_recycle_pool(4, 4096);
+        let _ = pool.alloc(4096).unwrap();
+
+        assert!(matches!(
+            pool.dealloc(0xDEAD),
+            Err(AllocError::InvalidFree(0xDEAD, 0))
+        ));
+    }
+
+    #[test]
+    fn test_recycle_pool_dealloc_misaligned() {
+        let pool = make_recycle_pool(4, 4096);
+        let _ = pool.alloc(4096).unwrap();
+
+        assert!(matches!(
+            pool.dealloc(0x80001),
+            Err(AllocError::InvalidFree(0x80001, 0))
+        ));
+    }
+
+    #[test]
+    fn test_recycle_pool_dealloc_double_free() {
+        let pool = make_recycle_pool(4, 4096);
+        let a = pool.alloc(4096).unwrap();
+        pool.dealloc(a.addr).unwrap();
+
+        // Second dealloc should fail - address is already in the free list
+        assert!(matches!(
+            pool.dealloc(a.addr),
+            Err(AllocError::InvalidFree(_, _))
+        ));
+    }
+
+    #[test]
+    fn test_recycle_pool_alloc_sg_rolls_back_on_failure() {
+        let pool = make_recycle_pool(2, 4096);
+
+        assert!(matches!(pool.alloc_sg(4096 * 3), Err(AllocError::NoSpace)));
+        assert_eq!(pool.num_free(), 2);
+
+        let alloc = pool.alloc(4096).unwrap();
+        assert_eq!(pool.num_free(), 1);
+        pool.dealloc(alloc.addr).unwrap();
+    }
+
+    #[test]
+    fn test_recycle_pool_dealloc_addr_and_allocation_len() {
+        let pool = make_recycle_pool(4, 4096);
+        let alloc = pool.alloc(4096).unwrap();
+
+        assert_eq!(pool.allocation_len(alloc.addr).unwrap(), 4096);
+        pool.dealloc_addr(alloc.addr).unwrap();
+        assert!(matches!(
+            pool.allocation_len(alloc.addr),
+            Err(AllocError::InvalidFree(_, 0))
+        ));
+    }
+
+    #[test]
+    fn test_recycle_pool_random_order_dealloc() {
+        let pool = make_recycle_pool(8, 4096);
+
+        let mut allocs: Vec<Allocation> = (0..8).map(|_| pool.alloc(4096).unwrap()).collect();
+        assert_eq!(pool.num_free(), 0);
+
+        // Dealloc in reverse order
+        allocs.reverse();
+        for a in &allocs {
+            pool.dealloc(a.addr).unwrap();
+        }
+        assert_eq!(pool.num_free(), 8);
+
+        // All slots should be re-allocatable
+        let reallocs: Vec<Allocation> = (0..8).map(|_| pool.alloc(4096).unwrap()).collect();
+        assert_eq!(pool.num_free(), 0);
+
+        // Verify all addresses are distinct
+        let mut addrs: Vec<u64> = reallocs.iter().map(|a| a.addr).collect();
+        addrs.sort();
+        addrs.dedup();
+        assert_eq!(addrs.len(), 8);
+    }
+
+    #[test]
+    fn test_recycle_pool_interleaved_alloc_dealloc_order() {
+        let pool = make_recycle_pool(4, 4096);
+
+        let a0 = pool.alloc(4096).unwrap();
+        let a1 = pool.alloc(4096).unwrap();
+        let a2 = pool.alloc(4096).unwrap();
+        let a3 = pool.alloc(4096).unwrap();
+        assert_eq!(pool.num_free(), 0);
+
+        // Free middle slots first (out of allocation order)
+        pool.dealloc(a2.addr).unwrap();
+        pool.dealloc(a0.addr).unwrap();
+        assert_eq!(pool.num_free(), 2);
+
+        // Re-alloc gets the out-of-order slots back (LIFO)
+        let b0 = pool.alloc(4096).unwrap();
+        assert_eq!(b0.addr, a0.addr);
+        let b1 = pool.alloc(4096).unwrap();
+        assert_eq!(b1.addr, a2.addr);
+
+        // Free everything in yet another order
+        pool.dealloc(a1.addr).unwrap();
+        pool.dealloc(b0.addr).unwrap();
+        pool.dealloc(b1.addr).unwrap();
+        pool.dealloc(a3.addr).unwrap();
+        assert_eq!(pool.num_free(), 4);
+
+        // All 4 original addresses should be available
+        let mut final_addrs: Vec<u64> = (0..4).map(|_| pool.alloc(4096).unwrap().addr).collect();
+        final_addrs.sort();
+        let expected: Vec<u64> = (0..4).map(|i| 0x80000 + i * 4096).collect();
+        assert_eq!(final_addrs, expected);
+    }
+
+    #[test]
+    fn test_recycle_pool_dealloc_order_independent_of_alloc_order() {
+        let pool = make_recycle_pool(6, 256);
+
+        // Allocate all
+        let allocs: Vec<Allocation> = (0..6).map(|_| pool.alloc(256).unwrap()).collect();
+
+        // Dealloc in scattered order: 4, 1, 5, 0, 3, 2
+        let order = [4, 1, 5, 0, 3, 2];
+        for &i in &order {
+            pool.dealloc(allocs[i].addr).unwrap();
+        }
+        assert_eq!(pool.num_free(), 6);
+
+        // Re-allocate all and verify we get back the full set
+        let mut realloc_addrs: Vec<u64> = (0..6).map(|_| pool.alloc(256).unwrap().addr).collect();
+        realloc_addrs.sort();
+
+        let mut orig_addrs: Vec<u64> = allocs.iter().map(|a| a.addr).collect();
+        orig_addrs.sort();
+
+        assert_eq!(realloc_addrs, orig_addrs);
+    }
+}
+
+#[cfg(test)]
+mod fuzz {
+    use quickcheck::{Arbitrary, Gen, QuickCheck};
+
+    use super::*;
+
+    const MAX_OPS: usize = 10;
+    const MAX_ALLOC_SIZE: usize = 8192;
+
+    #[derive(Clone, Debug)]
+    enum Op {
+        Alloc(usize),
+        AllocSg(usize),
+        Dealloc(usize),
+    }
+
+    impl Arbitrary for Op {
+        fn arbitrary(g: &mut Gen) -> Self {
+            match u8::arbitrary(g) % 3 {
+                0 => Op::Alloc(usize::arbitrary(g) % MAX_ALLOC_SIZE + 1),
+                1 => Op::AllocSg(usize::arbitrary(g) % MAX_ALLOC_SIZE + 1),
+                2 => Op::Dealloc(usize::arbitrary(g)),
+                _ => unreachable!(),
+            }
+        }
+    }
+
+    #[derive(Clone, Debug)]
+    struct Scenario {
+        pool_size: usize,
+        ops: Vec<Op>,
+    }
+
+    impl Arbitrary for Scenario {
+        fn arbitrary(g: &mut Gen) -> Self {
+            let pool_size = (usize::arbitrary(g) % (4 * 1024 * 1024)) + (1024 * 1024);
+            let num_ops = usize::arbitrary(g) % MAX_OPS + 1;
+            let ops = (0..num_ops).map(|_| Op::arbitrary(g)).collect();
+
+            Scenario { pool_size, ops }
+        }
+    }
+
+    fn run_scenario(s: Scenario) -> bool {
+        let base = align_up(0x10000, 4096) as u64;
+        let pool = match BufferPool::<256, 4096>::new(base, s.pool_size) {
+            Ok(p) => p,
+            Err(_) => return true,
+        };
+
+        let mut allocations: Vec<Allocation> = Vec::new();
+
+        for op in &s.ops {
+            match op {
+                Op::Alloc(size) => match pool.alloc(*size) {
+                    Ok(alloc) => {
+                        assert!(alloc.len >= *size);
+                        allocations.push(alloc);
+                    }
+                    Err(AllocError::NoSpace | AllocError::OutOfMemory) => {}
+                    Err(_) => {
+                        return false;
+                    }
+                },
+                Op::AllocSg(size) => match pool.alloc_sg(*size) {
+                    Ok(sgs) => {
+                        let total: usize = sgs.iter().map(|sg| sg.len).sum();
+                        assert!(total >= *size);
+                        allocations.extend(sgs);
+                    }
+                    Err(AllocError::NoSpace | AllocError::OutOfMemory) => {}
+                    Err(_) => {
+                        return false;
+                    }
+                },
+                Op::Dealloc(idx) => {
+                    if allocations.is_empty() {
+                        continue;
+                    }
+
+                    let idx = idx % allocations.len();
+                    let alloc = allocations.swap_remove(idx);
+
+                    match pool.dealloc(alloc.addr) {
+                        Ok(_) => {}
+                        Err(_) => return false,
+                    }
+                }
+            }
+
+            if check_pool_invariants(&pool, &allocations).is_err() {
+                return false;
+            }
+        }
+
+        // Cleanup
+        for alloc in &allocations {
+            if pool.dealloc(alloc.addr).is_err() {
+                return false;
+            }
+        }
+
+        check_pool_invariants(&pool, &allocations).is_ok()
+    }
+
+    fn check_slab_invariants<const N: usize>(slab: &Slab<N>) -> Result<(), &'static str> {
+        let used = slab.used_slots.count_ones(..);
+        let free = slab.used_slots.count_zeroes(..);
+        if used + free != slab.used_slots.len() {
+            return Err("used + free != total slots");
+        }
+
+        let expected_free = free * N;
+        if slab.free_bytes() != expected_free {
+            return Err("free_bytes doesn't match bitmap");
+        }
+
+        if let Some(alloc) = slab.last_free_run {
+            if alloc.len == 0 || alloc.len % N != 0 {
+                return Err("last_free_run has invalid length");
+            }
+            if !slab.contains(alloc.addr) {
+                return Err("last_free_run addr outside range");
+            }
+        }
+
+        Ok(())
+    }
+
+    fn check_pool_invariants<const L: usize, const U: usize>(
+        pool: &BufferPool<L, U>,
+        allocations: &[Allocation],
+    ) -> Result<(), &'static str> {
+        check_slab_invariants(&pool.inner.borrow().lower)?;
+        check_slab_invariants(&pool.inner.borrow().upper)?;
+
+        if pool.inner.borrow().lower.range().end > pool.inner.borrow().upper.range().start {
+            return Err("lower and upper ranges overlap");
+        }
+
+        let mut seen = std::collections::HashSet::new();
+
+        for alloc in allocations {
+            if !pool.inner.borrow().lower.contains(alloc.addr)
+                && !pool.inner.borrow().upper.contains(alloc.addr)
+            {
+                return Err("allocation address outside pool ranges");
+            }
+
+            if alloc.len % L != 0 && alloc.len % U != 0 {
+                return Err("allocation length not aligned to any tier");
+            }
+
+            if !seen.insert(alloc.addr) {
+                return Err("duplicate allocation address in tracking");
+            }
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn prop_allocator_invariants() {
+        #[cfg(miri)]
+        let tests = 10;
+        #[cfg(not(miri))]
+        let tests = 1000;
+
+        QuickCheck::new()
+            .tests(tests)
+            .quickcheck(run_scenario as fn(Scenario) -> bool);
+    }
+}

--- a/src/hyperlight_common/src/virtq/producer.rs
+++ b/src/hyperlight_common/src/virtq/producer.rs
@@ -1,0 +1,1776 @@
+/*
+Copyright 2026  The Hyperlight Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use alloc::collections::VecDeque;
+use alloc::vec::Vec;
+
+use bytes::Bytes;
+use smallvec::SmallVec;
+
+use super::*;
+
+/// A used chain observed by the driver (producer) side.
+///
+/// Read-only chains are returned as [`Ack`](Self::Ack). Chains with a writable
+/// buffer complete as [`Data`](Self::Data), even when the device wrote zero
+/// bytes. Non-empty segments in [`Data`](Self::Data) are backed by
+/// shared-memory pool allocations that are returned when the last clone is
+/// dropped.
+#[derive(Debug)]
+pub enum UsedChain {
+    /// Acknowledgement for a read-only/fire-and-forget chain.
+    Ack(Token),
+    /// Data written by the consumer into the chain's writable buffers.
+    ///
+    /// The payload may contain zero bytes when the consumer writes zero bytes;
+    /// that is still a data used chain because the submitted chain had
+    /// writable capacity.
+    Data(Token, Segments),
+}
+
+impl UsedChain {
+    /// Token identifying which submitted chain this used chain corresponds to.
+    pub fn token(&self) -> Token {
+        match self {
+            Self::Ack(token) | Self::Data(token, _) => *token,
+        }
+    }
+
+    /// Data written by the consumer as contiguous bytes, if this chain has data.
+    pub fn to_bytes(&self) -> Option<Bytes> {
+        match self {
+            Self::Ack(_) => None,
+            Self::Data(_, segments) => Some(segments.to_bytes()),
+        }
+    }
+
+    /// Segments written by the consumer, if this chain has data.
+    pub fn segments(&self) -> Option<&Segments> {
+        match self {
+            Self::Ack(_) => None,
+            Self::Data(_, segments) => Some(segments),
+        }
+    }
+
+    /// Consume the used chain and return written data as contiguous bytes, if present.
+    pub fn into_bytes(self) -> Option<Bytes> {
+        match self {
+            Self::Ack(_) => None,
+            Self::Data(_, segments) => Some(segments.into_bytes()),
+        }
+    }
+
+    /// Consume the used chain and return written segments, if present.
+    pub fn into_segments(self) -> Option<Segments> {
+        match self {
+            Self::Ack(_) => None,
+            Self::Data(_, segments) => Some(segments),
+        }
+    }
+}
+
+/// Allocation tracking for an in-flight descriptor chain.
+///
+/// Descriptor lengths have already been published to the ring, so in-flight
+/// state only needs the completion token and allocation ownership for later
+/// reclaim.
+#[derive(Debug)]
+pub(crate) struct Inflight {
+    token: Token,
+    chain: BufferChain,
+}
+
+/// A high-level virtqueue producer (driver side).
+///
+/// The producer sends chains to the consumer (device), and receives used chains.
+/// This is used on the driver/guest side.
+///
+/// # Threading
+///
+/// The producer is intended for single-threaded, guest-side use. Reply payloads
+/// are exposed as zero-copy [`Bytes`] via [`Bytes::from_owner`](bytes::Bytes::from_owner),
+/// which requires the owning pool to be `Send + Sync`. Do not move the producer
+/// or its replies across threads, and do not instantiate it on the multi-threaded
+/// host with those pools.
+///
+/// # Example
+///
+/// ```ignore
+/// let mut producer = VirtqProducer::new(layout, mem, notifier, pool);
+///
+/// // Build and submit a chain
+/// let mut chain = producer.chain().readable(64).writable(64).build()?;
+/// chain.write_all(b"hello")?;
+/// let token = producer.submit(chain)?;
+///
+/// // Later, poll for the used chain
+/// if let Some(used) = producer.poll()? {
+///     assert_eq!(used.token(), token);
+///     match used {
+///         UsedChain::Data(_, segments) => println!("Got used chain: {:?}", segments),
+///         UsedChain::Ack(_) => println!("Got ack"),
+///     }
+/// }
+/// ```
+pub struct VirtqProducer<M, N, P> {
+    inner: RingProducer<M>,
+    notifier: N,
+    pool: P,
+    next_token: u32,
+    inflight: Vec<Option<Inflight>>,
+    pending: VecDeque<UsedChain>,
+}
+
+impl<M, N, P> VirtqProducer<M, N, P>
+where
+    M: MemOps + Clone,
+    N: Notifier,
+    P: BufferProvider + Clone,
+{
+    /// Create a new virtqueue producer.
+    ///
+    /// # Arguments
+    ///
+    /// * `layout` - Ring memory layout (descriptor table and event suppression addresses)
+    /// * `mem` - Memory operations implementation for reading/writing to shared memory
+    /// * `notifier` - Callback for notifying the device (consumer) about new chains
+    /// * `pool` - Buffer allocator for chain payload and reply data
+    pub fn new(layout: Layout, mem: M, notifier: N, pool: P) -> Self {
+        let inner = RingProducer::new(layout, mem);
+        let ring_len = inner.len();
+
+        Self {
+            inner,
+            pool,
+            notifier,
+            next_token: 0,
+            inflight: (0..ring_len).map(|_| None).collect(),
+            pending: VecDeque::with_capacity(ring_len),
+        }
+    }
+
+    fn dealloc_elems(
+        &self,
+        elems: impl IntoIterator<Item = BufferElement>,
+    ) -> Result<(), VirtqError> {
+        let mut first_err = None;
+        for elem in elems {
+            if let Err(err) = self.pool.dealloc(elem.addr)
+                && first_err.is_none()
+            {
+                first_err = Some(VirtqError::Alloc(err));
+            }
+        }
+
+        if let Some(err) = first_err {
+            return Err(err);
+        }
+
+        Ok(())
+    }
+
+    /// Begin building a descriptor chain for submission.
+    ///
+    /// Returns a [`ChainBuilder`] that allocates buffers from the pool.
+    pub fn chain(&self) -> ChainBuilder<M, P> {
+        ChainBuilder::new(self.inner.mem().clone(), self.pool.clone())
+    }
+
+    /// Begin a batch of submissions.
+    ///
+    /// Chains submitted through the returned [`SubmitBatch`] are published to
+    /// the ring immediately, but the consumer is notified at most once when
+    /// [`SubmitBatch::finish`] is called. This mirrors the virtio pattern of
+    /// adding multiple buffers and then kicking the queue once.
+    pub fn batch(&mut self) -> SubmitBatch<'_, M, N, P> {
+        SubmitBatch::new(self)
+    }
+
+    /// Submit a [`SendChain`] to the ring.
+    ///
+    /// Publishes the descriptor chain, stores the in-flight tracking state,
+    /// and notifies the consumer if event suppression allows. Notifications
+    /// are layout-neutral; use [`batch`](Self::batch) when a higher-level
+    /// protocol wants to publish multiple chains and kick once.
+    ///
+    /// # Errors
+    ///
+    /// - [`VirtqError::PayloadTooLarge`] - written exceeds readable buffer capacity
+    /// - [`VirtqError::RingError`] - ring is full
+    /// - [`VirtqError::InvalidState`] - descriptor ID collision
+    pub fn submit(&mut self, chain: SendChain<M, P>) -> Result<Token, VirtqError> {
+        let cursor_before = self.inner.avail_cursor();
+        let token = self.publish(chain)?;
+        self.notify_since(cursor_before)?;
+        Ok(token)
+    }
+
+    fn publish(&mut self, send: SendChain<M, P>) -> Result<Token, VirtqError> {
+        let token_id = self.next_token;
+        let id = self.inner.submit_available(send.chain())?;
+        let token = Token { seq: token_id, id };
+
+        // A free descriptor id must never already be tracked as inflight.
+        if self.inflight[id as usize].is_some() {
+            return Err(VirtqError::InvalidState);
+        }
+
+        let inf = send.into_inflight(token);
+        self.inflight[id as usize] = Some(inf);
+        self.next_token = self.next_token.wrapping_add(1);
+
+        Ok(token)
+    }
+
+    fn notify_since(&mut self, cursor: RingCursor) -> Result<bool, VirtqError> {
+        let should_notify = self.inner.should_notify_since(cursor)?;
+        if should_notify {
+            self.notify_now();
+        }
+        Ok(should_notify)
+    }
+
+    fn notify_now(&self) {
+        self.notifier.notify(QueueStats {
+            num_free: self.inner.num_free(),
+            num_inflight: self.inner.num_inflight(),
+        });
+    }
+
+    /// Signal backpressure to the consumer.
+    ///
+    /// Bypasses event suppression. Call this when submit fails with a
+    /// backpressure error and the consumer needs to drain.
+    #[inline]
+    pub fn notify_backpressure(&self) {
+        self.notify_now();
+    }
+
+    /// Get the current used cursor position.
+    ///
+    /// Useful for setting up descriptor-based event suppression.
+    #[inline]
+    pub fn used_cursor(&self) -> RingCursor {
+        self.inner.used_cursor()
+    }
+
+    /// Number of free (unsubmitted) descriptors in the ring.
+    #[inline]
+    pub fn num_free(&self) -> usize {
+        self.inner.num_free()
+    }
+
+    /// Configure event suppression for used buffer notifications.
+    ///
+    /// This controls when the device (consumer) signals us about completed buffers:
+    ///
+    /// - [`SuppressionKind::Enable`]: Always signal (default) - good for latency
+    /// - [`SuppressionKind::Disable`]: Never signal - caller must poll
+    /// - [`SuppressionKind::Descriptor`]: Signal only at specific cursor position
+    ///
+    /// # Example: Used-chain batching
+    ///
+    /// ```ignore
+    /// // Submit chains, then suppress notifications until all are used
+    /// let mut se = producer.chain().readable(64).writable(128).build()?;
+    /// se.write_all(b"entry1")?;
+    /// producer.submit(se)?;
+    /// let cursor = producer.used_cursor();
+    /// producer.set_used_suppression(SuppressionKind::Descriptor(cursor))?;
+    /// // Device will notify only after reaching that cursor position
+    /// ```
+    pub fn set_used_suppression(&mut self, kind: SuppressionKind) -> Result<(), VirtqError> {
+        match kind {
+            SuppressionKind::Enable => self.inner.enable_used_notifications()?,
+            SuppressionKind::Disable => self.inner.disable_used_notifications()?,
+            SuppressionKind::Descriptor(cursor) => self
+                .inner
+                .enable_used_notifications_desc(cursor.head(), cursor.wrap())?,
+        }
+        Ok(())
+    }
+
+    /// Reset ring, inflight, and pool state to initial values.
+    ///
+    /// # Safety
+    ///
+    /// No outstanding [`UsedChain::Data`] buffers, borrowed segment views, or
+    /// peer accesses to previously submitted descriptors may exist. Resetting
+    /// recycles the same backing addresses, so outstanding zero-copy buffers or
+    /// stale descriptor users could alias memory that is handed out again.
+    ///
+    /// TODO(virtq): find a way to allow guest to keep used chains across resets.
+    pub unsafe fn reset(&mut self) {
+        self.inflight.iter_mut().for_each(|slot| *slot = None);
+        self.pending.clear();
+        self.inner.reset();
+        self.pool.reset();
+    }
+
+    /// Replace the pool and reset ring, inflight, and pending state.
+    ///
+    /// # Safety
+    ///
+    /// No outstanding [`UsedChain::Data`] buffers, borrowed segment views, or
+    /// peer accesses to previously submitted descriptors may exist. The new pool
+    /// may manage the same shared-memory addresses as the old pool, so old
+    /// zero-copy buffers must not outlive this transition.
+    pub unsafe fn reset_with_pool(&mut self, pool: P) {
+        self.pending.clear();
+        self.inflight.iter_mut().for_each(|slot| *slot = None);
+        self.inner.reset();
+        self.pool = pool;
+        self.pool.reset();
+    }
+}
+
+impl<M, N, P> VirtqProducer<M, N, P>
+where
+    M: MemOps + Clone + Send + 'static,
+    N: Notifier,
+    P: BufferProvider + Clone + Send + 'static,
+{
+    /// Poll for a single used chain from the device.
+    ///
+    /// Returns buffered used chains from prior [`reclaim`](Self::reclaim)
+    /// calls first, then checks the ring for newly used chains.
+    ///
+    /// Returns `Ok(Some(used))` if a used chain is available, `Ok(None)` if no
+    /// used chains are ready (would block), or an error if the device misbehaved.
+    ///
+    /// Data used chains contain zero-copy [`Bytes`] backed by the shared-memory
+    /// allocation via [`BufferOwner`]. The pool allocation is held alive as long
+    /// as any `Bytes` clone exists, and is returned to the pool when the last
+    /// clone is dropped.
+    ///
+    /// # Errors
+    ///
+    /// - [`VirtqError::InvalidState`] - Device returned invalid descriptor ID or
+    ///   wrote more data than the writable buffer capacity
+    pub fn poll(&mut self) -> Result<Option<UsedChain>, VirtqError> {
+        if let Some(chain) = self.pending.pop_front() {
+            return Ok(Some(chain));
+        }
+        self.poll_ring()
+    }
+
+    /// Reclaim ring slots and pool allocations from used descriptors.
+    ///
+    /// Processes all available used chains from the ring: frees readable
+    /// buffer allocations immediately, and buffers writable data for
+    /// later retrieval via [`poll`](Self::poll).
+    ///
+    /// Read-only ack used chains are discarded immediately.
+    ///
+    /// Use this to free resources under backpressure without losing
+    /// writable data. Returns the number of chains reclaimed.
+    pub fn reclaim(&mut self) -> Result<usize, VirtqError> {
+        let mut count = 0;
+        while let Some(chain) = self.poll_ring()? {
+            if matches!(chain, UsedChain::Data(_, _)) {
+                debug_assert!(self.pending.len() < self.inner.len());
+                self.pending.push_back(chain);
+            }
+            count += 1;
+        }
+        Ok(count)
+    }
+
+    /// Poll one used chain directly from the ring (bypassing pending buffer).
+    fn poll_ring(&mut self) -> Result<Option<UsedChain>, VirtqError> {
+        let used = match self.inner.poll_used() {
+            Ok(u) => u,
+            Err(RingError::WouldBlock) => return Ok(None),
+            Err(e) => return Err(e.into()),
+        };
+
+        let inf = self
+            .inflight
+            .get_mut(used.id as usize)
+            .and_then(Option::take)
+            .ok_or(VirtqError::InvalidState)?;
+
+        let written = used.len as usize;
+        let Inflight { token, chain } = inf;
+
+        self.dealloc_elems(chain.readables().iter().copied())?;
+
+        let used = if chain.writables().is_empty() {
+            UsedChain::Ack(token)
+        } else {
+            UsedChain::Data(token, self.recv_segments(chain.writables(), written)?)
+        };
+
+        Ok(Some(used))
+    }
+
+    fn recv_segments(
+        &self,
+        writables: &[BufferElement],
+        written: usize,
+    ) -> Result<Segments, VirtqError> {
+        let mut owned = SmallVec::<[(BufferElement, usize); 4]>::new();
+        let mut free = SmallVec::<[BufferElement; 4]>::new();
+        let mut remaining = written;
+
+        for &alloc in writables {
+            if remaining == 0 {
+                free.push(alloc);
+                continue;
+            }
+
+            let len = remaining.min(alloc.len as usize);
+            owned.push((alloc, len));
+            remaining -= len;
+        }
+
+        if remaining != 0 {
+            let elems = owned.iter().map(|(elem, _)| *elem).chain(free);
+            self.dealloc_elems(elems)?;
+            return Err(VirtqError::InvalidState);
+        }
+
+        for (elem, len) in &owned {
+            if unsafe { self.inner.mem().as_slice(elem.addr, *len) }.is_err() {
+                let elems = owned.iter().map(|(elem, _)| *elem).chain(free);
+                let _ = self.dealloc_elems(elems);
+                return Err(VirtqError::MemoryReadError);
+            }
+        }
+
+        let mut sgs = SmallVec::<[Bytes; 4]>::new();
+        for (elem, written) in owned {
+            let alloc = OwnedAlloc::new(
+                self.pool.clone(),
+                Allocation {
+                    addr: elem.addr,
+                    len: elem.len as usize,
+                },
+            );
+            let mem = self.inner.mem().clone();
+            let owner = BufferOwner {
+                alloc,
+                mem,
+                written,
+            };
+            sgs.push(Bytes::from_owner(owner));
+        }
+
+        self.dealloc_elems(free)?;
+
+        Ok(Segments::from_smallvec(sgs))
+    }
+
+    /// Drain all available used chains, calling the provided closure for each.
+    ///
+    /// This is a convenience method that repeatedly calls [`poll`](Self::poll)
+    /// until no more used chains are available.
+    ///
+    /// # Arguments
+    ///
+    /// * `f` - Closure called for each used chain
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// producer.drain(|used| {
+    ///     println!("Got used chain for {:?}", used.token());
+    /// })?;
+    /// ```
+    pub fn drain(&mut self, mut f: impl FnMut(UsedChain)) -> Result<(), VirtqError> {
+        while let Some(chain) = self.poll()? {
+            f(chain);
+        }
+
+        Ok(())
+    }
+}
+
+/// A scoped batch of producer submissions.
+///
+/// Submissions are published immediately, while notification is delayed until
+/// [`finish`](Self::finish). `finish` is explicit because the event-suppression
+/// check can fail; dropping a batch does not notify.
+#[must_use = "call finish to notify the consumer about batched submissions"]
+pub struct SubmitBatch<'a, M, N, P> {
+    producer: &'a mut VirtqProducer<M, N, P>,
+    notify_from: Option<RingCursor>,
+}
+
+impl<'a, M, N, P> SubmitBatch<'a, M, N, P>
+where
+    M: MemOps + Clone,
+    N: Notifier,
+    P: BufferProvider + Clone,
+{
+    fn new(producer: &'a mut VirtqProducer<M, N, P>) -> Self {
+        Self {
+            producer,
+            notify_from: None,
+        }
+    }
+
+    /// Begin building a descriptor chain for this batch.
+    pub fn chain(&self) -> ChainBuilder<M, P> {
+        self.producer.chain()
+    }
+
+    /// Publish a chain as part of this batch without notifying yet.
+    pub fn submit(&mut self, chain: SendChain<M, P>) -> Result<Token, VirtqError> {
+        let cursor_before = self.producer.inner.avail_cursor();
+        let token = self.producer.publish(chain)?;
+
+        if self.notify_from.is_none() {
+            self.notify_from = Some(cursor_before);
+        }
+        Ok(token)
+    }
+
+    /// Finish the batch and notify the consumer once if event suppression
+    /// requires it for the whole published range.
+    ///
+    /// Returns `true` if a notification was sent.
+    pub fn finish(mut self) -> Result<bool, VirtqError> {
+        let Some(notify_from) = self.notify_from.take() else {
+            return Ok(false);
+        };
+
+        self.producer.notify_since(notify_from)
+    }
+}
+
+/// Builder for configuring a descriptor chain's buffer layout.
+///
+/// If dropped without building, no resources are leaked (allocations are
+/// deferred to [`build`](Self::build)).
+#[must_use = "call .build() to create a SendChain"]
+pub struct ChainBuilder<M: MemOps, P: BufferProvider + Clone> {
+    mem: M,
+    pool: P,
+    rd_caps: SmallVec<[usize; 4]>,
+    wr_caps: SmallVec<[usize; 4]>,
+}
+
+impl<M: MemOps, P: BufferProvider + Clone> ChainBuilder<M, P> {
+    fn new(mem: M, pool: P) -> Self {
+        Self {
+            mem,
+            pool,
+            rd_caps: SmallVec::new(),
+            wr_caps: SmallVec::new(),
+        }
+    }
+
+    /// Request a device-readable buffer of `cap` bytes.
+    ///
+    /// The producer writes data into readable buffers before submission; the
+    /// consumer reads that data after polling the chain.
+    /// The actual allocation is deferred to [`build`](Self::build).
+    pub fn readable(mut self, cap: usize) -> Self {
+        self.rd_caps.push(cap);
+        self
+    }
+
+    /// Request a device-writable buffer of `cap` bytes.
+    ///
+    /// The writable buffer is filled by the consumer and returned via
+    /// [`VirtqProducer::poll`] as [`UsedChain`].
+    ///
+    /// Multiple writable buffers are completed as ordered [`Segments`]. The
+    /// consumer writes them sequentially, because the virtio used ring reports
+    /// one aggregate written length rather than per-descriptor lengths.
+    pub fn writable(mut self, cap: usize) -> Self {
+        self.wr_caps.push(cap);
+        self
+    }
+
+    /// Allocate buffers and return a [`SendChain`] for writing.
+    ///
+    /// # Errors
+    ///
+    /// - [`VirtqError::InvalidState`] - No buffers requested
+    /// - [`VirtqError::Alloc`] - Pool exhausted
+    pub fn build(self) -> Result<SendChain<M, P>, VirtqError> {
+        if self.rd_caps.is_empty() && self.wr_caps.is_empty() {
+            return Err(VirtqError::InvalidState);
+        }
+
+        let mut rollback = Rollback::new(&self.pool);
+        let mut rd_caps = SmallVec::<[usize; 4]>::new();
+        let mut rd_elems = SmallVec::<[BufferElement; 4]>::new();
+        let mut wr_elems = SmallVec::<[BufferElement; 4]>::new();
+
+        // Allocate readable buffers, splitting into multiple descriptors if needed.
+        // The buffer element lengths are initialized to zero and updated as the
+        // `SendChain` writes.
+        for &cap in &self.rd_caps {
+            let sgs = self.pool.alloc_sg(cap)?;
+            let mut remaining = cap;
+
+            for alloc in sgs {
+                let _ = checked_descriptor_len(alloc.len)?;
+                let seg_cap = remaining.min(alloc.len);
+
+                rd_caps.push(seg_cap);
+                rd_elems.push(BufferElement {
+                    addr: alloc.addr,
+                    len: 0,
+                    writable: false,
+                });
+                remaining -= seg_cap;
+                rollback.allocs.push(alloc);
+            }
+
+            if remaining != 0 {
+                return Err(VirtqError::InvalidState);
+            }
+        }
+
+        // Allocate writable buffers, with the same caveat about splitting as readable buffers.
+        // Writable buffer elements are initialized with their full capacity for the device to
+        // write into.
+        for &cap in &self.wr_caps {
+            let sgs = self.pool.alloc_sg(cap)?;
+            for alloc in sgs {
+                let len = checked_descriptor_len(alloc.len)?;
+                wr_elems.push(BufferElement {
+                    addr: alloc.addr,
+                    len,
+                    writable: true,
+                });
+                rollback.allocs.push(alloc);
+            }
+        }
+
+        let chain = BufferChainBuilder::new()
+            .readables(rd_elems)
+            .writables(wr_elems)
+            .build()?;
+
+        rollback.release();
+
+        Ok(SendChain {
+            mem: self.mem,
+            pool: self.pool,
+            chain: Some(chain),
+            rd_caps,
+            rd_capacity: self.rd_caps.iter().sum(),
+            rd_written: 0,
+            write_mode: WriteMode::Unset,
+        })
+    }
+}
+
+struct Rollback<'a, P: BufferProvider> {
+    pool: &'a P,
+    allocs: SmallVec<[Allocation; 8]>,
+}
+
+impl<'a, P: BufferProvider> Rollback<'a, P> {
+    fn new(pool: &'a P) -> Self {
+        Self {
+            pool,
+            allocs: SmallVec::new(),
+        }
+    }
+
+    fn release(mut self) {
+        self.allocs.clear();
+    }
+}
+
+impl<P: BufferProvider> Drop for Rollback<'_, P> {
+    fn drop(&mut self) {
+        for alloc in self.allocs.drain(..) {
+            let result = self.pool.dealloc(alloc.addr);
+            debug_assert!(result.is_ok(), "rollback dealloc failed: {result:?}");
+        }
+    }
+}
+
+/// Tracks which write API a [`SendChain`] payload uses, so the two paths are
+/// not mixed.
+///
+/// Copy writes ([`SendChain::write`]/[`SendChain::write_all`]) append at an
+/// aggregate cursor, while direct writes
+/// ([`SendChain::write_seg`]/[`SendChain::with_seg`]) set per-segment lengths
+/// absolutely. Mixing them would corrupt the written-length accounting.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum WriteMode {
+    Unset,
+    Append,
+    Direct,
+}
+
+/// A configured send chain ready for writing and submission.
+///
+/// Created by [`ChainBuilder::build`]. Write readable payload bytes directly on
+/// the chain, then submit via [`VirtqProducer::submit`].
+///
+/// # Examples
+///
+/// ```ignore
+/// let mut sc = producer.chain().readable(64).writable(128).build()?;
+/// sc.write_all(b"header")?.write_all(b" body")?;
+/// let tok = producer.submit(sc)?;
+///
+/// let mut sc = producer.chain().readable(128).build()?;
+/// sc.with_seg(0, |buf| serialize_into(buf))?;
+/// let tok = producer.submit(sc)?;
+/// ```
+///
+/// Copy writes (`write`/`write_all`) and direct writes (`write_seg`/`with_seg`)
+/// must not be mixed on the same chain; doing so panics in debug builds.
+///
+/// If dropped without submitting, allocated buffers are returned to the pool.
+#[must_use = "dropping without submitting deallocates the buffers"]
+pub struct SendChain<M: MemOps, P: BufferProvider> {
+    mem: M,
+    pool: P,
+    chain: Option<BufferChain>,
+    rd_caps: SmallVec<[usize; 4]>,
+    rd_capacity: usize,
+    rd_written: usize,
+    write_mode: WriteMode,
+}
+
+// `chain` is wrapped in `Option` only so `into_inflight` can `take()` it
+// without moving out of this `Drop` type; it stays `Some` for a chain's whole
+// public lifetime, so these `expect`s cannot fail.
+#[allow(clippy::expect_used)]
+impl<M: MemOps, P: BufferProvider> SendChain<M, P> {
+    fn chain(&self) -> &BufferChain {
+        self.chain.as_ref().expect("SendChain missing BufferChain")
+    }
+
+    fn chain_mut(&mut self) -> &mut BufferChain {
+        self.chain.as_mut().expect("SendChain missing BufferChain")
+    }
+
+    /// Record that this chain uses `mode`, asserting it is not mixed with the
+    /// other write path.
+    fn note_write_mode(&mut self, mode: WriteMode) {
+        debug_assert!(
+            self.write_mode == WriteMode::Unset || self.write_mode == mode,
+            "SendChain mixes copy writes (write/write_all) with direct writes (write_seg/with_seg)"
+        );
+        self.write_mode = mode;
+    }
+
+    fn into_inflight(mut self, token: Token) -> Inflight {
+        let chain = self.chain.take().expect("SendChain missing BufferChain");
+        Inflight { token, chain }
+    }
+
+    /// Number of producer-written readable segments in this chain.
+    pub fn segment_count(&self) -> usize {
+        self.chain().readables().len()
+    }
+
+    /// Total producer-written readable capacity in bytes.
+    pub fn capacity(&self) -> usize {
+        self.rd_capacity
+    }
+
+    /// Number of producer-written readable bytes written so far.
+    pub fn written(&self) -> usize {
+        self.rd_written
+    }
+
+    /// Remaining producer-written readable capacity.
+    pub fn remaining(&self) -> usize {
+        self.capacity() - self.written()
+    }
+
+    /// Write bytes into payload segments, returning how many bytes were written.
+    ///
+    /// Appends at the current aggregate write position and scatters across
+    /// readable segments in chain order. Uses [`MemOps::write`] (volatile on
+    /// host side). If `buf` is larger than the remaining capacity, writes as
+    /// many bytes as will fit.
+    ///
+    /// # Errors
+    ///
+    /// - [`VirtqError::NoPayloadSegment`] - no readable buffer allocated
+    /// - [`VirtqError::MemoryWriteError`] - underlying write failed
+    pub fn write(&mut self, buf: &[u8]) -> Result<usize, VirtqError> {
+        if self.segment_count() == 0 {
+            return Err(VirtqError::NoPayloadSegment);
+        }
+
+        self.note_write_mode(WriteMode::Append);
+
+        let mut remaining = &buf[..buf.len().min(self.remaining())];
+        let mut written = 0;
+
+        let SendChain {
+            mem,
+            chain,
+            rd_caps,
+            ..
+        } = self;
+
+        let readables = chain
+            .as_mut()
+            .expect("SendChain missing BufferChain")
+            .readables_mut();
+
+        for (readable, &cap) in readables.iter_mut().zip(rd_caps.iter()) {
+            if remaining.is_empty() {
+                break;
+            }
+
+            let written_len = readable.len as usize;
+            let free = cap - written_len;
+            if free == 0 {
+                continue;
+            }
+
+            let n = free.min(remaining.len());
+            let addr = readable.addr + written_len as u64;
+            mem.write(addr, &remaining[..n])
+                .map_err(|_| VirtqError::MemoryWriteError)?;
+
+            readable.len += n as u32;
+            written += n;
+            remaining = &remaining[n..];
+        }
+
+        self.rd_written += written;
+        Ok(written)
+    }
+
+    /// Write the entire buffer into payload segments.
+    ///
+    /// Appends at the current aggregate write position and scatters across
+    /// readable segments in chain order. Uses [`MemOps::write`] (volatile on
+    /// host side).
+    ///
+    /// # Errors
+    ///
+    /// - [`VirtqError::PayloadTooLarge`] - buf exceeds remaining capacity
+    /// - [`VirtqError::NoPayloadSegment`] - no readable buffer allocated
+    /// - [`VirtqError::MemoryWriteError`] - underlying write failed
+    pub fn write_all(&mut self, buf: &[u8]) -> Result<&mut Self, VirtqError> {
+        if self.segment_count() == 0 {
+            return Err(VirtqError::NoPayloadSegment);
+        }
+
+        if buf.len() > self.remaining() {
+            return Err(VirtqError::PayloadTooLarge {
+                recv: buf.len(),
+                limit: self.remaining(),
+            });
+        }
+
+        let written = self.write(buf)?;
+        debug_assert_eq!(written, buf.len());
+        Ok(self)
+    }
+
+    /// Write bytes into one readable segment by index.
+    ///
+    /// Writes from the start of the selected segment and records `buf.len()` as
+    /// that segment's descriptor length.
+    ///
+    /// # Errors
+    ///
+    /// - [`VirtqError::NoPayloadSegment`] - `index` does not name a payload segment
+    /// - [`VirtqError::PayloadTooLarge`] - `buf` exceeds the segment capacity
+    /// - [`VirtqError::MemoryWriteError`] - underlying write failed
+    pub fn write_seg(&mut self, index: usize, buf: &[u8]) -> Result<&mut Self, VirtqError> {
+        self.note_write_mode(WriteMode::Direct);
+
+        let cap = *self
+            .rd_caps
+            .get(index)
+            .ok_or(VirtqError::NoPayloadSegment)?;
+
+        if buf.len() > cap {
+            return Err(VirtqError::PayloadTooLarge {
+                recv: buf.len(),
+                limit: cap,
+            });
+        }
+
+        let addr = self
+            .chain()
+            .readables()
+            .get(index)
+            .ok_or(VirtqError::NoPayloadSegment)?
+            .addr;
+
+        self.mem
+            .write(addr, buf)
+            .map_err(|_| VirtqError::MemoryWriteError)?;
+
+        let previous = self.chain().readables()[index].len as usize;
+        self.chain_mut().readables_mut()[index].len = checked_descriptor_len(buf.len())?;
+        self.rd_written = self.rd_written - previous + buf.len();
+        Ok(self)
+    }
+
+    /// Serialize directly into one readable segment by index.
+    ///
+    /// The closure returns the number of valid bytes it wrote. The written
+    /// length for that segment is recorded on success.
+    ///
+    /// # Errors
+    ///
+    /// - [`VirtqError::NoPayloadSegment`] - `index` does not name a payload segment
+    /// - [`VirtqError::PayloadTooLarge`] - closure reports more bytes than segment capacity
+    /// - [`VirtqError::MemoryWriteError`] - the memory backend cannot expose a mutable slice
+    pub fn with_seg<E>(
+        &mut self,
+        index: usize,
+        f: impl FnOnce(&mut [u8]) -> Result<usize, E>,
+    ) -> Result<&mut Self, E>
+    where
+        E: From<VirtqError>,
+    {
+        self.note_write_mode(WriteMode::Direct);
+
+        let cap = *self
+            .rd_caps
+            .get(index)
+            .ok_or_else(|| E::from(VirtqError::NoPayloadSegment))?;
+
+        let addr = self
+            .chain()
+            .readables()
+            .get(index)
+            .ok_or_else(|| E::from(VirtqError::NoPayloadSegment))?
+            .addr;
+
+        let buf = unsafe {
+            self.mem
+                .as_mut_slice(addr, cap)
+                .map_err(|_| E::from(VirtqError::MemoryWriteError))?
+        };
+
+        let written = f(buf)?;
+        if written > buf.len() {
+            return Err(E::from(VirtqError::PayloadTooLarge {
+                recv: written,
+                limit: buf.len(),
+            }));
+        }
+
+        let previous = self.chain().readables()[index].len as usize;
+        // SAFETY: index was validated by the earlier get() call, so the readable element exists.
+        self.chain_mut().readables_mut()[index].len =
+            checked_descriptor_len(written).map_err(E::from)?;
+        self.rd_written = self.rd_written - previous + written;
+
+        Ok(self)
+    }
+}
+
+impl<M: MemOps, P: BufferProvider> Drop for SendChain<M, P> {
+    fn drop(&mut self) {
+        if let Some(chain) = self.chain.take() {
+            for elem in chain.elems() {
+                let result = self.pool.dealloc(elem.addr);
+                debug_assert!(result.is_ok(), "SendChain drop dealloc failed: {result:?}");
+            }
+        }
+    }
+}
+
+fn checked_descriptor_len(len: usize) -> Result<u32, VirtqError> {
+    if len > u32::MAX as usize {
+        return Err(VirtqError::PayloadTooLarge {
+            recv: len,
+            limit: u32::MAX as usize,
+        });
+    }
+    Ok(len as u32)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::virtq::ring::tests::{TestMem, make_ring};
+    use crate::virtq::test_utils::*;
+
+    fn poll_received<M: MemOps + Clone, N: Notifier>(
+        consumer: &mut VirtqConsumer<M, N>,
+    ) -> (RecvChain, ReplyChain<M>) {
+        consumer.poll(1024).unwrap().unwrap()
+    }
+
+    #[derive(Clone)]
+    struct NoDirectSliceMem(TestMem);
+
+    // SAFETY: Delegates all non-slice memory operations to TestMem. Direct
+    // slices are intentionally unsupported to exercise producer error handling.
+    unsafe impl MemOps for NoDirectSliceMem {
+        type Error = ();
+
+        fn read(&self, addr: u64, dst: &mut [u8]) -> Result<(), Self::Error> {
+            self.0.read(addr, dst).map_err(|e| match e {})
+        }
+
+        fn write(&self, addr: u64, src: &[u8]) -> Result<(), Self::Error> {
+            self.0.write(addr, src).map_err(|e| match e {})
+        }
+
+        fn load_acquire(&self, addr: u64) -> Result<u16, Self::Error> {
+            self.0.load_acquire(addr).map_err(|e| match e {})
+        }
+
+        fn store_release(&self, addr: u64, val: u16) -> Result<(), Self::Error> {
+            self.0.store_release(addr, val).map_err(|e| match e {})
+        }
+
+        unsafe fn as_slice(&self, _addr: u64, _len: usize) -> Result<&[u8], Self::Error> {
+            Err(())
+        }
+
+        unsafe fn as_mut_slice(&self, _addr: u64, _len: usize) -> Result<&mut [u8], Self::Error> {
+            Err(())
+        }
+    }
+
+    #[test]
+    fn test_chain_readwrite_build() {
+        let ring = make_ring(16);
+        let (producer, _consumer, _notifier) = make_test_producer(&ring);
+
+        let se = producer.chain().readable(64).writable(128).build().unwrap();
+        assert_eq!(se.capacity(), 64);
+        assert_eq!(se.written(), 0);
+        assert_eq!(se.remaining(), 64);
+    }
+
+    #[test]
+    fn test_chain_readable_writable_names_build() {
+        let ring = make_ring(16);
+        let (producer, _consumer, _notifier) = make_test_producer(&ring);
+
+        let se = producer.chain().readable(16).writable(32).build().unwrap();
+        assert_eq!(se.segment_count(), 1);
+        assert_eq!(se.capacity(), 16);
+    }
+
+    #[test]
+    fn test_chain_multi_readable_write_all_scatters() {
+        let ring = make_ring(16);
+        let (mut producer, mut consumer, _notifier) = make_test_producer(&ring);
+
+        let mut se = producer
+            .chain()
+            .readable(5)
+            .readable(6)
+            .writable(32)
+            .build()
+            .unwrap();
+        se.write_all(b"hello world").unwrap();
+
+        assert_eq!(se.written(), 11);
+
+        let token = producer.submit(se).unwrap();
+        let (recv, reply) = poll_received(&mut consumer);
+        assert_eq!(recv.token(), token);
+        assert_eq!(recv.to_bytes().as_ref(), b"hello world");
+        assert_eq!(recv.segments().segment_count(), 2);
+        assert_eq!(recv.segments().as_slice()[0].as_ref(), b"hello");
+        assert_eq!(recv.segments().as_slice()[1].as_ref(), b" world");
+        consumer.complete(reply).unwrap();
+    }
+
+    #[test]
+    fn test_chain_readable_splits_logical_capacity() {
+        let ring = make_ring(16);
+        let layout = ring.layout();
+        let mem = ring.mem();
+        let pool_base = mem.base_addr() + Layout::query_size(ring.len()) as u64 + 0x100;
+        let pool = TestPool::new_with_max_alloc_len(pool_base, 0x8000, 4);
+        let notifier = TestNotifier::new();
+        let mut producer = VirtqProducer::new(layout, mem.clone(), notifier.clone(), pool);
+        let mut consumer = VirtqConsumer::new(layout, mem, notifier);
+
+        let mut se = producer.chain().readable(10).writable(32).build().unwrap();
+
+        assert_eq!(se.segment_count(), 3);
+        assert_eq!(se.capacity(), 10);
+
+        se.write_all(b"abcdefghij").unwrap();
+        assert_eq!(se.written(), 10);
+
+        let token = producer.submit(se).unwrap();
+        let (recv, reply) = poll_received(&mut consumer);
+        assert_eq!(recv.token(), token);
+        assert_eq!(recv.to_bytes().as_ref(), b"abcdefghij");
+        assert_eq!(recv.segments().segment_count(), 3);
+        assert_eq!(recv.segments().as_slice()[0].as_ref(), b"abcd");
+        assert_eq!(recv.segments().as_slice()[1].as_ref(), b"efgh");
+        assert_eq!(recv.segments().as_slice()[2].as_ref(), b"ij");
+        consumer.complete(reply).unwrap();
+    }
+
+    #[test]
+    fn test_chain_readable_rejects_zero_capacity_on_build() {
+        let ring = make_ring(16);
+        let (producer, _consumer, _notifier) = make_test_producer(&ring);
+
+        assert!(matches!(
+            producer.chain().readable(0).build(),
+            Err(VirtqError::Alloc(AllocError::InvalidArg))
+        ));
+    }
+
+    #[test]
+    fn test_chain_writable_splits_logical_capacity() {
+        let ring = make_ring(16);
+        let layout = ring.layout();
+        let mem = ring.mem();
+        let pool_base = mem.base_addr() + Layout::query_size(ring.len()) as u64 + 0x100;
+        let pool = TestPool::new_with_max_alloc_len(pool_base, 0x8000, 4);
+        let notifier = TestNotifier::new();
+        let mut producer = VirtqProducer::new(layout, mem.clone(), notifier.clone(), pool);
+        let mut consumer = VirtqConsumer::new(layout, mem, notifier);
+
+        let se = producer.chain().writable(10).build().unwrap();
+        let token = producer.submit(se).unwrap();
+
+        let (_recv, reply) = poll_received(&mut consumer);
+        let ReplyChain::Writable(mut wc) = reply else {
+            panic!("expected writable reply");
+        };
+        assert_eq!(wc.capacity(), 10);
+
+        wc.write_all(b"abcdefghij").unwrap();
+        consumer.complete(wc).unwrap();
+
+        let used = producer.poll().unwrap().unwrap();
+        assert_eq!(used.token(), token);
+        let segments = used.segments().unwrap();
+        assert_eq!(segments.segment_count(), 3);
+        assert_eq!(segments.as_slice()[0].as_ref(), b"abcd");
+        assert_eq!(segments.as_slice()[1].as_ref(), b"efgh");
+        assert_eq!(segments.as_slice()[2].as_ref(), b"ij");
+    }
+
+    #[test]
+    fn test_chain_writable_rejects_zero_capacity_on_build() {
+        let ring = make_ring(16);
+        let (producer, _consumer, _notifier) = make_test_producer(&ring);
+
+        assert!(matches!(
+            producer.chain().writable(0).build(),
+            Err(VirtqError::Alloc(AllocError::InvalidArg))
+        ));
+    }
+
+    #[test]
+    fn test_chain_multi_readable_write_all_preserves_segments() {
+        let ring = make_ring(16);
+        let (mut producer, mut consumer, _notifier) = make_test_producer(&ring);
+
+        let mut se = producer.chain().readable(4).readable(4).build().unwrap();
+        se.write_all(b"headbody").unwrap();
+
+        producer.submit(se).unwrap();
+        let (recv, reply) = poll_received(&mut consumer);
+        assert_eq!(recv.to_bytes().as_ref(), b"headbody");
+        consumer.complete(reply).unwrap();
+    }
+
+    #[test]
+    fn test_chain_payload_segment_writer_serializes_directly() {
+        let ring = make_ring(16);
+        let (mut producer, mut consumer, _notifier) = make_test_producer(&ring);
+
+        let mut se = producer.chain().readable(4).readable(4).build().unwrap();
+        se.with_seg(0, |segment| {
+            segment.copy_from_slice(b"head");
+            Ok::<usize, VirtqError>(4)
+        })
+        .unwrap();
+        se.with_seg(1, |segment| {
+            segment.copy_from_slice(b"body");
+            Ok::<usize, VirtqError>(4)
+        })
+        .unwrap();
+
+        producer.submit(se).unwrap();
+        let (recv, reply) = poll_received(&mut consumer);
+        assert_eq!(recv.to_bytes().as_ref(), b"headbody");
+        assert_eq!(recv.segments().segment_count(), 2);
+        consumer.complete(reply).unwrap();
+    }
+
+    #[test]
+    fn test_chain_payload_segment_write_copies_directly() {
+        let ring = make_ring(16);
+        let (mut producer, mut consumer, _notifier) = make_test_producer(&ring);
+
+        let mut se = producer.chain().readable(4).readable(4).build().unwrap();
+        se.write_seg(0, b"head").unwrap();
+        se.write_seg(1, b"body").unwrap();
+
+        producer.submit(se).unwrap();
+        let (recv, reply) = poll_received(&mut consumer);
+        assert_eq!(recv.to_bytes().as_ref(), b"headbody");
+        assert_eq!(recv.segments().segment_count(), 2);
+        consumer.complete(reply).unwrap();
+    }
+
+    #[test]
+    fn test_chain_multi_writable_used_returns_segments() {
+        let ring = make_ring(16);
+        let (mut producer, mut consumer, _notifier) = make_test_producer(&ring);
+
+        let se = producer.chain().writable(5).writable(6).build().unwrap();
+        let token = producer.submit(se).unwrap();
+
+        let (_recv, reply) = poll_received(&mut consumer);
+        let ReplyChain::Writable(mut wc) = reply else {
+            panic!("expected writable reply");
+        };
+        assert_eq!(wc.capacity(), 11);
+
+        wc.write_all(b"hello world").unwrap();
+        consumer.complete(wc).unwrap();
+
+        let used = producer.poll().unwrap().unwrap();
+        assert_eq!(used.token(), token);
+        let segments = used.segments().unwrap();
+        assert_eq!(segments.segment_count(), 2);
+        assert_eq!(segments.as_slice()[0].as_ref(), b"hello");
+        assert_eq!(segments.as_slice()[1].as_ref(), b" world");
+        assert_eq!(segments.to_bytes().as_ref(), b"hello world");
+    }
+
+    #[test]
+    fn test_chain_multi_writable_short_used_truncates_last_segment() {
+        let ring = make_ring(16);
+        let (mut producer, mut consumer, _notifier) = make_test_producer(&ring);
+
+        let se = producer.chain().writable(5).writable(6).build().unwrap();
+        producer.submit(se).unwrap();
+
+        let (_recv, reply) = poll_received(&mut consumer);
+        let ReplyChain::Writable(mut wc) = reply else {
+            panic!("expected writable reply");
+        };
+
+        wc.write_all(b"hello wo").unwrap();
+        consumer.complete(wc).unwrap();
+
+        let used = producer.poll().unwrap().unwrap();
+        let segments = used.segments().unwrap();
+        assert_eq!(segments.segment_count(), 2);
+        assert_eq!(segments.as_slice()[0].as_ref(), b"hello");
+        assert_eq!(segments.as_slice()[1].as_ref(), b" wo");
+        assert_eq!(segments.to_bytes().as_ref(), b"hello wo");
+    }
+
+    #[test]
+    fn test_chain_multi_writable_zero_used_returns_empty_segments() {
+        let ring = make_ring(16);
+        let (mut producer, mut consumer, _notifier) = make_test_producer(&ring);
+
+        let se = producer.chain().writable(5).writable(6).build().unwrap();
+        producer.submit(se).unwrap();
+
+        let (_recv, reply) = poll_received(&mut consumer);
+        consumer.complete(reply).unwrap();
+
+        let used = producer.poll().unwrap().unwrap();
+        let segments = used.segments().unwrap();
+        assert_eq!(segments.segment_count(), 0);
+        assert!(segments.is_empty());
+        assert!(segments.to_bytes().is_empty());
+    }
+
+    #[test]
+    fn test_chain_readable_only_build() {
+        let ring = make_ring(16);
+        let (producer, _consumer, _notifier) = make_test_producer(&ring);
+
+        let se = producer.chain().readable(32).build().unwrap();
+        assert_eq!(se.capacity(), 32);
+    }
+
+    #[test]
+    fn test_chain_writable_only_build() {
+        let ring = make_ring(16);
+        let (producer, _consumer, _notifier) = make_test_producer(&ring);
+
+        let se = producer.chain().writable(64).build().unwrap();
+        assert_eq!(se.capacity(), 0);
+    }
+
+    #[test]
+    fn test_chain_empty_build_fails() {
+        let ring = make_ring(16);
+        let (producer, _consumer, _notifier) = make_test_producer(&ring);
+
+        let result = producer.chain().build();
+        assert!(matches!(result, Err(VirtqError::InvalidState)));
+    }
+
+    #[test]
+    fn test_send_chain_write_all_and_submit() {
+        let ring = make_ring(16);
+        let (mut producer, mut consumer, _notifier) = make_test_producer(&ring);
+
+        let mut se = producer.chain().readable(64).writable(128).build().unwrap();
+
+        se.write_all(b"hello")
+            .unwrap()
+            .write_all(b" world")
+            .unwrap();
+        assert_eq!(se.written(), 11);
+        assert_eq!(se.remaining(), 53);
+        let tok = producer.submit(se).unwrap();
+
+        let (recv, reply) = poll_received(&mut consumer);
+        assert_eq!(recv.token(), tok);
+        assert_eq!(recv.to_bytes().as_ref(), b"hello world");
+        consumer.complete(reply).unwrap();
+    }
+
+    #[test]
+    fn test_send_payload_write_all_fluent() {
+        let ring = make_ring(16);
+        let (mut producer, mut consumer, _notifier) = make_test_producer(&ring);
+
+        let mut se = producer.chain().readable(64).writable(128).build().unwrap();
+        se.write_all(b"hello")
+            .unwrap()
+            .write_all(b" world")
+            .unwrap();
+        assert_eq!(se.written(), 11);
+        assert_eq!(se.remaining(), 53);
+        let tok = producer.submit(se).unwrap();
+
+        let (recv, reply) = poll_received(&mut consumer);
+        assert_eq!(recv.token(), tok);
+        assert_eq!(recv.to_bytes().as_ref(), b"hello world");
+        consumer.complete(reply).unwrap();
+    }
+
+    #[test]
+    fn test_send_payload_partial_write() {
+        let ring = make_ring(16);
+        let (mut producer, mut consumer, _notifier) = make_test_producer(&ring);
+
+        let mut se = producer.chain().readable(8).build().unwrap();
+        let written = se.write(b"hello world").unwrap();
+        assert_eq!(written, 8);
+        assert_eq!(se.remaining(), 0);
+
+        producer.submit(se).unwrap();
+        let (recv, reply) = poll_received(&mut consumer);
+        assert_eq!(recv.to_bytes().as_ref(), b"hello wo");
+        consumer.complete(reply).unwrap();
+    }
+
+    #[test]
+    fn test_send_payload_write_with_serializes_directly() {
+        let ring = make_ring(16);
+        let (mut producer, mut consumer, _notifier) = make_test_producer(&ring);
+
+        let mut se = producer.chain().readable(64).writable(128).build().unwrap();
+        se.with_seg(0, |buf| {
+            buf[..5].copy_from_slice(b"hello");
+            Ok::<usize, VirtqError>(5)
+        })
+        .unwrap();
+
+        let _tok = producer.submit(se).unwrap();
+
+        let (recv, reply) = poll_received(&mut consumer);
+        assert_eq!(recv.to_bytes().as_ref(), b"hello");
+        consumer.complete(reply).unwrap();
+    }
+
+    #[test]
+    fn test_send_chain_single_segment_writer_serializes_directly() {
+        let ring = make_ring(16);
+        let (mut producer, mut consumer, _notifier) = make_test_producer(&ring);
+
+        let mut se = producer.chain().readable(64).writable(128).build().unwrap();
+        se.with_seg(0, |segment| {
+            assert_eq!(segment.len(), 64);
+            segment[..5].copy_from_slice(b"hello");
+            Ok::<usize, VirtqError>(5)
+        })
+        .unwrap();
+
+        let _tok = producer.submit(se).unwrap();
+
+        let (recv, reply) = poll_received(&mut consumer);
+        assert_eq!(recv.to_bytes().as_ref(), b"hello");
+        consumer.complete(reply).unwrap();
+    }
+
+    #[test]
+    fn test_send_chain_single_segment_writer_rejects_multi_segment() {
+        let ring = make_ring(16);
+        let (producer, _consumer, _notifier) = make_test_producer(&ring);
+
+        let mut se = producer.chain().readable(4).readable(4).build().unwrap();
+        assert!(matches!(
+            se.with_seg(2, |_| Ok::<usize, VirtqError>(0)),
+            Err(VirtqError::NoPayloadSegment)
+        ));
+    }
+
+    #[test]
+    fn test_send_chain_single_segment_writer_rejects_auto_split_chain() {
+        let ring = make_ring(16);
+        let layout = ring.layout();
+        let mem = ring.mem();
+        let pool_base = mem.base_addr() + Layout::query_size(ring.len()) as u64 + 0x100;
+        let pool = TestPool::new_with_max_alloc_len(pool_base, 0x8000, 4);
+        let notifier = TestNotifier::new();
+        let producer = VirtqProducer::new(layout, mem, notifier, pool);
+
+        let mut se = producer.chain().readable(8).build().unwrap();
+        assert_eq!(se.segment_count(), 2);
+        assert!(matches!(
+            se.with_seg(2, |_| Ok::<usize, VirtqError>(0)),
+            Err(VirtqError::NoPayloadSegment)
+        ));
+    }
+
+    #[test]
+    fn test_send_payload_segment_set_written_too_large() {
+        let ring = make_ring(16);
+        let (producer, _consumer, _notifier) = make_test_producer(&ring);
+
+        let mut se = producer.chain().readable(32).writable(64).build().unwrap();
+        let err = se
+            .with_seg(0, |_| Ok::<usize, VirtqError>(64))
+            .err()
+            .unwrap();
+        assert!(matches!(
+            err,
+            VirtqError::PayloadTooLarge {
+                recv: 64,
+                limit: 32
+            }
+        ));
+    }
+
+    #[test]
+    fn test_send_chain_write_too_large() {
+        let ring = make_ring(16);
+        let (producer, _consumer, _notifier) = make_test_producer(&ring);
+
+        let mut se = producer.chain().readable(4).build().unwrap();
+        let err = se.write_all(b"too long").err().unwrap();
+        assert!(matches!(
+            err,
+            VirtqError::PayloadTooLarge { recv: 8, limit: 4 }
+        ));
+    }
+
+    #[test]
+    fn test_writeonly_has_no_readable_buffer() {
+        let ring = make_ring(16);
+        let (producer, _consumer, _notifier) = make_test_producer(&ring);
+
+        let mut se = producer.chain().writable(32).build().unwrap();
+        let err = se.write_all(b"data").err().unwrap();
+        assert!(matches!(err, VirtqError::NoPayloadSegment));
+    }
+
+    #[test]
+    fn test_drop_chain_builder_deallocs() {
+        let ring = make_ring(16);
+        let (mut producer, _consumer, _notifier) = make_test_producer(&ring);
+
+        {
+            let _builder = producer.chain().readable(64).writable(128);
+            // dropped without build
+        }
+
+        // Ring should still be fully usable
+        let se = producer.chain().readable(64).writable(128).build().unwrap();
+        let tok = producer.submit(se).unwrap();
+        assert!(tok.id < 16);
+    }
+
+    #[test]
+    fn test_drop_send_chain_deallocs() {
+        let ring = make_ring(16);
+        let (mut producer, _consumer, _notifier) = make_test_producer(&ring);
+
+        {
+            let _se = producer.chain().readable(64).writable(128).build().unwrap();
+            // dropped without submit
+        }
+
+        // Ring should still be fully usable
+        let se = producer.chain().readable(64).writable(128).build().unwrap();
+        let tok = producer.submit(se).unwrap();
+        assert!(tok.id < 16);
+    }
+
+    #[test]
+    fn test_submit_notifies() {
+        let ring = make_ring(16);
+        let (mut producer, _consumer, notifier) = make_test_producer(&ring);
+
+        let initial_count = notifier.notification_count();
+
+        let mut se = producer.chain().readable(64).writable(128).build().unwrap();
+        se.write_all(b"hello").unwrap();
+        producer.submit(se).unwrap();
+
+        assert!(notifier.notification_count() > initial_count);
+    }
+
+    #[test]
+    fn test_submit_read_only_notifies_by_default() {
+        let ring = make_ring(16);
+        let (mut producer, _consumer, notifier) = make_test_producer(&ring);
+
+        let initial_count = notifier.notification_count();
+
+        let mut se = producer.chain().readable(64).build().unwrap();
+        se.write_all(b"fire-and-forget").unwrap();
+        producer.submit(se).unwrap();
+
+        assert!(notifier.notification_count() > initial_count);
+    }
+
+    #[test]
+    fn test_submit_write_only_notifies_by_default() {
+        let ring = make_ring(16);
+        let (mut producer, _consumer, notifier) = make_test_producer(&ring);
+
+        let initial_count = notifier.notification_count();
+
+        let se = producer.chain().writable(128).build().unwrap();
+        producer.submit(se).unwrap();
+
+        assert!(notifier.notification_count() > initial_count);
+    }
+
+    #[test]
+    fn test_batch_notifies_once_on_finish() {
+        let ring = make_ring(16);
+        let (mut producer, mut consumer, notifier) = make_test_producer(&ring);
+
+        let initial_count = notifier.notification_count();
+
+        let mut batch = producer.batch();
+
+        let mut first = batch.chain().readable(64).build().unwrap();
+        first.write_all(b"first").unwrap();
+        batch.submit(first).unwrap();
+
+        let mut second = batch.chain().readable(64).build().unwrap();
+        second.write_all(b"second").unwrap();
+        batch.submit(second).unwrap();
+
+        assert_eq!(notifier.notification_count(), initial_count);
+        assert!(batch.finish().unwrap());
+        assert_eq!(notifier.notification_count(), initial_count + 1);
+
+        let (recv, reply) = poll_received(&mut consumer);
+        assert_eq!(recv.to_bytes().as_ref(), b"first");
+        consumer.complete(reply).unwrap();
+
+        let (recv, reply) = poll_received(&mut consumer);
+        assert_eq!(recv.to_bytes().as_ref(), b"second");
+        consumer.complete(reply).unwrap();
+    }
+
+    #[test]
+    fn test_batch_finish_notifies_from_batch_start_cursor() {
+        let ring = make_ring(16);
+        let (mut producer, mut consumer, notifier) = make_test_producer(&ring);
+
+        let cursor = consumer.avail_cursor();
+        consumer
+            .set_avail_suppression(SuppressionKind::Descriptor(cursor))
+            .unwrap();
+
+        let mut batch = producer.batch();
+
+        let mut first = batch.chain().readable(64).build().unwrap();
+        first.write_all(b"first").unwrap();
+        batch.submit(first).unwrap();
+        assert_eq!(notifier.notification_count(), 0);
+
+        let mut second = batch.chain().readable(64).writable(64).build().unwrap();
+        second.write_all(b"second").unwrap();
+        batch.submit(second).unwrap();
+
+        assert!(batch.finish().unwrap());
+
+        assert_eq!(notifier.notification_count(), 1);
+    }
+
+    #[test]
+    fn test_empty_batch_finish_does_not_notify() {
+        let ring = make_ring(16);
+        let (mut producer, _consumer, notifier) = make_test_producer(&ring);
+
+        let batch = producer.batch();
+        assert!(!batch.finish().unwrap());
+        assert_eq!(notifier.notification_count(), 0);
+    }
+
+    #[test]
+    fn test_write_only_round_trip() {
+        let ring = make_ring(16);
+        let (mut producer, mut consumer, _notifier) = make_test_producer(&ring);
+
+        let se = producer.chain().writable(32).build().unwrap();
+        let token = producer.submit(se).unwrap();
+
+        let (recv, reply) = poll_received(&mut consumer);
+        assert_eq!(recv.token(), token);
+        assert!(recv.to_bytes().is_empty());
+
+        if let ReplyChain::Writable(mut wc) = reply {
+            wc.write_all(b"filled-by-consumer").unwrap();
+            consumer.complete(wc).unwrap();
+        } else {
+            panic!("expected Writable");
+        }
+
+        let used = producer.poll().unwrap().unwrap();
+        assert_eq!(used.token(), token);
+        assert_eq!(used.to_bytes().unwrap().len(), b"filled-by-consumer".len());
+        assert_eq!(used.to_bytes().unwrap().as_ref(), b"filled-by-consumer");
+    }
+
+    #[test]
+    fn test_read_only_round_trip() {
+        let ring = make_ring(16);
+        let (mut producer, mut consumer, _notifier) = make_test_producer(&ring);
+
+        let mut se = producer.chain().readable(32).build().unwrap();
+        se.write_all(b"fire-and-forget").unwrap();
+        let token = producer.submit(se).unwrap();
+
+        let (recv, reply) = poll_received(&mut consumer);
+        assert_eq!(recv.token(), token);
+        assert_eq!(recv.to_bytes().as_ref(), b"fire-and-forget");
+        assert!(matches!(reply, ReplyChain::Ack(_)));
+        consumer.complete(reply).unwrap();
+
+        let used = producer.poll().unwrap().unwrap();
+        assert!(matches!(used, UsedChain::Ack(t) if t == token));
+    }
+
+    #[test]
+    fn test_readwrite_round_trip() {
+        let ring = make_ring(16);
+        let (mut producer, mut consumer, _notifier) = make_test_producer(&ring);
+
+        let mut se = producer.chain().readable(64).writable(128).build().unwrap();
+        se.write_all(b"request data").unwrap();
+        let token = producer.submit(se).unwrap();
+
+        let (recv, reply) = poll_received(&mut consumer);
+        assert_eq!(recv.to_bytes().as_ref(), b"request data");
+        if let ReplyChain::Writable(mut wc) = reply {
+            wc.write_all(b"response data").unwrap();
+            consumer.complete(wc).unwrap();
+        } else {
+            panic!("expected Writable");
+        }
+
+        let used = producer.poll().unwrap().unwrap();
+        assert_eq!(used.token(), token);
+        assert_eq!(used.to_bytes().unwrap().as_ref(), b"response data");
+    }
+
+    #[test]
+    fn test_poll_used_requires_direct_slice() {
+        let ring = make_ring(16);
+        let layout = ring.layout();
+        let test_mem = ring.mem();
+        let pool_base = test_mem.base_addr() + Layout::query_size(ring.len()) as u64 + 0x100;
+        let pool = TestPool::new(pool_base, 0x8000);
+        let notifier = TestNotifier::new();
+        let mem = NoDirectSliceMem(test_mem);
+        let mut producer = VirtqProducer::new(layout, mem.clone(), notifier.clone(), pool);
+        let mut consumer = VirtqConsumer::new(layout, mem, notifier);
+
+        let mut se = producer.chain().readable(64).writable(128).build().unwrap();
+        se.write_all(b"request data").unwrap();
+        producer.submit(se).unwrap();
+
+        let (_recv, reply) = poll_received(&mut consumer);
+        if let ReplyChain::Writable(mut wc) = reply {
+            wc.write_all(b"response data").unwrap();
+            consumer.complete(wc).unwrap();
+        } else {
+            panic!("expected Writable");
+        }
+
+        assert!(matches!(producer.poll(), Err(VirtqError::MemoryReadError)));
+    }
+
+    #[test]
+    fn test_virtq_producer_reset() {
+        let ring = make_ring(16);
+        let (mut producer, mut consumer, _notifier) = make_test_producer(&ring);
+
+        // Submit and complete a round trip
+        let mut se = producer.chain().readable(32).writable(64).build().unwrap();
+        se.write_all(b"hello").unwrap();
+        producer.submit(se).unwrap();
+
+        let (recv, reply) = poll_received(&mut consumer);
+        assert_eq!(recv.to_bytes().as_ref(), b"hello");
+        consumer.complete(reply).unwrap();
+        let _ = producer.poll().unwrap().unwrap();
+
+        // Now reset
+        // SAFETY: the used chain was dropped before reset and no peer can
+        // access the reset test ring concurrently.
+        unsafe {
+            producer.reset();
+        }
+
+        // All inflight slots should be cleared
+        assert_eq!(producer.inner.num_inflight(), 0);
+        // Ring state should be back to initial
+        assert_eq!(producer.inner.num_free(), producer.inner.len());
+    }
+
+    #[test]
+    fn test_virtq_producer_reset_clears_inflight() {
+        let ring = make_ring(16);
+        let (mut producer, _consumer, _notifier) = make_test_producer(&ring);
+
+        // Submit without completing
+        let se = producer.chain().writable(64).build().unwrap();
+        producer.submit(se).unwrap();
+
+        assert_eq!(producer.inner.num_inflight(), 1);
+
+        // SAFETY: no peer can access the reset test ring concurrently.
+        unsafe {
+            producer.reset();
+        }
+
+        assert_eq!(producer.inner.num_inflight(), 0);
+        assert_eq!(producer.inner.num_free(), producer.inner.len());
+    }
+}

--- a/src/hyperlight_common/src/virtq/producer.rs
+++ b/src/hyperlight_common/src/virtq/producer.rs
@@ -102,7 +102,7 @@ pub(crate) struct Inflight {
 ///
 /// The producer is intended for single-threaded, guest-side use. Reply payloads
 /// are exposed as zero-copy [`Bytes`] via [`Bytes::from_owner`](bytes::Bytes::from_owner),
-/// which requires the owning pool to be `Send + Sync`. Do not move the producer
+/// which requires the owning pool to be `Send`. Do not move the producer
 /// or its replies across threads, and do not instantiate it on the multi-threaded
 /// host with those pools.
 ///

--- a/src/hyperlight_common/src/virtq/ring.rs
+++ b/src/hyperlight_common/src/virtq/ring.rs
@@ -360,6 +360,11 @@ impl BufferChain {
         &self.elems[..self.split]
     }
 
+    /// Get mutable readable buffers in chain.
+    pub(crate) fn readables_mut(&mut self) -> &mut [BufferElement] {
+        &mut self.elems[..self.split]
+    }
+
     /// Get writable buffers in chain
     pub fn writables(&self) -> &[BufferElement] {
         &self.elems[self.split..]
@@ -713,11 +718,15 @@ impl<M: MemOps> RingProducer<M> {
             .ok_or(RingError::InvalidState)?;
 
         // Acquire flags then fields (publish point)
-        let desc = Descriptor::read_acquire(&self.mem, addr)
+        let flags = Descriptor::read_flags_acquire(&self.mem, addr)
             .map_err(|_| RingError::mem_err(MemOp::ReadDesc, addr))?;
-        if !desc.is_used(wrap) {
+
+        if !flags.is_used(wrap) {
             return Err(RingError::WouldBlock);
         }
+
+        let desc = Descriptor::read_body(&self.mem, addr, flags)
+            .map_err(|_| RingError::mem_err(MemOp::ReadDesc, addr))?;
 
         let id = desc.id;
         let count = *self
@@ -893,10 +902,7 @@ impl<M: MemOps> RingProducer<M> {
         // Linux kernel uses virtio_mb() full barrier in virtqueue_kick_prepare_packed.
         fence(Ordering::SeqCst);
 
-        let evt = EventSuppression::read_acquire(&self.mem, self.dev_evt_addr)
-            .map_err(|_| RingError::mem_err(MemOp::ReadEvent, self.dev_evt_addr))?;
-
-        Ok(should_notify(evt, self.len() as u16, old, new))
+        should_notify_evt(&self.mem, self.dev_evt_addr, self.len() as u16, old, new)
     }
 
     /// Reset to initial state matching a freshly zeroed ring.
@@ -1022,13 +1028,16 @@ impl<M: MemOps> RingConsumer<M> {
             .ok_or(RingError::InvalidState)?;
 
         // Acquire: flags then fields (publish point)
-        let head_desc = Descriptor::read_acquire(&self.mem, head_addr)
+        let flags = Descriptor::read_flags_acquire(&self.mem, head_addr)
             .map_err(|_| RingError::mem_err(MemOp::ReadDesc, head_addr))?;
 
         // Check if head descriptor is available to consume
-        if !head_desc.is_avail(wrap) {
+        if !flags.is_avail(wrap) {
             return Err(RingError::WouldBlock);
         }
+
+        let head_desc = Descriptor::read_body(&self.mem, head_addr, flags)
+            .map_err(|_| RingError::mem_err(MemOp::ReadDesc, head_addr))?;
 
         // Build chain (head + tails), tracking readable/writable split inline.
         let mut elements = SmallVec::<[BufferElement; 16]>::new();
@@ -1167,9 +1176,10 @@ impl<M: MemOps> RingConsumer<M> {
             return Err(RingError::InvalidState);
         };
 
-        let desc = Descriptor::read_acquire(&self.mem, addr)
+        let flags = Descriptor::read_flags_acquire(&self.mem, addr)
             .map_err(|_| RingError::mem_err(MemOp::ReadDesc, addr))?;
-        Ok(desc.is_avail(self.avail_cursor.wrap()))
+
+        Ok(flags.is_avail(self.avail_cursor.wrap()))
     }
 
     /// Submit a used descriptor and return whether to notify the driver.
@@ -1301,10 +1311,7 @@ impl<M: MemOps> RingConsumer<M> {
         // Driver Event Suppression structure. See also should_notify_device()
         fence(Ordering::SeqCst);
 
-        let evt = EventSuppression::read_acquire(&self.mem, self.drv_evt_addr)
-            .map_err(|_| RingError::mem_err(MemOp::ReadEvent, self.drv_evt_addr))?;
-
-        Ok(should_notify(evt, self.desc_table.len() as u16, old, new))
+        should_notify_evt(&self.mem, self.drv_evt_addr, self.len() as u16, old, new)
     }
 
     /// Reset to initial state matching a freshly zeroed ring.
@@ -1316,6 +1323,27 @@ impl<M: MemOps> RingConsumer<M> {
         self.num_inflight = 0;
         self.event_flags_shadow = EventFlags::ENABLE;
     }
+}
+
+/// Read an event-suppression structure and decide whether to notify the peer.
+fn should_notify_evt<M: MemOps>(
+    mem: &M,
+    evt_addr: u64,
+    ring_len: u16,
+    old: RingCursor,
+    new: RingCursor,
+) -> Result<bool, RingError> {
+    let flags = EventSuppression::read_flags_acquire(mem, evt_addr)
+        .map_err(|_| RingError::mem_err(MemOp::ReadEvent, evt_addr))?;
+
+    let evt = if flags == EventFlags::DESC {
+        EventSuppression::read_body(mem, evt_addr, flags)
+            .map_err(|_| RingError::mem_err(MemOp::ReadEvent, evt_addr))?
+    } else {
+        EventSuppression::new(0, flags)
+    };
+
+    Ok(should_notify(evt, ring_len, old, new))
 }
 
 /// Common packed-ring notification decision:
@@ -3358,7 +3386,8 @@ pub(crate) mod tests {
 
         let reader = make_producer(&ring);
         let addr = reader.desc_table().desc_addr(0).unwrap();
-        let desc = Descriptor::read_acquire(reader.mem(), addr).unwrap();
+        let flags = Descriptor::read_flags_acquire(reader.mem(), addr).unwrap();
+        let desc = Descriptor::read_body(reader.mem(), addr, flags).unwrap();
         assert_eq!(desc.addr, 0x1000);
         assert_eq!(desc.len, 4096);
         assert!(desc.is_writable());
@@ -3385,7 +3414,8 @@ pub(crate) mod tests {
 
         let reader = make_producer(&ring);
         let addr = reader.desc_table().desc_addr(0).unwrap();
-        let desc = Descriptor::read_acquire(reader.mem(), addr).unwrap();
+        let flags = Descriptor::read_flags_acquire(reader.mem(), addr).unwrap();
+        let desc = Descriptor::read_body(reader.mem(), addr, flags).unwrap();
         assert!(desc.is_used(true));
         assert!(!desc.is_avail(true));
     }

--- a/src/tests/rust_guests/Cargo.lock
+++ b/src/tests/rust_guests/Cargo.lock
@@ -103,6 +103,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bytes"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -152,6 +158,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
 name = "flatbuffers"
 version = "25.12.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -185,6 +197,8 @@ dependencies = [
  "anyhow",
  "bitflags",
  "bytemuck",
+ "bytes",
+ "fixedbitset",
  "flatbuffers",
  "log",
  "smallvec",


### PR DESCRIPTION
This patch adds a higher level api on top of the packed ring primitives in hyperlight_common so callers don't manage raw descriptors directly.

- Add VirtqProducer/VirtqConsumer in producer.rs and consumer.rs that handle buffer allocation, chain lifecycle, and event suppression/notification decisions; expand virtq/mod.rs with the public API, builders, and docs.
- Add buffer management: the BufferProvider trait and shared types in buffer.rs plus two concrete allocators - a two-tier variable-size BufferPool and a fixed-slot RecyclePool.
- Add an 8-byte wire message header in msg.rs  for message type discrimination and request/response correlation.
- Add loom-based concurrency tests in concurrency.rs using shadow atomics
- Add criterion benchmarks for the buffer pool and virtq API.