### PR TITLE
Updates rust version to 1.94

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -49,7 +49,7 @@ RUN SNIPPET="export PROMPT_COMMAND='history -a' && export HISTFILE=/commandhisto
 
 USER $USER
 
-ARG RUST_TOOLCHAIN=1.89
+ARG RUST_TOOLCHAIN=1.94
 
 # Install rust
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y \

--- a/.github/workflows/CargoAudit.yml
+++ b/.github/workflows/CargoAudit.yml
@@ -19,7 +19,7 @@ jobs:
       # TODO: Once the runner image is updated to include the necessary tools (without downloading), we can switch to the common workflow.
       - uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6  # v1.16.1
         with:
-          toolchain: "1.89"
+          toolchain: "1.94"
 
       - uses: rustsec/audit-check@69366f33c96575abad1ee0dba8212993eecbe998  # v2.0.0
         with:

--- a/.github/workflows/CargoPublish.yml
+++ b/.github/workflows/CargoPublish.yml
@@ -35,7 +35,7 @@ jobs:
 
       - uses: hyperlight-dev/ci-setup-workflow@f6bd9cc86d0737976d2128c8b8ced8edc017cbb4  # v1.9.0
         with:
-          rust-toolchain: "1.89"
+          rust-toolchain: "1.94"
 
       - name: Check crate versions
         shell: bash

--- a/.github/workflows/Coverage.yml
+++ b/.github/workflows/Coverage.yml
@@ -39,7 +39,7 @@ jobs:
 
       - uses: hyperlight-dev/ci-setup-workflow@f6bd9cc86d0737976d2128c8b8ced8edc017cbb4  # v1.9.0
         with:
-          rust-toolchain: "1.89"
+          rust-toolchain: "1.94"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/CreateDevcontainerImage.yml
+++ b/.github/workflows/CreateDevcontainerImage.yml
@@ -16,7 +16,7 @@ env:
   USER: vscode
   GROUP: vscode
   LLVM_VERSION: 18
-  RUST_TOOLCHAIN_DEFAULT: 1.89
+  RUST_TOOLCHAIN_DEFAULT: 1.94
   RUST_TOOLCHAIN_FILE: rust-toolchain.toml
 
 # There is a single job in this workflow. It's configured to run on the latest available version of Ubuntu.

--- a/.github/workflows/CreateRelease.yml
+++ b/.github/workflows/CreateRelease.yml
@@ -138,7 +138,7 @@ jobs:
           echo "HYPERLIGHT_VERSION=$version"
 
       - name: Install cargo-hyperlight
-        run: cargo install cargo-hyperlight --version 0.1.10 --locked --force
+        run: just ensure-cargo-hyperlight
 
       - name: Build and archive guest library + header files
         run: |

--- a/.github/workflows/CreateRelease.yml
+++ b/.github/workflows/CreateRelease.yml
@@ -32,7 +32,7 @@ jobs:
 
       - uses: hyperlight-dev/ci-setup-workflow@f6bd9cc86d0737976d2128c8b8ced8edc017cbb4  # v1.9.0
         with:
-          rust-toolchain: "1.89"
+          rust-toolchain: "1.94"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -53,7 +53,7 @@ jobs:
 
       - uses: hyperlight-dev/ci-setup-workflow@f6bd9cc86d0737976d2128c8b8ced8edc017cbb4  # v1.9.0
         with:
-          rust-toolchain: "1.89"
+          rust-toolchain: "1.94"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -123,7 +123,7 @@ jobs:
 
       - uses: hyperlight-dev/ci-setup-workflow@f6bd9cc86d0737976d2128c8b8ced8edc017cbb4  # v1.9.0
         with:
-          rust-toolchain: "1.89"
+          rust-toolchain: "1.94"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       

--- a/.github/workflows/PrimeCaches.yml
+++ b/.github/workflows/PrimeCaches.yml
@@ -81,7 +81,7 @@ jobs:
 
       - uses: hyperlight-dev/ci-setup-workflow@f6bd9cc86d0737976d2128c8b8ced8edc017cbb4  # v1.9.0
         with:
-          rust-toolchain: "1.89"
+          rust-toolchain: "1.94"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/RustNightly.yml
+++ b/.github/workflows/RustNightly.yml
@@ -74,7 +74,7 @@ jobs:
             src/tests/rust_guests -> target
 
       - name: Install cargo-hyperlight
-        run: cargo install cargo-hyperlight --version 0.1.10 --locked --force
+        run: just ensure-cargo-hyperlight
 
       - name: Build and move Rust guests
         run: |

