### PR TITLE
Adds optional repo variables for job timeout values

### DIFF
--- a/.github/workflows/Coverage.yml
+++ b/.github/workflows/Coverage.yml
@@ -24,7 +24,7 @@ defaults:
 
 jobs:
   coverage:
-    timeout-minutes: 90
+    timeout-minutes: ${{ vars.COVERAGE_JOB_TIMEOUT || 90 }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/Coverage.yml
+++ b/.github/workflows/Coverage.yml
@@ -24,7 +24,7 @@ defaults:
 
 jobs:
   coverage:
-    timeout-minutes: ${{ vars.COVERAGE_JOB_TIMEOUT || 90 }}
+    timeout-minutes: ${{ fromJSON(vars.COVERAGE_JOB_TIMEOUT || '90') }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/PrimeCaches.yml
+++ b/.github/workflows/PrimeCaches.yml
@@ -67,7 +67,7 @@ jobs:
             config: debug
           - hypervisor: hyperv-ws2025
             config: release
-    timeout-minutes: ${{ vars.PRIME_CACHES_JOB_TIMEOUT || 30 }}
+    timeout-minutes: ${{ fromJSON(vars.PRIME_CACHES_JOB_TIMEOUT || '30') }}
     runs-on: ${{ fromJson(
         format('["self-hosted", "{0}", "X64", "1ES.Pool=hld-{1}-amd", "JobId=prime-cache-{2}-{3}-{4}-{5}-{6}"]',
           matrix.hypervisor == 'hyperv-ws2025' && 'Windows' || 'Linux',

--- a/.github/workflows/PrimeCaches.yml
+++ b/.github/workflows/PrimeCaches.yml
@@ -67,7 +67,7 @@ jobs:
             config: debug
           - hypervisor: hyperv-ws2025
             config: release
-    timeout-minutes: 30
+    timeout-minutes: ${{ vars.PRIME_CACHES_JOB_TIMEOUT || 30 }}
     runs-on: ${{ fromJson(
         format('["self-hosted", "{0}", "X64", "1ES.Pool=hld-{1}-amd", "JobId=prime-cache-{2}-{3}-{4}-{5}-{6}"]',
           matrix.hypervisor == 'hyperv-ws2025' && 'Windows' || 'Linux',

--- a/.github/workflows/RustNightly.yml
+++ b/.github/workflows/RustNightly.yml
@@ -24,7 +24,7 @@ jobs:
   # This is a self-contained job since musl builds are a special case
   # that require TARGET_TRIPLE for cross-compilation
   musl:
-    timeout-minutes: 60
+    timeout-minutes: ${{ vars.NIGHTLY_JOB_TIMEOUT || 90 }}
     strategy:
       fail-fast: true
       matrix:

--- a/.github/workflows/RustNightly.yml
+++ b/.github/workflows/RustNightly.yml
@@ -24,7 +24,7 @@ jobs:
   # This is a self-contained job since musl builds are a special case
   # that require TARGET_TRIPLE for cross-compilation
   musl:
-    timeout-minutes: ${{ vars.NIGHTLY_JOB_TIMEOUT || 90 }}
+    timeout-minutes: ${{ fromJSON(vars.NIGHTLY_JOB_TIMEOUT || '60') }}
     strategy:
       fail-fast: true
       matrix:

--- a/.github/workflows/dep_benchmarks.yml
+++ b/.github/workflows/dep_benchmarks.yml
@@ -71,7 +71,7 @@ defaults:
 jobs:
   run-benchmarks:
     if: ${{ inputs.docs_only == 'false' }}
-    timeout-minutes: ${{ vars.BENCHMARKS_JOB_TIMEOUT || 60 }}
+    timeout-minutes: ${{ fromJSON(vars.BENCHMARKS_JOB_TIMEOUT || '60') }}
     runs-on: ${{ fromJson(
         format('["self-hosted", "{0}", "X64", "1ES.Pool=hld-{1}-{2}", "JobId=run-benchmarks-{3}-{4}-{5}"]', 
           inputs.hypervisor == 'hyperv-ws2025' && 'Windows' || 'Linux', 

--- a/.github/workflows/dep_benchmarks.yml
+++ b/.github/workflows/dep_benchmarks.yml
@@ -71,7 +71,7 @@ defaults:
 jobs:
   run-benchmarks:
     if: ${{ inputs.docs_only == 'false' }}
-    timeout-minutes: 60
+    timeout-minutes: ${{ vars.BENCHMARKS_JOB_TIMEOUT || 60 }}
     runs-on: ${{ fromJson(
         format('["self-hosted", "{0}", "X64", "1ES.Pool=hld-{1}-{2}", "JobId=run-benchmarks-{3}-{4}-{5}"]', 
           inputs.hypervisor == 'hyperv-ws2025' && 'Windows' || 'Linux', 

--- a/.github/workflows/dep_build_guests.yml
+++ b/.github/workflows/dep_build_guests.yml
@@ -32,7 +32,7 @@ defaults:
 jobs:
   build-guests:
     if: ${{ inputs.docs_only == 'false' }}
-    timeout-minutes: 15
+    timeout-minutes: ${{ vars.BUILD_GUESTS_JOB_TIMEOUT || 15 }}
     runs-on: ${{ fromJson(
       format('["self-hosted", "Linux", "{0}", "{1}" {2}]',
         inputs.arch,

--- a/.github/workflows/dep_build_guests.yml
+++ b/.github/workflows/dep_build_guests.yml
@@ -32,7 +32,7 @@ defaults:
 jobs:
   build-guests:
     if: ${{ inputs.docs_only == 'false' }}
-    timeout-minutes: ${{ vars.BUILD_GUESTS_JOB_TIMEOUT || 15 }}
+    timeout-minutes: ${{ fromJSON(vars.BUILD_GUESTS_JOB_TIMEOUT || '15') }}
     runs-on: ${{ fromJson(
       format('["self-hosted", "Linux", "{0}", "{1}" {2}]',
         inputs.arch,

--- a/.github/workflows/dep_build_test.yml
+++ b/.github/workflows/dep_build_test.yml
@@ -41,7 +41,7 @@ defaults:
 jobs:
   build-and-test:
     if: ${{ inputs.docs_only == 'false' }}
-    timeout-minutes: ${{ vars.BUILD_TEST_JOB_TIMEOUT || 45 }}
+    timeout-minutes: ${{ fromJSON(vars.BUILD_TEST_JOB_TIMEOUT || '45') }}
     runs-on: ${{ fromJson(
         format('["self-hosted", "{0}", "{1}", {2} {3}]',
           inputs.hypervisor == 'hyperv-ws2025' && 'Windows' || 'Linux',

--- a/.github/workflows/dep_build_test.yml
+++ b/.github/workflows/dep_build_test.yml
@@ -41,7 +41,7 @@ defaults:
 jobs:
   build-and-test:
     if: ${{ inputs.docs_only == 'false' }}
-    timeout-minutes: 45
+    timeout-minutes: ${{ vars.BUILD_TEST_JOB_TIMEOUT || 45 }}
     runs-on: ${{ fromJson(
         format('["self-hosted", "{0}", "{1}", {2} {3}]',
           inputs.hypervisor == 'hyperv-ws2025' && 'Windows' || 'Linux',

--- a/.github/workflows/dep_code_checks.yml
+++ b/.github/workflows/dep_code_checks.yml
@@ -25,7 +25,7 @@ defaults:
 jobs:
   linux-checks:
     if: ${{ inputs.docs_only == 'false' }}
-    timeout-minutes: 30
+    timeout-minutes: ${{ vars.CODE_CHECKS_JOB_TIMEOUT || 30 }}
     runs-on: ["self-hosted", "Linux", "X64", "1ES.Pool=hld-kvm-amd", "JobId=linux-checks-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}"]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
@@ -95,7 +95,7 @@ jobs:
 
   windows-checks:
     if: ${{ inputs.docs_only == 'false' }}
-    timeout-minutes: 30
+    timeout-minutes: ${{ vars.CODE_CHECKS_JOB_TIMEOUT || 30 }}
     runs-on: ["self-hosted", "Windows", "X64", "1ES.Pool=hld-win2025-amd", "JobId=windows-checks-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}"]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0

--- a/.github/workflows/dep_code_checks.yml
+++ b/.github/workflows/dep_code_checks.yml
@@ -25,7 +25,7 @@ defaults:
 jobs:
   linux-checks:
     if: ${{ inputs.docs_only == 'false' }}
-    timeout-minutes: ${{ vars.CODE_CHECKS_JOB_TIMEOUT || 30 }}
+    timeout-minutes: ${{ fromJSON(vars.CODE_CHECKS_JOB_TIMEOUT || '30') }}
     runs-on: ["self-hosted", "Linux", "X64", "1ES.Pool=hld-kvm-amd", "JobId=linux-checks-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}"]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
@@ -95,7 +95,7 @@ jobs:
 
   windows-checks:
     if: ${{ inputs.docs_only == 'false' }}
-    timeout-minutes: ${{ vars.CODE_CHECKS_JOB_TIMEOUT || 30 }}
+    timeout-minutes: ${{ fromJSON(vars.CODE_CHECKS_JOB_TIMEOUT || '30') }}
     runs-on: ["self-hosted", "Windows", "X64", "1ES.Pool=hld-win2025-amd", "JobId=windows-checks-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}"]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0

--- a/.github/workflows/dep_run_examples.yml
+++ b/.github/workflows/dep_run_examples.yml
@@ -41,7 +41,7 @@ defaults:
 jobs:
   run-examples:
     if: ${{ inputs.docs_only == 'false' }}
-    timeout-minutes: ${{ vars.RUN_EXAMPLES_JOB_TIMEOUT || 15}}
+    timeout-minutes: ${{ fromJSON(vars.RUN_EXAMPLES_JOB_TIMEOUT || '15') }}
     runs-on: ${{ fromJson(
         format('["self-hosted", "{0}", "{1}", {2} {3}]',
           inputs.hypervisor == 'hyperv-ws2025' && 'Windows' || 'Linux',

--- a/.github/workflows/dep_run_examples.yml
+++ b/.github/workflows/dep_run_examples.yml
@@ -41,7 +41,7 @@ defaults:
 jobs:
   run-examples:
     if: ${{ inputs.docs_only == 'false' }}
-    timeout-minutes: 15
+    timeout-minutes: ${{ vars.RUN_EXAMPLES_JOB_TIMEOUT || 15}}
     runs-on: ${{ fromJson(
         format('["self-hosted", "{0}", "{1}", {2} {3}]',
           inputs.hypervisor == 'hyperv-ws2025' && 'Windows' || 'Linux',

--- a/.github/workflows/dep_update_guest_locks.yml
+++ b/.github/workflows/dep_update_guest_locks.yml
@@ -24,7 +24,7 @@ defaults:
 jobs:
   update-guest-locks:
     runs-on: [self-hosted, Linux, X64, "1ES.Pool=hld-kvm-amd", "JobId=update-guest-locks-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}"]
-    timeout-minutes: 15
+    timeout-minutes: ${{ vars.UPDATE_GUEST_LOCKS_JOB_TIMEOUT || 15 }}
     steps:
       # Get GitHub App token for pushing commits back to the PR
       # Uses the same app as auto-merge-dependabot.yml

--- a/.github/workflows/dep_update_guest_locks.yml
+++ b/.github/workflows/dep_update_guest_locks.yml
@@ -24,7 +24,7 @@ defaults:
 jobs:
   update-guest-locks:
     runs-on: [self-hosted, Linux, X64, "1ES.Pool=hld-kvm-amd", "JobId=update-guest-locks-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}"]
-    timeout-minutes: ${{ vars.UPDATE_GUEST_LOCKS_JOB_TIMEOUT || 15 }}
+    timeout-minutes: ${{ fromJSON(vars.UPDATE_GUEST_LOCKS_JOB_TIMEOUT || '15') }}
     steps:
       # Get GitHub App token for pushing commits back to the PR
       # Uses the same app as auto-merge-dependabot.yml


### PR DESCRIPTION
The timeout values on GH jobs are hardcoded, this means that if we need to change any of these values even temporarily then we need to submit a PR, this PR allows the timeout value for each job to be optionally read from a repo variable. The hardcoded (fallback) values are not changed.