### PR TITLE
Fix CI caching and parameterize workflows by arch for future aarch64

### DIFF
--- a/.github/workflows/CreateRelease.yml
+++ b/.github/workflows/CreateRelease.yml
@@ -76,13 +76,15 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
+        arch: [X64]
         hypervisor: ['hyperv-ws2025', mshv3, kvm]
-        cpu: [amd, intel]
+        cpu_vendor: [amd, intel]
     uses: ./.github/workflows/dep_benchmarks.yml
     secrets: inherit
     with:
       hypervisor: ${{ matrix.hypervisor }}
-      cpu: ${{ matrix.cpu }}
+      cpu_vendor: ${{ matrix.cpu_vendor }}
+      arch: ${{ matrix.arch }}
     permissions:
       contents: read
 

--- a/.github/workflows/DailyBenchmarks.yml
+++ b/.github/workflows/DailyBenchmarks.yml
@@ -45,13 +45,15 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
+        arch: [X64]
         hypervisor: ['hyperv-ws2025', mshv3, kvm]
-        cpu: [amd, intel]
+        cpu_vendor: [amd, intel]
     uses: ./.github/workflows/dep_benchmarks.yml
     secrets: inherit
     with:
       hypervisor: ${{ matrix.hypervisor }}
-      cpu: ${{ matrix.cpu }}
+      cpu_vendor: ${{ matrix.cpu_vendor }}
+      arch: ${{ matrix.arch }}
       baseline_run_id: ${{ needs.find-baseline.outputs.run-id }}
       retention_days: 90
 

--- a/.github/workflows/Fuzzing.yml
+++ b/.github/workflows/Fuzzing.yml
@@ -19,9 +19,14 @@ jobs:
 
   fuzzing:
     needs: build-guests
+    strategy:
+      fail-fast: false
+      matrix:
+        target: ['fuzz_host_print', 'fuzz_guest_call', 'fuzz_host_call', 'fuzz_guest_estimate_trace_event', 'fuzz_guest_trace']
     uses: ./.github/workflows/dep_fuzzing.yml
     with:
-      targets: '["fuzz_host_print", "fuzz_guest_call", "fuzz_host_call", "fuzz_guest_estimate_trace_event", "fuzz_guest_trace"]' # Pass as a JSON array
+      target: ${{ matrix.target }}
+      arch: X64
       max_total_time: 18000 # 5 hours in seconds
     secrets: inherit
 

--- a/.github/workflows/PrimeCaches.yml
+++ b/.github/workflows/PrimeCaches.yml
@@ -28,16 +28,17 @@ defaults:
     shell: bash
 
 jobs:
-  # Populate v0-rust-guests-{debug,release}-Linux-x64 caches.
+  # Populate guest caches (key guests-{arch}-{config}) for both architectures.
   guests:
     strategy:
       fail-fast: false
       matrix:
+        arch: [X64, arm64]
         config: [debug, release]
     uses: ./.github/workflows/dep_build_guests.yml
     secrets: inherit
     with:
-      arch: X64
+      arch: ${{ matrix.arch }}
       config: ${{ matrix.config }}
 
   # Populate v0-rust-code-checks-{linux,windows} caches.
@@ -45,8 +46,8 @@ jobs:
     uses: ./.github/workflows/dep_code_checks.yml
     secrets: inherit
 
-  # Populate v0-rust-{Linux,Windows}-{hypervisor}-{debug,release} caches used
-  # by dep_build_test.yml. Linux is primed once per hypervisor because the kvm
+  # Populate the host caches (key {arch}-{os}-{hypervisor}-{config}) used by
+  # dep_build_test.yml. Linux is primed once per hypervisor because the kvm
   # pools run Ubuntu and the mshv3 pools run Azure Linux 3, and we want each
   # distro to restore a cache produced under its own libc. Only the host
   # dependency graph is built here, no tests are run.
@@ -55,28 +56,41 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - hypervisor: kvm
+          - arch: X64
+            hypervisor: kvm
             config: debug
-          - hypervisor: kvm
+          - arch: X64
+            hypervisor: kvm
             config: release
-          - hypervisor: mshv3
+          - arch: X64
+            hypervisor: mshv3
             config: debug
-          - hypervisor: mshv3
+          - arch: X64
+            hypervisor: mshv3
             config: release
