### PR TITLE
fix: update tar-headers sysroot path for cargo-hyperlight 0.1.12

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -392,7 +392,7 @@ run-rust-examples-linux target=default-target features="": (run-rust-examples ta
 #########################
 
 tar-headers: (build-rust-capi) # build-rust-capi is a dependency because we need the hyperlight_guest.h to be built
-    tar -zcvf include.tar.gz -C {{root}}/target/sysroot/lib/rustlib/x86_64-hyperlight-none/ include -C {{root}}/src/hyperlight_guest_capi include
+    tar -zcvf include.tar.gz -C {{root}}/target/sysroot/ include -C {{root}}/src/hyperlight_guest_capi include
 
 tar-static-lib: (build-rust-capi "release") (build-rust-capi "debug")
     tar -zcvf hyperlight-guest-c-api-linux.tar.gz -C {{root}}/target/x86_64-hyperlight-none/ release/libhyperlight_guest_capi.a -C {{root}}/target/x86_64-hyperlight-none/ debug/libhyperlight_guest_capi.a


### PR DESCRIPTION
Fixes the publish job failure on main: https://github.com/hyperlight-dev/hyperlight/actions/runs/28255787499/job/83728732967

cargo-hyperlight 0.1.12 moved the sysroot include directory from `target/sysroot/lib/rustlib/x86_64-hyperlight-none/include` to `target/sysroot/include`.