### PR TITLE
Fix bad state on unmap failure

### DIFF
--- a/src/hyperlight_host/src/hypervisor/hyperlight_vm/mod.rs
+++ b/src/hyperlight_host/src/hypervisor/hyperlight_vm/mod.rs
@@ -509,9 +509,10 @@ impl HyperlightVm {
             .position(|(_, r)| r == region)
             .ok_or(UnmapRegionError::RegionNotFound)?;
 
-        let (slot, _) = self.mmap_regions.remove(pos);
-        self.freed_slots.push(slot);
+        let slot = self.mmap_regions[pos].0;
         self.vm.unmap_memory((slot, region))?;
+        self.mmap_regions.remove(pos);
+        self.freed_slots.push(slot);
         Ok(())
     }
 


### PR DESCRIPTION
Fixes a potential issue where state gets messed up if the hv unmap fails, but we still mark it as removed. Fixed by unmapping first, and only then mark removed