### PR TITLE
Update surrogate process to nostd, avoid overhead of loading unecessary libraries

### DIFF
--- a/src/hyperlight_host/build.rs
+++ b/src/hyperlight_host/build.rs
@@ -30,6 +30,8 @@ fn main() -> Result<()> {
     // This logic runs when targeting Windows, even if cross-compiling from Linux.
     if std::env::var("CARGO_CFG_TARGET_OS")? == "windows" {
         println!("cargo:rerun-if-changed=src/hyperlight_surrogate/src/main.rs");
+        println!("cargo:rerun-if-changed=src/hyperlight_surrogate/build.rs");
+        println!("cargo:rerun-if-changed=src/hyperlight_surrogate/Cargo.toml_temp_name");
 
         // Build hyperlight_surrogate and
         // Set $HYPERLIGHT_SURROGATE_DIR env var during rust build so we can
@@ -45,6 +47,10 @@ fn main() -> Result<()> {
         std::fs::copy(
             format!("{manifest_dir}/src/hyperlight_surrogate/src/main.rs"),
             format!("{out_dir}/hyperlight_surrogate/src/main.rs"),
+        )?;
+        std::fs::copy(
+            format!("{manifest_dir}/src/hyperlight_surrogate/build.rs"),
+            format!("{out_dir}/hyperlight_surrogate/build.rs"),
         )?;
         std::fs::copy(
             format!("{manifest_dir}/src/hyperlight_surrogate/Cargo.toml_temp_name"),

--- a/src/hyperlight_host/src/hyperlight_surrogate/Cargo.toml_temp_name
+++ b/src/hyperlight_host/src/hyperlight_surrogate/Cargo.toml_temp_name
@@ -9,6 +9,17 @@ edition = "2021"
 
 [dependencies]
 
+[profile.dev]
+panic = "abort"
+
+[profile.release]
+panic = "abort"
+
+[profile.release-with-debug]
+inherits = "release"
+debug = true
+panic = "abort"
+
 # Note - This crate will currently get built during the build.rs script for the hyperlight-host crate.
 # Cargo package does not allow for files named 'Cargo.toml' to be included in a crate so we'll rename
 # during the build.rs script so this file can be included with source for hyperlight_surrogate.exe 

--- a/src/hyperlight_host/src/hyperlight_surrogate/build.rs
+++ b/src/hyperlight_host/src/hyperlight_surrogate/build.rs
@@ -1,0 +1,22 @@
+/*
+Copyright 2025  The Hyperlight Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+fn main() {
+    // The surrogate is a #![no_std] binary with a custom entry point.
+    // We need to tell the MSVC linker the entry point and subsystem.
+    println!("cargo:rustc-link-arg=/ENTRY:mainCRTStartup");
+    println!("cargo:rustc-link-arg=/SUBSYSTEM:CONSOLE");
+}

--- a/src/hyperlight_host/src/hyperlight_surrogate/src/main.rs
+++ b/src/hyperlight_host/src/hyperlight_surrogate/src/main.rs
@@ -14,6 +14,40 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-fn main() {
-    std::thread::sleep(std::time::Duration::MAX)
+// This binary is used solely as an address-space host for WHvMapGpaRange2.
+// It is created with CREATE_SUSPENDED and never executes user code.
+//
+// We use #![no_std] to avoid linking dbghelp.dll and VCRUNTIME140.dll,
+// which add ~200ms to CreateProcess on ARM64 Windows. The process never
+// runs, so the Rust stdlib is pure dead weight here.
+
+#![no_std]
+#![no_main]
+
+#[link(name = "kernel32")]
+unsafe extern "system" {
+    fn Sleep(dwMilliseconds: u32);
+}
+
+/// Entry point — sleeps forever. In practice this code is never reached
+/// because the process is created suspended, but Windows requires a valid
+/// entry point in the PE.
+///
+/// # Safety
+///
+/// This is the raw PE entry point called by the OS loader. 
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn mainCRTStartup() -> ! {
+    // INFINITE = 0xFFFFFFFF
+    Sleep(0xFFFF_FFFF);
+    loop {
+        core::hint::spin_loop();
+    }
+}
+
+#[panic_handler]
+fn panic(_: &core::panic::PanicInfo) -> ! {
+    loop {
+        core::hint::spin_loop();
+    }
 }


### PR DESCRIPTION
Creating a surrogate process on windows unnecessarily loads the Rust std library (which it doesn't need since it starts suspended and sleeps forever), the overhead of this on creating a process appears to be  large on AARCH64 (200ms) , this PR makes the surrogate `no_std` which removes this overhead.