--- a/.github/workflows/RustNightly.yml
+++ b/.github/workflows/RustNightly.yml
@@ -46,7 +46,7 @@ jobs:
 
       - uses: hyperlight-dev/ci-setup-workflow@f6bd9cc86d0737976d2128c8b8ced8edc017cbb4  # v1.9.0
         with:
-          rust-toolchain: "1.89"
+          rust-toolchain: "1.94"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -31,6 +31,6 @@ jobs:
 
       - uses: hyperlight-dev/ci-setup-workflow@f6bd9cc86d0737976d2128c8b8ced8edc017cbb4  # v1.9.0
         with:
-          rust-toolchain: "1.89" 
+          rust-toolchain: "1.94" 
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dep_benchmarks.yml
+++ b/.github/workflows/dep_benchmarks.yml
@@ -85,7 +85,7 @@ jobs:
 
       - uses: hyperlight-dev/ci-setup-workflow@f6bd9cc86d0737976d2128c8b8ced8edc017cbb4  # v1.9.0
         with:
-          rust-toolchain: "1.89"
+          rust-toolchain: "1.94"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/dep_build_guests.yml
+++ b/.github/workflows/dep_build_guests.yml
@@ -35,7 +35,7 @@ jobs:
 
       - uses: hyperlight-dev/ci-setup-workflow@f6bd9cc86d0737976d2128c8b8ced8edc017cbb4  # v1.9.0
         with:
-          rust-toolchain: "1.89"
+          rust-toolchain: "1.94"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/dep_build_guests.yml
+++ b/.github/workflows/dep_build_guests.yml
@@ -67,7 +67,7 @@ jobs:
             src/tests/rust_guests -> target
 
       - name: Install cargo-hyperlight
-        run: cargo install cargo-hyperlight --version 0.1.10 --locked --force
+        run: just ensure-cargo-hyperlight
 
       - name: Build Rust guests
         run: |

--- a/.github/workflows/dep_build_test.yml
+++ b/.github/workflows/dep_build_test.yml
@@ -52,7 +52,7 @@ jobs:
 
       - uses: hyperlight-dev/ci-setup-workflow@f6bd9cc86d0737976d2128c8b8ced8edc017cbb4  # v1.9.0
         with:
-          rust-toolchain: "1.89"
+          rust-toolchain: "1.94"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/dep_code_checks.yml
+++ b/.github/workflows/dep_code_checks.yml
@@ -71,7 +71,7 @@ jobs:
         run: just fmt-check
 
       - name: Install cargo-hyperlight
-        run: cargo install cargo-hyperlight --version 0.1.10 --locked --force
+        run: just ensure-cargo-hyperlight
 
       - name: clippy exhaustive check (debug)
         run: just clippy-exhaustive debug
@@ -139,7 +139,7 @@ jobs:
         run: just fmt-check
 
       - name: Install cargo-hyperlight
-        run: cargo install cargo-hyperlight --version 0.1.10 --locked --force
+        run: just ensure-cargo-hyperlight
 
       - name: clippy (debug)
         run: |

--- a/.github/workflows/dep_code_checks.yml
+++ b/.github/workflows/dep_code_checks.yml
@@ -32,7 +32,7 @@ jobs:
 
       - uses: hyperlight-dev/ci-setup-workflow@f6bd9cc86d0737976d2128c8b8ced8edc017cbb4  # v1.9.0
         with:
-          rust-toolchain: "1.89" 
+          rust-toolchain: "1.94" 
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -104,7 +104,7 @@ jobs:
 
       - uses: hyperlight-dev/ci-setup-workflow@f6bd9cc86d0737976d2128c8b8ced8edc017cbb4  # v1.9.0
         with:
-          rust-toolchain: "1.89" 
+          rust-toolchain: "1.94" 
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/dep_fuzzing.yml
+++ b/.github/workflows/dep_fuzzing.yml
@@ -33,7 +33,7 @@ jobs:
 
       - uses: hyperlight-dev/ci-setup-workflow@f6bd9cc86d0737976d2128c8b8ced8edc017cbb4  # v1.9.0
         with:
-          rust-toolchain: "1.89"
+          rust-toolchain: "1.94"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/dep_run_examples.yml
+++ b/.github/workflows/dep_run_examples.yml
@@ -52,7 +52,7 @@ jobs:
 
       - uses: hyperlight-dev/ci-setup-workflow@f6bd9cc86d0737976d2128c8b8ced8edc017cbb4  # v1.9.0
         with:
