### PR TITLE
Don't fuzz on arm64 on pr

### DIFF
--- a/.github/workflows/ValidatePullRequest.yml
+++ b/.github/workflows/ValidatePullRequest.yml
@@ -164,12 +164,15 @@ jobs:
     strategy:
       matrix:
         target: ['fuzz_host_print', 'fuzz_guest_call', 'fuzz_host_call', 'fuzz_guest_estimate_trace_event', 'fuzz_guest_trace']
-        arch: [X64, arm64]
-        exclude:
-        - arch: arm64
-          target: fuzz_guest_trace
-        - arch: arm64
-          target: fuzz_guest_estimate_trace_event
+        arch:
+          - X64
+        # arm64 disabled to conserve the limited self-hosted Apple runners.
+        # - arm64
+        # exclude:
+        # - arch: arm64
+        #   target: fuzz_guest_trace
+        # - arch: arm64
+        #   target: fuzz_guest_estimate_trace_event
     uses: ./.github/workflows/dep_fuzzing.yml
     secrets: inherit
     with:


### PR DESCRIPTION
Should help a bit with limited apple runnres. Will create an issue to track that it's disabled, once this is merged, so we remember to turn on when we have more ci runners