### PR TITLE
chore(deps): bump crossbeam-epoch to 0.9.20

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -667,9 +667,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
Updates `crossbeam-epoch` from 0.9.18 to 0.9.20, the first patched release for RUSTSEC-2026-0204.

Fixes #1643