-          rust-toolchain: "1.89"
+          rust-toolchain: "1.94"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/dep_update_guest_locks.yml
+++ b/.github/workflows/dep_update_guest_locks.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Setup Rust toolchain
         uses: hyperlight-dev/ci-setup-workflow@f6bd9cc86d0737976d2128c8b8ced8edc017cbb4  # v1.9.0
         with:
-          rust-toolchain: "1.89"
+          rust-toolchain: "1.94"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/Justfile
+++ b/Justfile
@@ -48,7 +48,7 @@ build target=default-target:
 guests: build-and-move-rust-guests build-and-move-c-guests
 
 ensure-cargo-hyperlight:
-    cargo install --locked cargo-hyperlight
+    cargo install --locked --version 0.1.11 cargo-hyperlight
 
 witguest-wit:
     cargo install --locked wasm-tools

--- a/flake.nix
+++ b/flake.nix
@@ -91,9 +91,9 @@
           # for rustfmt and old toolchains to verify MSRV
           toolchains = lib.mapAttrs (_: customisedRustChannelOf) {
             stable = {
-              date = "2025-12-11";
+              date = "2026-03-05";
               channel = "stable";
-              sha256 = "sha256-sqSWJDUxc+zaz1nBWMAJKTAGBuGWP25GCftIOlCEAtA=";
+              sha256 = "sha256-qqF33vNuAdU5vua96VKVIwuc43j4EFeEXbjQ6+l4mO4=";
             };
             nightly = {
               date = "2026-02-27";

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.89"
+channel = "1.94"
 # Target used for guest binaries. This is an additive list of targets in addition to host platform.
 # Will install the target if not already installed when building guest binaries.
 targets = ["x86_64-unknown-none", "x86_64-unknown-linux-musl"]

--- a/src/hyperlight_common/src/virtq/mod.rs
+++ b/src/hyperlight_common/src/virtq/mod.rs
@@ -167,6 +167,7 @@ impl Layout {
 }
 
 const _: () = {
+    #[allow(clippy::panic)]
     #[allow(clippy::unwrap_used)]
     const fn verify_layout(num_descs: usize) {
         let base = 0x1000u64;

--- a/src/hyperlight_common/src/virtq/ring.rs
+++ b/src/hyperlight_common/src/virtq/ring.rs
@@ -411,7 +411,7 @@ impl RingCursor {
         let new = self.head + n;
         let wraps = new / self.size;
         self.head = new % self.size;
-        if wraps % 2 != 0 {
+        if !wraps.is_multiple_of(2) {
             self.wrap = !self.wrap;
         }
     }

--- a/src/hyperlight_guest_bin/src/lib.rs
+++ b/src/hyperlight_guest_bin/src/lib.rs
@@ -304,7 +304,7 @@ pub(crate) extern "C" fn generic_init(
         hyperlight_guest_tracing::flush();
     }
 
-    dispatch_function as usize as u64
+    dispatch_function as *const () as usize as u64
 }
 
 #[cfg(feature = "macros")]

--- a/src/hyperlight_guest_tracing/src/invariant_tsc.rs
+++ b/src/hyperlight_guest_tracing/src/invariant_tsc.rs
@@ -20,6 +20,10 @@ use core::arch::x86_64::{__cpuid, _rdtsc};
 /// Check if the processor supports invariant TSC
 ///
 /// Returns true if CPUID.80000007H:EDX[8] is set, indicating invariant TSC support
+// TODO: Remove this when MSRV is raised above 1.89.
+// On Rust 1.89, __cpuid requires `unsafe`; on newer compilers it is safe and
+// clippy flags these blocks as unnecessary.
+#[allow(unused_unsafe)]
 pub fn has_invariant_tsc() -> bool {
     // Check if extended CPUID functions are available
     let max_extended = unsafe { __cpuid(0x80000000) };

--- a/src/hyperlight_host/src/hypervisor/hyperlight_vm/x86_64.rs
+++ b/src/hyperlight_host/src/hypervisor/hyperlight_vm/x86_64.rs
@@ -1256,6 +1256,10 @@ mod tests {
     /// - size: CPUID.0DH.n:EAX - size in bytes
     /// - offset: CPUID.0DH.n:EBX - offset from XSAVE base (standard format only)
     /// - align_64: CPUID.0DH.n:ECX bit 1 - true if 64-byte aligned (compacted format)
+    // TODO: Remove this when MSRV is raised above 1.89.
+    // On Rust 1.89, __cpuid_count requires `unsafe`; on newer compilers it is safe and
+    // clippy flags these blocks as unnecessary.
+    #[allow(unused_unsafe)]
     fn xsave_component_info(comp_id: u32) -> (usize, usize, bool) {
         let result = unsafe { std::arch::x86_64::__cpuid_count(0xD, comp_id) };
         let size = result.eax as usize;
@@ -1266,6 +1270,10 @@ mod tests {
 
     /// Query CPUID.0DH.00H for the bitmap of supported user state components.
     /// EDX:EAX forms a 64-bit bitmap where bit i indicates support for component i.
+    // TODO: Remove this when MSRV is raised above 1.89.
+    // On Rust 1.89, __cpuid_count requires `unsafe`; on newer compilers it is safe and
+    // clippy flags these blocks as unnecessary.
+    #[allow(unused_unsafe)]
     fn xsave_supported_components() -> u64 {
         let result = unsafe { std::arch::x86_64::__cpuid_count(0xD, 0) };
         (result.edx as u64) << 32 | (result.eax as u64)

--- a/src/hyperlight_host/src/hypervisor/hyperlight_vm/x86_64.rs
+++ b/src/hyperlight_host/src/hypervisor/hyperlight_vm/x86_64.rs
@@ -1703,9 +1703,42 @@ mod tests {
         if reset_xsave.len() >= 576 {
             expected_xsave[512..576].copy_from_slice(&reset_xsave[512..576]);
         }
+
+        // Compute the end of valid XSAVE component data. In compacted format (MSHV/WHP),
+        // components are packed contiguously starting at offset 576. Bytes beyond the last
+        // component are undefined
+        let xcomp_bv = u64::from_le_bytes(reset_xsave[520..528].try_into().unwrap_or([0u8; 8]));
+        let compacted = (xcomp_bv & (1u64 << 63)) != 0;
+        let valid_end = if compacted {
+            // Compacted format: compute end from CPUID component sizes
+            let supported = xsave_supported_components();
+            let mut offset = 576usize;
+            for comp_id in 2..63u32 {
+                if (supported & (1u64 << comp_id)) == 0 {
+                    continue;
+                }
+                if (xcomp_bv & (1u64 << comp_id)) == 0 {
+                    continue;
+                }
+                let (size, _, align_64) = xsave_component_info(comp_id);
+                if align_64 {
+                    offset = offset.next_multiple_of(64);
+                }
+                offset += size;
+            }
+            offset
+        } else {
+            // Standard format (KVM): full buffer is valid
+            reset_xsave.len()
+        };
+
+        // Only compare bytes within the valid region
         assert_eq!(
-            reset_xsave, expected_xsave,
-            "xsave should be zeroed except for hypervisor-specific fields"
+            &reset_xsave[..valid_end],
+            &expected_xsave[..valid_end],
+            "xsave should be zeroed except for hypervisor-specific fields \
+             (comparing bytes 0..{valid_end} of {} total)",
+            reset_xsave.len()
         );
 
         // Verify sregs are reset to defaults (CR3 is 0 as passed to reset_vcpu)

--- a/src/tests/rust_guests/simpleguest/src/main.rs
+++ b/src/tests/rust_guests/simpleguest/src/main.rs
@@ -134,8 +134,10 @@ fn test_exception_handler(
 /// Install handler for a specific vector
 #[guest_function("InstallHandler")]
 fn install_handler(vector: i32) {
-    hyperlight_guest_bin::exception::arch::HANDLERS[vector as usize]
-        .store(test_exception_handler as *const () as usize as u64, Ordering::Release);
+    hyperlight_guest_bin::exception::arch::HANDLERS[vector as usize].store(
+        test_exception_handler as *const () as usize as u64,
+        Ordering::Release,
+    );
 }
 
 /// Get how many times the handler was invoked

--- a/src/tests/rust_guests/simpleguest/src/main.rs
+++ b/src/tests/rust_guests/simpleguest/src/main.rs
@@ -135,7 +135,7 @@ fn test_exception_handler(
 #[guest_function("InstallHandler")]
 fn install_handler(vector: i32) {
     hyperlight_guest_bin::exception::arch::HANDLERS[vector as usize]
-        .store(test_exception_handler as usize as u64, Ordering::Release);
+        .store(test_exception_handler as *const () as usize as u64, Ordering::Release);
 }
 
 /// Get how many times the handler was invoked


### PR DESCRIPTION
Updates rust version to 1.94 , MSRV remains at 1.89.

Latest rust version is 1.96 but this requires a change to cargo-hyperlight. I will open a PR for that shortly along with a PR to update the common-workflow and dev-images