### PR TITLE
Revert "Disable arm runners since unavailable (#1646)"

### DIFF
--- a/.github/workflows/DailyArm64.yml
+++ b/.github/workflows/DailyArm64.yml
@@ -27,8 +27,6 @@ jobs:
   # Build aarch64 guest binaries once and upload them as artifacts for the
   # build-test and run-examples jobs to download.
   build-guests:
-    # Temporarily disabled while Arm runners are unavailable.
-    if: ${{ false }}
     strategy:
       fail-fast: false
       matrix:
@@ -42,8 +40,6 @@ jobs:
   # Full aarch64 build-and-test. full_aarch64: "true" re-enables the Miri and
   # single-driver steps that are skipped on PRs.
   build-test:
-    # Temporarily disabled while Arm runners are unavailable.
-    if: ${{ false }}
     needs: build-guests
     permissions:
       # checkout in the called workflow
@@ -64,8 +60,6 @@ jobs:
       full_aarch64: "true"
 
   run-examples:
-    # Temporarily disabled while Arm runners are unavailable.
-    if: ${{ false }}
     needs: build-guests
     strategy:
       fail-fast: false
@@ -83,8 +77,6 @@ jobs:
   # limited arm64 runners, and runs here daily instead. The tracing
   # fuzzers (fuzz_guest_trace, fuzz_guest_estimate_trace_event) are x86_64-only
   fuzzing:
-    # Temporarily disabled while Arm runners are unavailable.
-    if: ${{ false }}
     needs: build-guests
     strategy:
       fail-fast: false

--- a/.github/workflows/PrimeCaches.yml
+++ b/.github/workflows/PrimeCaches.yml
@@ -33,9 +33,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Temporarily disabled while Arm runners are unavailable.
-        arch: [X64]
-        # arch: [X64, arm64]
+        arch: [X64, arm64]
         config: [debug, release]
     uses: ./.github/workflows/dep_build_guests.yml
     secrets: inherit
@@ -76,13 +74,12 @@ jobs:
           - arch: X64
             hypervisor: hyperv-ws2025
             config: release
-          # Arm cache entries are retained for when Arm CI is re-enabled.
-          # - arch: arm64
-          #   hypervisor: kvm
-          #   config: debug
-          # - arch: arm64
-          #   hypervisor: kvm
-          #   config: release
+          - arch: arm64
+            hypervisor: kvm
+            config: debug
+          - arch: arm64
+            hypervisor: kvm
+            config: release
     timeout-minutes: ${{ fromJSON(vars.PRIME_CACHES_JOB_TIMEOUT || '30') }}
     runs-on: ${{ fromJson(matrix.arch == 'X64'
         && format('["self-hosted", "{0}", "X64", "1ES.Pool=hld-{1}-amd", "JobId=prime-cache-{2}-{3}-{4}-{5}-{6}"]',

--- a/.github/workflows/RegenSnapshotGoldens.yml
+++ b/.github/workflows/RegenSnapshotGoldens.yml
@@ -124,9 +124,7 @@ jobs:
     if: needs.check-published.outputs.needs_publish == 'true'
     strategy:
       matrix:
-        # Temporarily disabled while Arm runners are unavailable.
-        arch: [X64]
-        # arch: [X64, arm64]
+        arch: [X64, arm64]
         config: [debug, release]
     uses: ./.github/workflows/dep_build_guests.yml
     with:
@@ -142,9 +140,7 @@ jobs:
       matrix:
         hypervisor: [kvm, mshv3, hyperv-ws2025]
         cpu: [amd, intel, apple]
-        # Temporarily disabled while Arm runners are unavailable.
-        arch: [X64]
-        # arch: [X64, arm64]
+        arch: [X64, arm64]
         config: [debug, release]
         exclude:
           # aarch64 covers Apple under KVM only.
@@ -152,13 +148,12 @@ jobs:
             hypervisor: mshv3
           - cpu: apple
             hypervisor: hyperv-ws2025
-          # Arm exclusions are retained for when Arm CI is re-enabled.
-          # - cpu: amd
-          #   arch: arm64
-          # - cpu: intel
-          #   arch: arm64
           - cpu: apple
             arch: X64
+          - cpu: amd
+            arch: arm64
+          - cpu: intel
+            arch: arm64
     runs-on: ${{ fromJson(
         format('["self-hosted", "{0}", "{1}"{2}]',
           matrix.hypervisor == 'hyperv-ws2025' && 'Windows' || 'Linux',

--- a/.github/workflows/ValidatePullRequest.yml
+++ b/.github/workflows/ValidatePullRequest.yml
@@ -57,9 +57,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        # Temporarily disabled while Arm runners are unavailable.
-        arch: [X64]
-        # arch: [X64, arm64]
+        arch: [X64, arm64]
         config: [debug, release]
     uses: ./.github/workflows/dep_build_guests.yml
     secrets: inherit
@@ -151,22 +149,19 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        # Temporarily disabled while Arm runners are unavailable.
         hypervisor: ['hyperv-ws2025', mshv3, kvm]
         cpu_vendor: [amd, intel, apple]
-        arch: [X64]
-        # arch: [X64, arm64]
+        arch: [X64, arm64]
         config: [debug, release]
         exclude:
         - cpu_vendor: apple
           hypervisor: hyperv-ws2025
         - cpu_vendor: apple
           hypervisor: mshv3
-        # Arm exclusions are retained for when Arm CI is re-enabled.
-        # - cpu_vendor: amd
-        #   arch: arm64
-        # - cpu_vendor: intel
-        #   arch: arm64
+        - cpu_vendor: amd
+          arch: arm64
+        - cpu_vendor: intel
+          arch: arm64
         - cpu_vendor: apple
           arch: X64
     uses: ./.github/workflows/dep_build_test.yml

--- a/src/hyperlight_host/src/sandbox/config.rs
+++ b/src/hyperlight_host/src/sandbox/config.rs
@@ -345,7 +345,9 @@ impl Default for SandboxConfiguration {
 
 #[cfg(test)]
 mod tests {
-    use super::{GuestMsrError, SandboxConfiguration};
+    #[cfg(target_arch = "x86_64")]
+    use super::GuestMsrError;
+    use super::SandboxConfiguration;
 
     #[test]
     #[cfg(target_arch = "x86_64")]


### PR DESCRIPTION
This reverts commit 817a2d3a14d4afc2589f742caaff4447cb359a6f, since we have an aarch64 KVM runner again.