-          - hypervisor: hyperv-ws2025
+          - arch: X64
+            hypervisor: hyperv-ws2025
             config: debug
-          - hypervisor: hyperv-ws2025
+          - arch: X64
+            hypervisor: hyperv-ws2025
+            config: release
+          - arch: arm64
+            hypervisor: kvm
+            config: debug
+          - arch: arm64
+            hypervisor: kvm
             config: release
     timeout-minutes: ${{ fromJSON(vars.PRIME_CACHES_JOB_TIMEOUT || '30') }}
-    runs-on: ${{ fromJson(
-        format('["self-hosted", "{0}", "X64", "1ES.Pool=hld-{1}-amd", "JobId=prime-cache-{2}-{3}-{4}-{5}-{6}"]',
-          matrix.hypervisor == 'hyperv-ws2025' && 'Windows' || 'Linux',
-          matrix.hypervisor == 'hyperv-ws2025' && 'win2025' || matrix.hypervisor == 'mshv3' && 'azlinux3-mshv' || matrix.hypervisor,
-          matrix.hypervisor,
-          matrix.config,
-          github.run_id,
-          github.run_number,
-          github.run_attempt)) }}
+    runs-on: ${{ fromJson(matrix.arch == 'X64'
+        && format('["self-hosted", "{0}", "X64", "1ES.Pool=hld-{1}-amd", "JobId=prime-cache-{2}-{3}-{4}-{5}-{6}"]',
+            matrix.hypervisor == 'hyperv-ws2025' && 'Windows' || 'Linux',
+            matrix.hypervisor == 'hyperv-ws2025' && 'win2025' || matrix.hypervisor == 'mshv3' && 'azlinux3-mshv' || matrix.hypervisor,
+            matrix.hypervisor,
+            matrix.config,
+            github.run_id,
+            github.run_number,
+            github.run_attempt)
+        || '["self-hosted", "Linux", "arm64", "kvm", "ubuntu-24.04"]') }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
@@ -94,7 +108,7 @@ jobs:
       - name: Rust cache
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
         with:
-          shared-key: "${{ runner.os }}-${{ matrix.hypervisor }}-${{ matrix.config }}"
+          shared-key: "${{ matrix.arch }}-${{ runner.os }}-${{ matrix.hypervisor }}-${{ matrix.config }}"
           cache-on-failure: "true"
           # Only save on main as caches are not shared across branches.
           # https://docs.github.com/en/actions/reference/workflows-and-actions/dependency-caching#restrictions-for-accessing-a-cache

--- a/.github/workflows/RustNightly.yml
+++ b/.github/workflows/RustNightly.yml
@@ -29,12 +29,12 @@ jobs:
       fail-fast: true
       matrix:
         hypervisor: [kvm, mshv3]
-        cpu: [amd, intel]
+        cpu_vendor: [amd, intel]
         config: [debug, release]
     runs-on: ${{ fromJson(
         format('["self-hosted", "Linux", "X64", "1ES.Pool=hld-{0}-{1}", "JobId=musl-{2}-{3}-{4}-{5}"]', 
           matrix.hypervisor == 'mshv3' && 'azlinux3-mshv' || matrix.hypervisor, 
-          matrix.cpu,
+          matrix.cpu_vendor,
           matrix.config,
           github.run_id,
           github.run_number,

--- a/.github/workflows/ValidatePullRequest.yml
+++ b/.github/workflows/ValidatePullRequest.yml
@@ -94,26 +94,26 @@ jobs:
       fail-fast: true
       matrix:
         hypervisor: ['hyperv-ws2025', mshv3, kvm]
-        cpu: [amd, intel, apple]
+        cpu_vendor: [amd, intel, apple]
         arch: [X64, arm64]
         config: [debug, release]
         exclude:
-        - cpu: apple
+        - cpu_vendor: apple
           hypervisor: hyperv-ws2025
-        - cpu: apple
+        - cpu_vendor: apple
           hypervisor: mshv3
-        - cpu: amd
+        - cpu_vendor: amd
           arch: arm64
-        - cpu: intel
+        - cpu_vendor: intel
           arch: arm64
-        - cpu: apple
+        - cpu_vendor: apple
           arch: X64
     uses: ./.github/workflows/dep_build_test.yml
     secrets: inherit
     with:
       docs_only: ${{ needs.docs-pr.outputs.docs-only }}
       hypervisor: ${{ matrix.hypervisor }}
-      cpu: ${{ matrix.cpu }}
+      cpu_vendor: ${{ matrix.cpu_vendor }}
       arch: ${{ matrix.arch }}
       config: ${{ matrix.config }}
 
@@ -130,26 +130,26 @@ jobs:
       fail-fast: true
       matrix:
         hypervisor: ['hyperv-ws2025', mshv3, kvm]
-        cpu: [amd, intel, apple]
+        cpu_vendor: [amd, intel, apple]
         arch: [X64, arm64]
         config: [debug, release]
         exclude:
-        - cpu: apple
+        - cpu_vendor: apple
           hypervisor: hyperv-ws2025
-        - cpu: apple
+        - cpu_vendor: apple
           hypervisor: mshv3
-        - cpu: amd
+        - cpu_vendor: amd
           arch: arm64
-        - cpu: intel
+        - cpu_vendor: intel
           arch: arm64
-        - cpu: apple
+        - cpu_vendor: apple
           arch: X64
     uses: ./.github/workflows/dep_run_examples.yml
     secrets: inherit
     with: 
       docs_only: ${{ needs.docs-pr.outputs.docs-only }}
       hypervisor: ${{ matrix.hypervisor }}
-      cpu: ${{ matrix.cpu }}
+      cpu_vendor: ${{ matrix.cpu_vendor }}
       arch: ${{ matrix.arch }}
       config: ${{ matrix.config }}
 

--- a/.github/workflows/dep_benchmarks.yml
+++ b/.github/workflows/dep_benchmarks.yml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
 
-# Reusable workflow to run benchmarks on a single hypervisor/cpu combination.
+# Reusable workflow to run benchmarks on a single hypervisor/cpu_vendor combination.
 #
 # Baseline comparison:
 #   The workflow supports two mutually exclusive ways to load a baseline for
@@ -20,7 +20,7 @@
 #
 # Artifact upload:
 #   Benchmark results are always uploaded as workflow artifacts named
-#   benchmarks_<OS>_<hypervisor>_<cpu>. The retention_days input controls
+#   benchmarks_<OS>_<hypervisor>_<cpu_vendor>. The retention_days input controls
 #   how long they are kept (default: 5 days).
 
 name: Run Benchmarks
@@ -37,8 +37,12 @@ on:
         description: Hypervisor for this run (passed from caller matrix)
         required: true
         type: string
-      cpu:
-        description: CPU architecture for the build (passed from caller matrix)
+      cpu_vendor:
+        description: CPU vendor for the build, amd or intel (passed from caller matrix)
+        required: true
+        type: string
+      arch:
+        description: CPU architecture for the build, X64 or arm64 (passed from caller matrix)
         required: true
         type: string
       baseline_tag:
@@ -72,14 +76,15 @@ jobs:
   run-benchmarks:
     if: ${{ inputs.docs_only == 'false' }}
     timeout-minutes: ${{ fromJSON(vars.BENCHMARKS_JOB_TIMEOUT || '60') }}
-    runs-on: ${{ fromJson(
-        format('["self-hosted", "{0}", "X64", "1ES.Pool=hld-{1}-{2}", "JobId=run-benchmarks-{3}-{4}-{5}"]', 
-          inputs.hypervisor == 'hyperv-ws2025' && 'Windows' || 'Linux', 
-          inputs.hypervisor == 'hyperv-ws2025' && 'win2025' || inputs.hypervisor == 'mshv3' && 'azlinux3-mshv' || inputs.hypervisor, 
-          inputs.cpu,
-          github.run_id,
-          github.run_number,
-          github.run_attempt)) }} 
+    runs-on: ${{ fromJson(inputs.arch == 'X64'
+        && format('["self-hosted", "{0}", "X64", "1ES.Pool=hld-{1}-{2}", "JobId=run-benchmarks-{3}-{4}-{5}"]',
+            inputs.hypervisor == 'hyperv-ws2025' && 'Windows' || 'Linux',
+            inputs.hypervisor == 'hyperv-ws2025' && 'win2025' || inputs.hypervisor == 'mshv3' && 'azlinux3-mshv' || inputs.hypervisor,
+            inputs.cpu_vendor,
+            github.run_id,
+            github.run_number,
+            github.run_attempt)
+        || '["self-hosted", "Linux", "arm64", "kvm", "ubuntu-24.04"]') }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
@@ -97,19 +102,19 @@ jobs:
       - name: Rust cache
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
         with:
-          shared-key: "${{ runner.os }}-${{ inputs.hypervisor }}-release"
+          shared-key: "${{ inputs.arch }}-${{ runner.os }}-${{ inputs.hypervisor }}-release"
           save-if: "false"
 
       - name: Download Rust guests
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
-          name: rust-guests-X64-release
+          name: rust-guests-${{ inputs.arch }}-release
           path: src/tests/rust_guests/bin/release/
 
       - name: Download C guests
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
-          name: c-guests-X64-release
+          name: c-guests-${{ inputs.arch }}-release
           path: src/tests/c_guests/bin/release/
 
       - name: Build
@@ -119,7 +124,7 @@ jobs:
         if: ${{ inputs.baseline_run_id != '' }}
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
-          name: benchmarks_${{ runner.os }}_${{ inputs.hypervisor }}_${{ inputs.cpu }}
+          name: benchmarks_${{ runner.os }}_${{ inputs.hypervisor }}_${{ inputs.cpu_vendor }}
           path: ./target/criterion/
           run-id: ${{ inputs.baseline_run_id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -127,7 +132,7 @@ jobs:
 
       - name: Download baseline from release
         if: ${{ inputs.baseline_run_id == '' }}
-        run: just bench-download ${{ runner.os }} ${{ inputs.hypervisor }} ${{ inputs.cpu }} ${{ inputs.baseline_tag }}
+        run: just bench-download ${{ runner.os }} ${{ inputs.hypervisor }} ${{ inputs.cpu_vendor }} ${{ inputs.baseline_tag }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         continue-on-error: true
@@ -137,7 +142,7 @@ jobs:
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
-          name: benchmarks_${{ runner.os }}_${{ inputs.hypervisor }}_${{ inputs.cpu }}
+          name: benchmarks_${{ runner.os }}_${{ inputs.hypervisor }}_${{ inputs.cpu_vendor }}
           path: ./target/criterion/
           if-no-files-found: error
           retention-days: ${{ inputs.retention_days }}

--- a/.github/workflows/dep_build_guests.yml
+++ b/.github/workflows/dep_build_guests.yml
@@ -33,17 +33,13 @@ jobs:
   build-guests:
     if: ${{ inputs.docs_only == 'false' }}
     timeout-minutes: ${{ fromJSON(vars.BUILD_GUESTS_JOB_TIMEOUT || '15') }}
-    runs-on: ${{ fromJson(
-      format('["self-hosted", "Linux", "{0}", "{1}" {2}]',
-        inputs.arch,
-        inputs.arch == 'X64' && '1ES.Pool=hld-kvm-amd' || 'ubuntu-24.04',
-        inputs.arch == 'X64' && format(', "JobId=build-guests-{0}-{1}-{2}-{3}"',
-                                  inputs.config,
-                                  github.run_id,
-                                  github.run_number,
-                                  github.run_attempt)
-                             || ''
-      )) }}
+    runs-on: ${{ fromJson(inputs.arch == 'X64'
+        && format('["self-hosted", "Linux", "X64", "1ES.Pool=hld-kvm-amd", "JobId=build-guests-{0}-{1}-{2}-{3}"]',
+            inputs.config,
+            github.run_id,
+            github.run_number,
+            github.run_attempt)
+        || '["self-hosted", "Linux", "arm64", "ubuntu-24.04"]') }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
@@ -128,8 +124,9 @@ jobs:
           retention-days: 1
           if-no-files-found: error
 
+      # The .wasm is arch-independent, so upload it once from X64 only.
       - name: Upload bindgen-test-cases.wasm
-        if: inputs.config == 'debug'
+        if: inputs.config == 'debug' && inputs.arch == 'X64'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: bindgen-test-cases-wasm

--- a/.github/workflows/dep_build_test.yml
+++ b/.github/workflows/dep_build_test.yml
@@ -18,7 +18,7 @@ on:
         description: Build configuration for this run (passed from caller matrix)
         required: true
         type: string
-      cpu:
+      cpu_vendor:
         description: CPU vendor for the build (passed from caller matrix)
         required: true
         type: string
@@ -42,12 +42,16 @@ jobs:
   build-and-test:
     if: ${{ inputs.docs_only == 'false' }}
     timeout-minutes: ${{ fromJSON(vars.BUILD_TEST_JOB_TIMEOUT || '45') }}
-    runs-on: ${{ fromJson(
-        format('["self-hosted", "{0}", "{1}", {2} {3}]',
-          inputs.hypervisor == 'hyperv-ws2025' && 'Windows' || 'Linux',
-          inputs.arch,
-          inputs.arch == 'X64' && format('"1ES.Pool=hld-{0}-{1}"', inputs.hypervisor == 'hyperv-ws2025' && 'win2025' || inputs.hypervisor == 'mshv3' && 'azlinux3-mshv' || inputs.hypervisor, inputs.cpu) || inputs.hypervisor == 'kvm' && '"kvm", "ubuntu-24.04"' || '',
-          inputs.arch == 'X64' && format(', "JobId=build-and-test-{0}-{1}-{2}-{3}"', inputs.config, github.run_id, github.run_number, github.run_attempt) || '')) }}
+    runs-on: ${{ fromJson(inputs.arch == 'X64'
+        && format('["self-hosted", "{0}", "X64", "1ES.Pool=hld-{1}-{2}", "JobId=build-and-test-{3}-{4}-{5}-{6}"]',
+            inputs.hypervisor == 'hyperv-ws2025' && 'Windows' || 'Linux',
+            inputs.hypervisor == 'hyperv-ws2025' && 'win2025' || inputs.hypervisor == 'mshv3' && 'azlinux3-mshv' || inputs.hypervisor,
+            inputs.cpu_vendor,
+            inputs.config,
+            github.run_id,
+            github.run_number,
+            github.run_attempt)
+        || '["self-hosted", "Linux", "arm64", "kvm", "ubuntu-24.04"]') }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 

--- a/.github/workflows/dep_fuzzing.yml
+++ b/.github/workflows/dep_fuzzing.yml
@@ -27,17 +27,13 @@ permissions:
 jobs:
   fuzz:
     if: ${{ inputs.docs_only == 'false' }}
-    runs-on: ${{ fromJson(
-      format('["self-hosted", "Linux", "{0}", "{1}" {2}]',
-        inputs.arch,
-        inputs.arch == 'X64' && '1ES.Pool=hld-kvm-amd' || 'ubuntu-24.04',
-        inputs.arch == 'X64' && format(', "JobId=fuzz-{0}-{1}-{2}-{3}"',
-                                  inputs.target,
-                                  github.run_id,
-                                  github.run_number,
-                                  github.run_attempt)
-                             || ''
-      )) }}
+    runs-on: ${{ fromJson(inputs.arch == 'X64'
+        && format('["self-hosted", "Linux", "X64", "1ES.Pool=hld-kvm-amd", "JobId=fuzz-{0}-{1}-{2}-{3}"]',
+            inputs.target,
+            github.run_id,
+            github.run_number,
+            github.run_attempt)
+        || '["self-hosted", "Linux", "arm64", "kvm", "ubuntu-24.04"]') }}
     steps:
       - name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
@@ -65,6 +61,6 @@ jobs:
         if: failure() # This ensures artifacts are only uploaded on failure
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
-          name: fuzz-crash-artifacts
+          name: fuzz-crash-artifacts-${{ inputs.target }}
           path: fuzz/artifacts/
           retention-days: 28

--- a/.github/workflows/dep_run_examples.yml
+++ b/.github/workflows/dep_run_examples.yml
@@ -18,7 +18,7 @@ on:
         description: Build configuration for this run (passed from caller matrix)
         required: true
         type: string
-      cpu:
+      cpu_vendor:
         description: CPU vendor for the build (passed from caller matrix)
         required: true
         type: string
@@ -42,12 +42,16 @@ jobs:
   run-examples:
     if: ${{ inputs.docs_only == 'false' }}
     timeout-minutes: ${{ fromJSON(vars.RUN_EXAMPLES_JOB_TIMEOUT || '15') }}
-    runs-on: ${{ fromJson(
-        format('["self-hosted", "{0}", "{1}", {2} {3}]',
-          inputs.hypervisor == 'hyperv-ws2025' && 'Windows' || 'Linux',
-          inputs.arch,
-          inputs.arch == 'X64' && format('"1ES.Pool=hld-{0}-{1}"', inputs.hypervisor == 'hyperv-ws2025' && 'win2025' || inputs.hypervisor == 'mshv3' && 'azlinux3-mshv' || inputs.hypervisor, inputs.cpu) || inputs.hypervisor == 'kvm' && '"kvm", "ubuntu-24.04"' || '',
-          inputs.arch == 'X64' && format(', "JobId=run-examples-{0}-{1}-{2}-{3}"', inputs.config, github.run_id, github.run_number, github.run_attempt) || '')) }}
+    runs-on: ${{ fromJson(inputs.arch == 'X64'
+        && format('["self-hosted", "{0}", "X64", "1ES.Pool=hld-{1}-{2}", "JobId=run-examples-{3}-{4}-{5}-{6}"]',
+            inputs.hypervisor == 'hyperv-ws2025' && 'Windows' || 'Linux',
+            inputs.hypervisor == 'hyperv-ws2025' && 'win2025' || inputs.hypervisor == 'mshv3' && 'azlinux3-mshv' || inputs.hypervisor,
+            inputs.cpu_vendor,
+            inputs.config,
+            github.run_id,
+            github.run_number,
+            github.run_attempt)
+        || '["self-hosted", "Linux", "arm64", "kvm", "ubuntu-24.04"]') }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 

--- a/Justfile
+++ b/Justfile
@@ -416,11 +416,11 @@ tar-static-lib: (build-rust-capi "release") (build-rust-capi "debug")
 # Options for os: "Windows", or "Linux"
 # Options for Linux hypervisor: "kvm", "mshv3"
 # Options for Windows hypervisor: "hyperv", "hyperv-ws2025"
-# Options for cpu: "amd", "intel"
-bench-download os hypervisor cpu tag="":
-    gh release download {{ tag }} -D ./target/ -p benchmarks_{{ os }}_{{ hypervisor }}_{{ cpu }}.tar.gz
+# Options for cpu_vendor: "amd", "intel"
+bench-download os hypervisor cpu_vendor tag="":
+    gh release download {{ tag }} -D ./target/ -p benchmarks_{{ os }}_{{ hypervisor }}_{{ cpu_vendor }}.tar.gz
     mkdir -p target/criterion {{ if os() == "windows" { "-Force" } else { "" } }}
-    tar -zxvf target/benchmarks_{{ os }}_{{ hypervisor }}_{{ cpu }}.tar.gz -C target/criterion/ --strip-components=1
+    tar -zxvf target/benchmarks_{{ os }}_{{ hypervisor }}_{{ cpu_vendor }}.tar.gz -C target/criterion/ --strip-components=1
 
 # Warning: compares to and then OVERWRITES the given baseline
 bench-ci baseline features="":

--- a/docs/benchmarking-hyperlight.md
+++ b/docs/benchmarking-hyperlight.md
@@ -72,6 +72,6 @@ Found 1 outliers among 100 measurements (1.00%)
 
 ## Running benchmarks locally
 
-Use `just bench` to run benchmarks with release builds (the only supported configuration). Comparing local benchmark results to github-saved benchmarks doesn't make much sense, since you'd be using different hardware, but you can use `just bench-download os hypervisor [tag] ` to download and extract the GitHub release benchmarks to the correct place folder. You can then run `just bench-ci main` to compare to (and overwrite) the previous release benchmarks. Note that `main` is the name of the baselines stored in GitHub.
+Use `just bench` to run benchmarks with release builds (the only supported configuration). Comparing local benchmark results to GitHub-saved benchmarks doesn't make much sense, since you'd be using different hardware, but you can use `just bench-download os hypervisor cpu_vendor [tag] ` to download and extract the GitHub release benchmarks to the correct folder. You can then run `just bench-ci main` to compare to (and overwrite) the previous release benchmarks. Note that `main` is the name of the baselines stored in GitHub.
 
 **Important**: The `just bench` command uses release builds by default to ensure meaningful performance measurements. For profiling purposes, you can compile benchmarks with debug symbols by running `cargo bench` directly.


### PR DESCRIPTION
Caching is broken so fixed it (wrong key after aarch64 PR). Refactored some other stuff to easier add aarch64 support in future as well. Rename `cpu` (intel / amd) to `cpu_vendor`.