### PR TITLE
Fix just-clippyw recipe

### DIFF
--- a/src/hyperlight_host/src/hyperlight_surrogate/build.rs
+++ b/src/hyperlight_host/src/hyperlight_surrogate/build.rs
@@ -15,8 +15,20 @@ limitations under the License.
 */
 
 fn main() {
+    if std::env::var("CARGO_CFG_TARGET_OS").as_deref() != Ok("windows") {
+        panic!("hyperlight_surrogate can only be built for Windows targets");
+    }
+
+    let target_env = std::env::var("CARGO_CFG_TARGET_ENV")
+        .expect("CARGO_CFG_TARGET_ENV should be set for Windows targets");
     // The surrogate is a #![no_std] binary with a custom entry point.
-    // We need to tell the MSVC linker the entry point and subsystem.
-    println!("cargo:rustc-link-arg=/ENTRY:mainCRTStartup");
-    println!("cargo:rustc-link-arg=/SUBSYSTEM:CONSOLE");
+    if target_env == "gnu" {
+        // useful for `just clippyw` (targeting x86_64-pc-windows-gnu on linux host)
+        println!("cargo:rustc-link-arg-bin=hyperlight_surrogate=-nostartfiles");
+        println!("cargo:rustc-link-arg-bin=hyperlight_surrogate=-Wl,-e,mainCRTStartup");
+        println!("cargo:rustc-link-arg-bin=hyperlight_surrogate=-Wl,--subsystem,console");
+    } else {
+        println!("cargo:rustc-link-arg-bin=hyperlight_surrogate=/ENTRY:mainCRTStartup");
+        println!("cargo:rustc-link-arg-bin=hyperlight_surrogate=/SUBSYSTEM:CONSOLE");
+    }
 }


### PR DESCRIPTION
Fixes #1559

I use this all the time on linux machine to verify `just clippy` would pass on windows target