### PR TITLE
Fix publish workflow to account for recent changes

### DIFF
--- a/.github/workflows/CreateRelease.yml
+++ b/.github/workflows/CreateRelease.yml
@@ -68,6 +68,7 @@ jobs:
     secrets: inherit
     needs: [release-blocker-check]
     with:
+      arch: X64
       config: release
 
   benchmarks:

--- a/.github/workflows/DailyBenchmarks.yml
+++ b/.github/workflows/DailyBenchmarks.yml
@@ -35,6 +35,7 @@ jobs:
     uses: ./.github/workflows/dep_build_guests.yml
     secrets: inherit
     with:
+      arch: X64
       config: release
 
   # Run benchmarks across all hypervisor/cpu combos, comparing against

--- a/.github/workflows/Fuzzing.yml
+++ b/.github/workflows/Fuzzing.yml
@@ -14,6 +14,7 @@ jobs:
     uses: ./.github/workflows/dep_build_guests.yml
     secrets: inherit
     with:
+      arch: X64
       config: release
 
   fuzzing:

--- a/.github/workflows/PrimeCaches.yml
+++ b/.github/workflows/PrimeCaches.yml
@@ -37,6 +37,7 @@ jobs:
     uses: ./.github/workflows/dep_build_guests.yml
     secrets: inherit
     with:
+      arch: X64
       config: ${{ matrix.config }}
 
   # Populate v0-rust-code-checks-{linux,windows} caches.


### PR DESCRIPTION
With the recent changes to support aarch64, we now need to specify the arch in a few places.
This was missing for the publish workflows.