### PR TITLE
fix(guest): drop nomem from out32 OUT-trap asm

### DIFF
--- a/src/hyperlight_guest/src/arch/amd64/exit.rs
+++ b/src/hyperlight_guest/src/arch/amd64/exit.rs
@@ -38,7 +38,7 @@ pub(crate) unsafe fn out32(port: u16, val: u32) {
                     in("r8") OutBAction::TraceBatch as u64,
                     in("r9") ptr,
                     in("r10") len,
-                    options(preserves_flags, nomem, nostack)
+                    options(preserves_flags, nostack)
                 )
             };
 
@@ -49,12 +49,12 @@ pub(crate) unsafe fn out32(port: u16, val: u32) {
         } else {
             // If tracing is not enabled, just send the value
             unsafe {
-                asm!("out dx, eax", in("dx") port, in("eax") val, options(preserves_flags, nomem, nostack))
+                asm!("out dx, eax", in("dx") port, in("eax") val, options(preserves_flags, nostack))
             };
         }
     }
     #[cfg(not(feature = "trace_guest"))]
     unsafe {
-        asm!("out dx, eax", in("dx") port, in("eax") val, options(preserves_flags, nomem, nostack));
+        asm!("out dx, eax", in("dx") port, in("eax") val, options(preserves_flags, nostack));
     }
 }


### PR DESCRIPTION
3 `asm!` blocks in `out32` are tagged options(nomem). That promises LLVM the asm does not touch any memory accessible to the abstract machine, which lets it cache loads and reorder stores across the asm. The OUT traps to the host VMM, which writes the shared input stack and the shared output stack, so the promise is false and per the Rust Reference is undefined behavior, see https://doc.rust-lang.org/reference/inline-assembly.html.