### PR TITLE
Add SandboxBuilder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Prerelease] - Unreleased
 
 ### Added
+* `SandboxBuilder`, the entry point for creating a sandbox. It gathers machine
+  configuration, host functions, init data and memory mappings, then builds a
+  `MultiUseSandbox` from a guest binary on disk, a guest binary in memory, or a
+  snapshot by @jprendes in https://github.com/hyperlight-dev/hyperlight/pull/1725
 
 ### Changed
 * **Breaking:** Guest MSR state is now saved and restored across snapshots.

--- a/src/hyperlight_host/src/lib.rs
+++ b/src/hyperlight_host/src/lib.rs
@@ -91,6 +91,8 @@ pub use hypervisor::virtual_machine::is_hypervisor_present;
 pub use sandbox::MultiUseSandbox;
 /// The re-export for the `UninitializedSandbox` type
 pub use sandbox::UninitializedSandbox;
+/// The re-export for the `SandboxBuilder` type
+pub use sandbox::builder::SandboxBuilder;
 /// A collection of host functions that can be supplied to a sandbox
 /// constructor (e.g. [`MultiUseSandbox::from_snapshot`]).
 pub use sandbox::host_funcs::HostFunctions;

--- a/src/hyperlight_host/src/sandbox/builder.rs
+++ b/src/hyperlight_host/src/sandbox/builder.rs
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 use std::path::Path;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 #[cfg(target_os = "linux")]
 use std::time::Duration;
 
@@ -41,6 +41,44 @@ use crate::{
 /// the `build_from_*` methods to create the sandbox from a guest binary on
 /// disk, a guest binary in memory, or a [`Snapshot`]. Every setting has a
 /// default, so a builder with no adjustments is valid.
+///
+/// # Examples
+///
+/// From a guest binary on disk:
+///
+/// ```no_run
+/// # use hyperlight_host::{Result, SandboxBuilder};
+/// # fn example() -> Result<()> {
+/// let mut sandbox = SandboxBuilder::new()
+///     .with_heap_size(1024 * 1024)
+///     .with_host_function("Add", |a: i32, b: i32| a + b)
+///     .build_from_file("guest.bin")?;
+///
+/// let result: String = sandbox.call("Echo", "hello".to_string())?;
+/// # Ok(())
+/// # }
+/// ```
+///
+/// From a snapshot. The snapshot carries the guest binary and the state it was
+/// taken in, so no guest binary is given here. The builder must still register
+/// every host function the snapshot was taken with:
+///
+/// ```no_run
+/// # use hyperlight_host::{Result, SandboxBuilder};
+/// # fn example() -> Result<()> {
+/// let mut sandbox = SandboxBuilder::new()
+///     .with_host_function("Add", |a: i32, b: i32| a + b)
+///     .build_from_file("guest.bin")?;
+/// let snapshot = sandbox.snapshot()?;
+///
+/// let mut restored = SandboxBuilder::new()
+///     .with_host_function("Add", |a: i32, b: i32| a + b)
+///     .build_from_snapshot(snapshot)?;
+///
+/// let result: String = restored.call("Echo", "hello".to_string())?;
+/// # Ok(())
+/// # }
+/// ```
 #[derive(Default)]
 pub struct SandboxBuilder {
     cfg: SandboxConfiguration,
@@ -52,7 +90,12 @@ pub struct SandboxBuilder {
 }
 
 impl SandboxBuilder {
-    /// Create a builder with the default configuration and no host functions.
+    /// Create a builder with the default configuration and the default host
+    /// functions.
+    ///
+    /// By default only the `HostPrint` host function is registered, which
+    /// writes guest output to the host's stdout. Replace it with
+    /// [`Self::host_print`].
     pub fn new() -> Self {
         Self::default()
     }
@@ -82,17 +125,7 @@ impl SandboxBuilder {
 
         let mut uninitialized_sandbox = UninitializedSandbox::new(env, Some(self.cfg))?;
 
-        let mut func_registry = uninitialized_sandbox
-            .host_funcs
-            .try_lock()
-            .map_err(|_| new_error!("Error locking"))?;
-
-        let host_funcs = self.host_funcs.into_inner().functions_map;
-        for (func_name, func_entry) in host_funcs {
-            func_registry.register_host_function(func_name, func_entry);
-        }
-
-        drop(func_registry);
+        uninitialized_sandbox.host_funcs = Arc::new(Mutex::new(self.host_funcs.into_inner()));
 
         for (path, guest_base) in self.mapped_file_cow {
             uninitialized_sandbox.map_file_cow(&path, guest_base)?;
@@ -105,7 +138,7 @@ impl SandboxBuilder {
         let mut sandbox = uninitialized_sandbox.evolve()?;
 
         for region in self.mapped_memory_regions {
-            // SAFETY: the caller of `map_memory_region` guaranteed each region
+            // SAFETY: the caller of `mapped_memory_region` guaranteed each region
             // stays valid and unmodified for the lifetime of this sandbox.
             unsafe { sandbox.map_region(&region)? };
         }
@@ -139,7 +172,7 @@ impl SandboxBuilder {
         }
 
         for region in self.mapped_memory_regions {
-            // SAFETY: the caller of `map_memory_region` guaranteed each region
+            // SAFETY: the caller of `mapped_memory_region` guaranteed each region
             // stays valid and unmodified for the lifetime of this sandbox.
             unsafe { sandbox.map_region(&region)? };
         }
@@ -171,15 +204,15 @@ impl SandboxBuilder {
     /// `guest_base` must be page-aligned and lie outside the sandbox's primary
     /// shared memory region. Violations surface as an error from the
     /// `build_from_*` call, not here. Call this once per file to map several.
-    pub fn map_file_cow(&mut self, path: impl AsRef<Path>, guest_base: u64) -> &mut Self {
+    pub fn mapped_file_cow(&mut self, path: impl AsRef<Path>, guest_base: u64) -> &mut Self {
         self.mapped_file_cow
             .push((path.as_ref().to_path_buf(), guest_base));
         self
     }
 
-    /// Like [`Self::map_file_cow`], but consumes and returns `self` for chaining.
+    /// Like [`Self::mapped_file_cow`], but consumes and returns `self` for chaining.
     pub fn with_mapped_file_cow(mut self, path: impl AsRef<Path>, guest_base: u64) -> Self {
-        self.map_file_cow(path, guest_base);
+        self.mapped_file_cow(path, guest_base);
         self
     }
 
@@ -193,18 +226,18 @@ impl SandboxBuilder {
     ///
     /// The caller must ensure the host memory region remains valid and
     /// unmodified for the lifetime of the sandbox this builder produces.
-    pub unsafe fn map_memory_region(&mut self, region: MemoryRegion) -> &mut Self {
+    pub unsafe fn mapped_memory_region(&mut self, region: MemoryRegion) -> &mut Self {
         self.mapped_memory_regions.push(region);
         self
     }
 
-    /// Like [`Self::map_memory_region`], but consumes and returns `self` for chaining.
+    /// Like [`Self::mapped_memory_region`], but consumes and returns `self` for chaining.
     ///
     /// # Safety
     ///
-    /// Same as [`Self::map_memory_region`].
+    /// Same as [`Self::mapped_memory_region`].
     pub unsafe fn with_mapped_memory_region(mut self, region: MemoryRegion) -> Self {
-        unsafe { self.map_memory_region(region) };
+        unsafe { self.mapped_memory_region(region) };
         self
     }
 
@@ -234,6 +267,9 @@ impl SandboxBuilder {
 
 impl SandboxBuilder {
     /// Registers a host function that the guest can call.
+    ///
+    /// Note: registering under the name `HostPrint` overrides guest printing.
+    /// Prefer [`Self::host_print`], which checks the signature at compile time.
     pub fn host_function<Args: ParameterTuple, Output: SupportedReturnType>(
         &mut self,
         name: impl AsRef<str>,
@@ -248,9 +284,7 @@ impl SandboxBuilder {
             return_type: Output::TYPE,
         };
 
-        self.host_funcs
-            .inner_mut()
-            .register_host_function(name, entry);
+        self.host_funcs.inner_mut().register_host_function(name, entry);
         self
     }
 
@@ -283,12 +317,12 @@ impl SandboxBuilder {
     /// Registers every host function in `host_funcs`.
     ///
     /// Entries whose names are already registered are overwritten.
+    ///
+    /// Note: an entry named `HostPrint` overrides guest printing. Prefer
+    /// [`Self::host_print`], which checks the signature at compile time.
     pub fn host_functions(&mut self, host_funcs: HostFunctions) -> &mut Self {
-        let host_funcs = host_funcs.into_inner().functions_map;
-        for (func_name, func_entry) in host_funcs {
-            self.host_funcs
-                .inner_mut()
-                .register_host_function(func_name, func_entry);
+        for (func_name, func_entry) in host_funcs.into_iter() {
+            self.host_funcs.inner_mut().register_host_function(func_name, func_entry);
         }
         self
     }

--- a/src/hyperlight_host/src/sandbox/builder.rs
+++ b/src/hyperlight_host/src/sandbox/builder.rs
@@ -1,0 +1,525 @@
+/*
+Copyright 2025 The Hyperlight Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use std::path::Path;
+use std::sync::Arc;
+#[cfg(target_os = "linux")]
+use std::time::Duration;
+
+use hyperlight_common::func::{ParameterTuple, SupportedReturnType};
+use tracing_core::LevelFilter;
+
+use crate::func::HostFunction;
+use crate::mem::memory_region::{MemoryRegion, MemoryRegionFlags};
+use crate::sandbox::SandboxConfiguration;
+#[cfg(gdb)]
+use crate::sandbox::config::DebugInfo;
+use crate::sandbox::host_funcs::FunctionEntry;
+use crate::sandbox::snapshot::Snapshot;
+use crate::sandbox::uninitialized::{GuestBlob, GuestEnvironment};
+use crate::{
+    GuestBinary, HostFunctions, MultiUseSandbox as Sandbox, Result, UninitializedSandbox, new_error,
+};
+
+/// Builds a [`Sandbox`].
+///
+/// Start from [`SandboxBuilder::new`], adjust settings through the `with_*`
+/// (consuming, chainable) or bare-named (in place) accessors, then call one of
+/// the `build_from_*` methods to create the sandbox from a guest binary on
+/// disk, a guest binary in memory, or a [`Snapshot`]. Every setting has a
+/// default, so a builder with no adjustments is valid.
+#[derive(Default)]
+pub struct SandboxBuilder {
+    cfg: SandboxConfiguration,
+    host_funcs: HostFunctions,
+    init_data: Option<(Vec<u8>, MemoryRegionFlags)>,
+    mapped_file_cow: Vec<(std::path::PathBuf, u64)>,
+    mapped_memory_regions: Vec<MemoryRegion>,
+    max_guest_log_level: Option<LevelFilter>,
+}
+
+impl SandboxBuilder {
+    /// Create a builder with the default configuration and no host functions.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Build a sandbox running the guest binary at `path`.
+    pub fn build_from_file(self, path: impl AsRef<Path>) -> Result<Sandbox> {
+        let path = path.as_ref().to_path_buf();
+        self.build_from_guest_binary(GuestBinary::FilePath(path))
+    }
+
+    /// Build a sandbox running the guest binary held in `buffer`.
+    pub fn build_from_bytes(self, buffer: impl AsRef<[u8]>) -> Result<Sandbox> {
+        let buffer = buffer.as_ref();
+        self.build_from_guest_binary(GuestBinary::Buffer(buffer))
+    }
+
+    fn build_from_guest_binary(self, guest_binary: GuestBinary) -> Result<Sandbox> {
+        let init_data = self.init_data.as_ref().map(|(data, flags)| GuestBlob {
+            data,
+            permissions: *flags,
+        });
+
+        let env = GuestEnvironment {
+            init_data,
+            guest_binary,
+        };
+
+        let mut uninitialized_sandbox = UninitializedSandbox::new(env, Some(self.cfg))?;
+
+        let mut func_registry = uninitialized_sandbox
+            .host_funcs
+            .try_lock()
+            .map_err(|_| new_error!("Error locking"))?;
+
+        let host_funcs = self.host_funcs.into_inner().functions_map;
+        for (func_name, func_entry) in host_funcs {
+            func_registry.register_host_function(func_name, func_entry);
+        }
+
+        drop(func_registry);
+
+        for (path, guest_base) in self.mapped_file_cow {
+            uninitialized_sandbox.map_file_cow(&path, guest_base)?;
+        }
+
+        if let Some(max_log_level) = self.max_guest_log_level {
+            uninitialized_sandbox.set_max_guest_log_level(max_log_level);
+        }
+
+        let mut sandbox = uninitialized_sandbox.evolve()?;
+
+        for region in self.mapped_memory_regions {
+            // SAFETY: the caller of `map_memory_region` guaranteed each region
+            // stays valid and unmodified for the lifetime of this sandbox.
+            unsafe { sandbox.map_region(&region)? };
+        }
+
+        Ok(sandbox)
+    }
+
+    /// Build a sandbox restored from `snapshot`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if [`Self::init_data`] or [`Self::max_guest_log_level`]
+    /// are set. The snapshot already carries both, so they have no effect here.
+    pub fn build_from_snapshot(self, snapshot: Arc<Snapshot>) -> Result<Sandbox> {
+        if self.init_data.is_some() {
+            return Err(new_error!(
+                "init_data has no effect when building from a snapshot, as the snapshot already contains it"
+            ));
+        }
+
+        if self.max_guest_log_level.is_some() {
+            return Err(new_error!(
+                "max_guest_log_level has no effect when building from a snapshot, as the snapshot already contains it"
+            ));
+        }
+
+        let mut sandbox = Sandbox::from_snapshot(snapshot, self.host_funcs, Some(self.cfg))?;
+
+        for (path, guest_base) in self.mapped_file_cow {
+            sandbox.map_file_cow(&path, guest_base)?;
+        }
+
+        for region in self.mapped_memory_regions {
+            // SAFETY: the caller of `map_memory_region` guaranteed each region
+            // stays valid and unmodified for the lifetime of this sandbox.
+            unsafe { sandbox.map_region(&region)? };
+        }
+
+        Ok(sandbox)
+    }
+}
+
+impl SandboxBuilder {
+    /// Sets the sandbox `init_data` into the sandbox's memory when it is built, with `flags` as
+    /// the guest's permissions on that region.
+    ///
+    /// Note: [`Self::build_from_snapshot`] errors if this setting is set, as the snapshot already
+    /// contains the init data.
+    pub fn init_data(&mut self, data: impl Into<Vec<u8>>, flags: MemoryRegionFlags) -> &mut Self {
+        self.init_data = Some((data.into(), flags));
+        self
+    }
+
+    /// Like [`Self::init_data`], but consumes and returns `self` for chaining.
+    pub fn with_init_data(mut self, data: impl Into<Vec<u8>>, flags: MemoryRegionFlags) -> Self {
+        self.init_data(data, flags);
+        self
+    }
+
+    /// Map the contents of the file at `path` into the guest at `guest_base`,
+    /// copy-on-write.
+    ///
+    /// `guest_base` must be page-aligned and lie outside the sandbox's primary
+    /// shared memory region. Violations surface as an error from the
+    /// `build_from_*` call, not here. Call this once per file to map several.
+    pub fn map_file_cow(&mut self, path: impl AsRef<Path>, guest_base: u64) -> &mut Self {
+        self.mapped_file_cow
+            .push((path.as_ref().to_path_buf(), guest_base));
+        self
+    }
+
+    /// Like [`Self::map_file_cow`], but consumes and returns `self` for chaining.
+    pub fn with_mapped_file_cow(mut self, path: impl AsRef<Path>, guest_base: u64) -> Self {
+        self.map_file_cow(path, guest_base);
+        self
+    }
+
+    /// Maps a region of host memory into the sandbox address space.
+    ///
+    /// The base address and length must meet platform alignment requirements
+    /// (typically page-aligned). The `region_type` field is ignored as guest
+    /// page table entries are not created.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure the host memory region remains valid and
+    /// unmodified for the lifetime of the sandbox this builder produces.
+    pub unsafe fn map_memory_region(&mut self, region: MemoryRegion) -> &mut Self {
+        self.mapped_memory_regions.push(region);
+        self
+    }
+
+    /// Like [`Self::map_memory_region`], but consumes and returns `self` for chaining.
+    ///
+    /// # Safety
+    ///
+    /// Same as [`Self::map_memory_region`].
+    pub unsafe fn with_mapped_memory_region(mut self, region: MemoryRegion) -> Self {
+        unsafe { self.map_memory_region(region) };
+        self
+    }
+
+    /// Sets the maximum log level for guest code execution.
+    ///
+    /// If not set, the log level is determined by the `RUST_LOG` environment variable,
+    /// defaulting to [`LevelFilter::ERROR`] if unset.
+    ///
+    /// Note: [`Self::build_from_snapshot`] errors if this setting is set, as the log level is
+    /// already captured in the snapshot.
+    pub fn max_guest_log_level(&mut self, level: LevelFilter) -> &mut Self {
+        self.max_guest_log_level = Some(level);
+        self
+    }
+
+    /// Like [`Self::max_guest_log_level`], but consumes and returns `self` for chaining.
+    pub fn with_max_guest_log_level(mut self, level: LevelFilter) -> Self {
+        self.max_guest_log_level(level);
+        self
+    }
+
+    /// The maximum log level for guest code execution, or `None` if not set.
+    pub fn get_max_guest_log_level(&self) -> Option<LevelFilter> {
+        self.max_guest_log_level
+    }
+}
+
+impl SandboxBuilder {
+    /// Registers a host function that the guest can call.
+    pub fn host_function<Args: ParameterTuple, Output: SupportedReturnType>(
+        &mut self,
+        name: impl AsRef<str>,
+        host_func: impl Into<HostFunction<Output, Args>>,
+    ) -> &mut Self {
+        let func = host_func.into().into();
+        let name = name.as_ref().to_string();
+
+        let entry = FunctionEntry {
+            function: func,
+            parameter_types: Args::TYPE,
+            return_type: Output::TYPE,
+        };
+
+        self.host_funcs
+            .inner_mut()
+            .register_host_function(name, entry);
+        self
+    }
+
+    /// Like [`Self::host_function`], but consumes and returns `self` for chaining.
+    pub fn with_host_function<Args: ParameterTuple, Output: SupportedReturnType>(
+        mut self,
+        name: impl AsRef<str>,
+        host_func: impl Into<HostFunction<Output, Args>>,
+    ) -> Self {
+        self.host_function(name, host_func);
+        self
+    }
+
+    /// Registers the special "HostPrint" function for guest printing.
+    ///
+    /// This overrides the default behavior of writing to stdout.
+    /// The function expects the signature `FnMut(String) -> i32`
+    /// and will be called when the guest wants to print output.
+    pub fn host_print(&mut self, print_func: impl Into<HostFunction<i32, (String,)>>) -> &mut Self {
+        self.host_function("HostPrint", print_func);
+        self
+    }
+
+    /// Like [`Self::host_print`], but consumes and returns `self` for chaining.
+    pub fn with_host_print(mut self, print_func: impl Into<HostFunction<i32, (String,)>>) -> Self {
+        self.host_print(print_func);
+        self
+    }
+
+    /// Registers every host function in `host_funcs`.
+    ///
+    /// Entries whose names are already registered are overwritten.
+    pub fn host_functions(&mut self, host_funcs: HostFunctions) -> &mut Self {
+        let host_funcs = host_funcs.into_inner().functions_map;
+        for (func_name, func_entry) in host_funcs {
+            self.host_funcs
+                .inner_mut()
+                .register_host_function(func_name, func_entry);
+        }
+        self
+    }
+
+    /// Like [`Self::host_functions`], but consumes and returns `self` for chaining.
+    pub fn with_host_functions(mut self, host_funcs: HostFunctions) -> Self {
+        self.host_functions(host_funcs);
+        self
+    }
+}
+
+impl SandboxBuilder {
+    /// Set the size of the memory buffer made available for input to the guest.
+    /// Values below [`SandboxConfiguration::MIN_INPUT_SIZE`] are clamped up.
+    pub fn input_data_size(&mut self, size: usize) -> &mut Self {
+        self.cfg.set_input_data_size(size);
+        self
+    }
+
+    /// Like [`Self::input_data_size`], but consumes and returns `self` for chaining.
+    pub fn with_input_data_size(mut self, size: usize) -> Self {
+        self.input_data_size(size);
+        self
+    }
+
+    /// The size of the memory buffer made available for input to the guest.
+    pub fn get_input_data_size(&self) -> usize {
+        self.cfg.get_input_data_size()
+    }
+
+    /// Set the size of the memory buffer made available for output from the guest.
+    /// Values below [`SandboxConfiguration::MIN_OUTPUT_SIZE`] are clamped up.
+    pub fn output_data_size(&mut self, size: usize) -> &mut Self {
+        self.cfg.set_output_data_size(size);
+        self
+    }
+
+    /// Like [`Self::output_data_size`], but consumes and returns `self` for chaining.
+    pub fn with_output_data_size(mut self, size: usize) -> Self {
+        self.output_data_size(size);
+        self
+    }
+
+    /// The size of the memory buffer made available for output from the guest.
+    pub fn get_output_data_size(&self) -> usize {
+        self.cfg.get_output_data_size()
+    }
+
+    /// Set the guest heap size. A size of 0 selects
+    /// [`SandboxConfiguration::DEFAULT_HEAP_SIZE`].
+    pub fn heap_size(&mut self, size: u64) -> &mut Self {
+        self.cfg.set_heap_size(size);
+        self
+    }
+
+    /// Like [`Self::heap_size`], but consumes and returns `self` for chaining.
+    pub fn with_heap_size(mut self, size: u64) -> Self {
+        self.heap_size(size);
+        self
+    }
+
+    /// The guest heap size, defaulting to
+    /// [`SandboxConfiguration::DEFAULT_HEAP_SIZE`] when no override is set.
+    pub fn get_heap_size(&self) -> u64 {
+        self.cfg.get_heap_size()
+    }
+
+    /// Set how much writable memory to offer the guest.
+    pub fn scratch_size(&mut self, size: usize) -> &mut Self {
+        self.cfg.set_scratch_size(size);
+        self
+    }
+
+    /// Like [`Self::scratch_size`], but consumes and returns `self` for chaining.
+    pub fn with_scratch_size(mut self, size: usize) -> Self {
+        self.scratch_size(size);
+        self
+    }
+
+    /// How much writable memory is offered to the guest.
+    pub fn get_scratch_size(&self) -> usize {
+        self.cfg.get_scratch_size()
+    }
+
+    /// Set how long to wait between attempts to signal the VCPU thread.
+    #[cfg(target_os = "linux")]
+    pub fn interrupt_retry_delay(&mut self, delay: Duration) -> &mut Self {
+        self.cfg.set_interrupt_retry_delay(delay);
+        self
+    }
+
+    /// Like [`Self::interrupt_retry_delay`], but consumes and returns `self` for chaining.
+    #[cfg(target_os = "linux")]
+    pub fn with_interrupt_retry_delay(mut self, delay: Duration) -> Self {
+        self.interrupt_retry_delay(delay);
+        self
+    }
+
+    /// How long to wait between attempts to signal the VCPU thread.
+    #[cfg(target_os = "linux")]
+    pub fn get_interrupt_retry_delay(&self) -> Duration {
+        self.cfg.get_interrupt_retry_delay()
+    }
+
+    /// Set the offset from `SIGRTMIN` for the signal used to interrupt the VCPU
+    /// thread.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `SIGRTMIN + offset` exceeds `SIGRTMAX`.
+    #[cfg(target_os = "linux")]
+    pub fn interrupt_vcpu_sigrtmin_offset(&mut self, offset: u8) -> Result<&mut Self> {
+        self.cfg.set_interrupt_vcpu_sigrtmin_offset(offset)?;
+        Ok(self)
+    }
+
+    /// Like [`Self::interrupt_vcpu_sigrtmin_offset`], but consumes and returns `self` for chaining.
+    #[cfg(target_os = "linux")]
+    pub fn with_interrupt_vcpu_sigrtmin_offset(mut self, offset: u8) -> Result<Self> {
+        self.interrupt_vcpu_sigrtmin_offset(offset)?;
+        Ok(self)
+    }
+
+    /// The offset from `SIGRTMIN` for the signal used to interrupt the VCPU thread.
+    #[cfg(target_os = "linux")]
+    pub fn get_interrupt_vcpu_sigrtmin_offset(&self) -> u8 {
+        self.cfg.get_interrupt_vcpu_sigrtmin_offset()
+    }
+
+    /// Toggle guest core dump generation.
+    #[cfg(crashdump)]
+    pub fn guest_core_dump(&mut self, enabled: bool) -> &mut Self {
+        self.cfg.set_guest_core_dump(enabled);
+        self
+    }
+
+    /// Like [`Self::guest_core_dump`], but consumes and returns `self` for chaining.
+    #[cfg(crashdump)]
+    pub fn with_guest_core_dump(mut self, enabled: bool) -> Self {
+        self.guest_core_dump(enabled);
+        self
+    }
+
+    /// Whether guest core dump generation is enabled.
+    #[cfg(crashdump)]
+    pub fn get_guest_core_dump(&self) -> bool {
+        self.cfg.get_guest_core_dump()
+    }
+
+    /// Set the guest debug configuration.
+    #[cfg(gdb)]
+    pub fn guest_debug_info(&mut self, debug_info: DebugInfo) -> &mut Self {
+        self.cfg.set_guest_debug_info(debug_info);
+        self
+    }
+
+    /// Like [`Self::guest_debug_info`], but consumes and returns `self` for chaining.
+    #[cfg(gdb)]
+    pub fn with_guest_debug_info(mut self, debug_info: DebugInfo) -> Self {
+        self.guest_debug_info(debug_info);
+        self
+    }
+
+    /// The guest debug configuration, or `None` when debugging is not configured.
+    #[cfg(gdb)]
+    pub fn get_guest_debug_info(&self) -> Option<DebugInfo> {
+        self.cfg.get_guest_debug_info()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use hyperlight_testing::simple_guest_as_string;
+    use tracing_core::LevelFilter;
+
+    use super::SandboxBuilder;
+    use crate::mem::memory_region::MemoryRegionFlags;
+
+    #[test]
+    fn build_from_file() {
+        let path = simple_guest_as_string().unwrap();
+        let mut sandbox = SandboxBuilder::new()
+            .with_input_data_size(0x8000)
+            .build_from_file(path)
+            .unwrap();
+
+        let result = sandbox.call::<String>("Echo", "hello".to_string()).unwrap();
+        assert_eq!(result, "hello");
+    }
+
+    #[test]
+    fn build_from_bytes() {
+        let bytes = std::fs::read(simple_guest_as_string().unwrap()).unwrap();
+        let mut sandbox = SandboxBuilder::new().build_from_bytes(bytes).unwrap();
+
+        let result = sandbox.call::<String>("Echo", "hello".to_string()).unwrap();
+        assert_eq!(result, "hello");
+    }
+
+    #[test]
+    fn build_from_snapshot() {
+        let path = simple_guest_as_string().unwrap();
+        let mut sandbox = SandboxBuilder::new().build_from_file(path).unwrap();
+        let snapshot = sandbox.snapshot().unwrap();
+
+        let mut restored = SandboxBuilder::new().build_from_snapshot(snapshot).unwrap();
+
+        let result = restored
+            .call::<String>("Echo", "hello".to_string())
+            .unwrap();
+        assert_eq!(result, "hello");
+    }
+
+    #[test]
+    fn build_from_snapshot_errors_on_ignored_settings() {
+        let path = simple_guest_as_string().unwrap();
+        let mut sandbox = SandboxBuilder::new().build_from_file(path).unwrap();
+        let snapshot = sandbox.snapshot().unwrap();
+
+        assert!(
+            SandboxBuilder::new()
+                .with_init_data([0u8; 8], MemoryRegionFlags::READ)
+                .build_from_snapshot(snapshot.clone())
+                .is_err()
+        );
+
+        assert!(
+            SandboxBuilder::new()
+                .with_max_guest_log_level(LevelFilter::INFO)
+                .build_from_snapshot(snapshot)
+                .is_err()
+        );
+    }
+}

--- a/src/hyperlight_host/src/sandbox/builder.rs
+++ b/src/hyperlight_host/src/sandbox/builder.rs
@@ -87,7 +87,7 @@ pub struct SandboxBuilder {
     init_data: Option<(Vec<u8>, MemoryRegionFlags)>,
     mapped_file_cow: Vec<(std::path::PathBuf, u64)>,
     mapped_memory_regions: Vec<MemoryRegion>,
-    max_guest_log_level: Option<LevelFilter>,
+    guest_log_level: Option<LevelFilter>,
 }
 
 impl SandboxBuilder {
@@ -132,8 +132,8 @@ impl SandboxBuilder {
             uninitialized_sandbox.map_file_cow(&path, guest_base)?;
         }
 
-        if let Some(max_log_level) = self.max_guest_log_level {
-            uninitialized_sandbox.set_max_guest_log_level(max_log_level);
+        if let Some(log_level) = self.guest_log_level {
+            uninitialized_sandbox.set_max_guest_log_level(log_level);
         }
 
         let mut sandbox = uninitialized_sandbox.evolve()?;
@@ -151,7 +151,7 @@ impl SandboxBuilder {
     ///
     /// # Errors
     ///
-    /// Returns an error if [`Self::init_data`] or [`Self::max_guest_log_level`]
+    /// Returns an error if [`Self::init_data`] or [`Self::guest_log_level`]
     /// are set. The snapshot already carries both, so they have no effect here.
     pub fn build_from_snapshot(self, snapshot: Arc<Snapshot>) -> Result<Sandbox> {
         if self.init_data.is_some() {
@@ -160,9 +160,9 @@ impl SandboxBuilder {
             ));
         }
 
-        if self.max_guest_log_level.is_some() {
+        if self.guest_log_level.is_some() {
             return Err(new_error!(
-                "max_guest_log_level has no effect when building from a snapshot, as the snapshot already contains it"
+                "guest_log_level has no effect when building from a snapshot, as the snapshot already contains it"
             ));
         }
 
@@ -227,14 +227,14 @@ impl SandboxBuilder {
     ///
     /// Note: [`Self::build_from_snapshot`] errors if this setting is set, as the log level is
     /// already captured in the snapshot.
-    pub fn max_guest_log_level(mut self, level: LevelFilter) -> Self {
-        self.max_guest_log_level = Some(level);
+    pub fn guest_log_level(mut self, level: LevelFilter) -> Self {
+        self.guest_log_level = Some(level);
         self
     }
 
     /// The maximum log level for guest code execution, or `None` if not set.
-    pub fn get_max_guest_log_level(&self) -> Option<LevelFilter> {
-        self.max_guest_log_level
+    pub fn get_guest_log_level(&self) -> Option<LevelFilter> {
+        self.guest_log_level
     }
 }
 
@@ -470,7 +470,7 @@ mod tests {
 
         assert!(
             SandboxBuilder::new()
-                .max_guest_log_level(LevelFilter::INFO)
+                .guest_log_level(LevelFilter::INFO)
                 .build_from_snapshot(snapshot)
                 .is_err()
         );

--- a/src/hyperlight_host/src/sandbox/builder.rs
+++ b/src/hyperlight_host/src/sandbox/builder.rs
@@ -38,10 +38,9 @@ use crate::{
 
 /// Builds a [`Sandbox`].
 ///
-/// Start from [`SandboxBuilder::new`], adjust settings through the `with_*`
-/// (consuming, chainable) or bare-named (in place) accessors, then call one of
-/// the `build_from_*` methods to create the sandbox from a guest binary on
-/// disk, a guest binary in memory, or a [`Snapshot`]. Every setting has a
+/// Start from [`SandboxBuilder::new`], chain the settings you need, then call
+/// one of the `build_from_*` methods to create the sandbox from a guest binary
+/// on disk, a guest binary in memory, or a [`Snapshot`]. Every setting has a
 /// default, so a builder with no adjustments is valid.
 ///
 /// # Examples
@@ -52,8 +51,8 @@ use crate::{
 /// # use hyperlight_host::{Result, SandboxBuilder};
 /// # fn example() -> Result<()> {
 /// let mut sandbox = SandboxBuilder::new()
-///     .with_heap_size(1024 * 1024)
-///     .with_host_function("Add", |a: i32, b: i32| a + b)
+///     .heap_size(1024 * 1024)
+///     .host_function("Add", |a: i32, b: i32| a + b)
 ///     .build_from_file("guest.bin")?;
 ///
 /// let result: String = sandbox.call("Echo", "hello".to_string())?;
@@ -69,12 +68,12 @@ use crate::{
 /// # use hyperlight_host::{Result, SandboxBuilder};
 /// # fn example() -> Result<()> {
 /// let mut sandbox = SandboxBuilder::new()
-///     .with_host_function("Add", |a: i32, b: i32| a + b)
+///     .host_function("Add", |a: i32, b: i32| a + b)
 ///     .build_from_file("guest.bin")?;
 /// let snapshot = sandbox.snapshot()?;
 ///
 /// let mut restored = SandboxBuilder::new()
-///     .with_host_function("Add", |a: i32, b: i32| a + b)
+///     .host_function("Add", |a: i32, b: i32| a + b)
 ///     .build_from_snapshot(snapshot)?;
 ///
 /// let result: String = restored.call("Echo", "hello".to_string())?;
@@ -189,14 +188,8 @@ impl SandboxBuilder {
     ///
     /// Note: [`Self::build_from_snapshot`] errors if this setting is set, as the snapshot already
     /// contains the init data.
-    pub fn init_data(&mut self, data: impl Into<Vec<u8>>, flags: MemoryRegionFlags) -> &mut Self {
+    pub fn init_data(mut self, data: impl Into<Vec<u8>>, flags: MemoryRegionFlags) -> Self {
         self.init_data = Some((data.into(), flags));
-        self
-    }
-
-    /// Like [`Self::init_data`], but consumes and returns `self` for chaining.
-    pub fn with_init_data(mut self, data: impl Into<Vec<u8>>, flags: MemoryRegionFlags) -> Self {
-        self.init_data(data, flags);
         self
     }
 
@@ -206,15 +199,9 @@ impl SandboxBuilder {
     /// `guest_base` must be page-aligned and lie outside the sandbox's primary
     /// shared memory region. Violations surface as an error from the
     /// `build_from_*` call, not here. Call this once per file to map several.
-    pub fn mapped_file_cow(&mut self, path: impl AsRef<Path>, guest_base: u64) -> &mut Self {
+    pub fn mapped_file_cow(mut self, path: impl AsRef<Path>, guest_base: u64) -> Self {
         self.mapped_file_cow
             .push((path.as_ref().to_path_buf(), guest_base));
-        self
-    }
-
-    /// Like [`Self::mapped_file_cow`], but consumes and returns `self` for chaining.
-    pub fn with_mapped_file_cow(mut self, path: impl AsRef<Path>, guest_base: u64) -> Self {
-        self.mapped_file_cow(path, guest_base);
         self
     }
 
@@ -228,18 +215,8 @@ impl SandboxBuilder {
     ///
     /// The caller must ensure the host memory region remains valid and
     /// unmodified for the lifetime of the sandbox this builder produces.
-    pub unsafe fn mapped_memory_region(&mut self, region: MemoryRegion) -> &mut Self {
+    pub unsafe fn mapped_memory_region(mut self, region: MemoryRegion) -> Self {
         self.mapped_memory_regions.push(region);
-        self
-    }
-
-    /// Like [`Self::mapped_memory_region`], but consumes and returns `self` for chaining.
-    ///
-    /// # Safety
-    ///
-    /// Same as [`Self::mapped_memory_region`].
-    pub unsafe fn with_mapped_memory_region(mut self, region: MemoryRegion) -> Self {
-        unsafe { self.mapped_memory_region(region) };
         self
     }
 
@@ -250,14 +227,8 @@ impl SandboxBuilder {
     ///
     /// Note: [`Self::build_from_snapshot`] errors if this setting is set, as the log level is
     /// already captured in the snapshot.
-    pub fn max_guest_log_level(&mut self, level: LevelFilter) -> &mut Self {
+    pub fn max_guest_log_level(mut self, level: LevelFilter) -> Self {
         self.max_guest_log_level = Some(level);
-        self
-    }
-
-    /// Like [`Self::max_guest_log_level`], but consumes and returns `self` for chaining.
-    pub fn with_max_guest_log_level(mut self, level: LevelFilter) -> Self {
-        self.max_guest_log_level(level);
         self
     }
 
@@ -273,10 +244,10 @@ impl SandboxBuilder {
     /// Note: registering under the name `HostPrint` overrides guest printing.
     /// Prefer [`Self::host_print`], which checks the signature at compile time.
     pub fn host_function<Args: ParameterTuple, Output: SupportedReturnType>(
-        &mut self,
+        mut self,
         name: impl AsRef<str>,
         host_func: impl Into<HostFunction<Output, Args>>,
-    ) -> &mut Self {
+    ) -> Self {
         let func = host_func.into().into();
         let name = name.as_ref().to_string();
 
@@ -292,30 +263,13 @@ impl SandboxBuilder {
         self
     }
 
-    /// Like [`Self::host_function`], but consumes and returns `self` for chaining.
-    pub fn with_host_function<Args: ParameterTuple, Output: SupportedReturnType>(
-        mut self,
-        name: impl AsRef<str>,
-        host_func: impl Into<HostFunction<Output, Args>>,
-    ) -> Self {
-        self.host_function(name, host_func);
-        self
-    }
-
     /// Registers the special "HostPrint" function for guest printing.
     ///
     /// This overrides the default behavior of writing to stdout.
     /// The function expects the signature `FnMut(String) -> i32`
     /// and will be called when the guest wants to print output.
-    pub fn host_print(&mut self, print_func: impl Into<HostFunction<i32, (String,)>>) -> &mut Self {
-        self.host_function("HostPrint", print_func);
-        self
-    }
-
-    /// Like [`Self::host_print`], but consumes and returns `self` for chaining.
-    pub fn with_host_print(mut self, print_func: impl Into<HostFunction<i32, (String,)>>) -> Self {
-        self.host_print(print_func);
-        self
+    pub fn host_print(self, print_func: impl Into<HostFunction<i32, (String,)>>) -> Self {
+        self.host_function("HostPrint", print_func)
     }
 
     /// Registers every host function in `host_funcs`.
@@ -324,7 +278,7 @@ impl SandboxBuilder {
     ///
     /// Note: an entry named `HostPrint` overrides guest printing. Prefer
     /// [`Self::host_print`], which checks the signature at compile time.
-    pub fn host_functions(&mut self, host_funcs: HostFunctions) -> &mut Self {
+    pub fn host_functions(mut self, host_funcs: HostFunctions) -> Self {
         for (func_name, func_entry) in host_funcs.into_iter() {
             self.host_funcs
                 .inner_mut()
@@ -332,25 +286,13 @@ impl SandboxBuilder {
         }
         self
     }
-
-    /// Like [`Self::host_functions`], but consumes and returns `self` for chaining.
-    pub fn with_host_functions(mut self, host_funcs: HostFunctions) -> Self {
-        self.host_functions(host_funcs);
-        self
-    }
 }
 
 impl SandboxBuilder {
     /// Set the size of the memory buffer made available for input to the guest.
     /// Values below [`SandboxConfiguration::MIN_INPUT_SIZE`] are clamped up.
-    pub fn input_data_size(&mut self, size: usize) -> &mut Self {
+    pub fn input_data_size(mut self, size: usize) -> Self {
         self.cfg.set_input_data_size(size);
-        self
-    }
-
-    /// Like [`Self::input_data_size`], but consumes and returns `self` for chaining.
-    pub fn with_input_data_size(mut self, size: usize) -> Self {
-        self.input_data_size(size);
         self
     }
 
@@ -361,14 +303,8 @@ impl SandboxBuilder {
 
     /// Set the size of the memory buffer made available for output from the guest.
     /// Values below [`SandboxConfiguration::MIN_OUTPUT_SIZE`] are clamped up.
-    pub fn output_data_size(&mut self, size: usize) -> &mut Self {
+    pub fn output_data_size(mut self, size: usize) -> Self {
         self.cfg.set_output_data_size(size);
-        self
-    }
-
-    /// Like [`Self::output_data_size`], but consumes and returns `self` for chaining.
-    pub fn with_output_data_size(mut self, size: usize) -> Self {
-        self.output_data_size(size);
         self
     }
 
@@ -379,14 +315,8 @@ impl SandboxBuilder {
 
     /// Set the guest heap size. A size of 0 selects
     /// [`SandboxConfiguration::DEFAULT_HEAP_SIZE`].
-    pub fn heap_size(&mut self, size: u64) -> &mut Self {
+    pub fn heap_size(mut self, size: u64) -> Self {
         self.cfg.set_heap_size(size);
-        self
-    }
-
-    /// Like [`Self::heap_size`], but consumes and returns `self` for chaining.
-    pub fn with_heap_size(mut self, size: u64) -> Self {
-        self.heap_size(size);
         self
     }
 
@@ -397,14 +327,8 @@ impl SandboxBuilder {
     }
 
     /// Set how much writable memory to offer the guest.
-    pub fn scratch_size(&mut self, size: usize) -> &mut Self {
+    pub fn scratch_size(mut self, size: usize) -> Self {
         self.cfg.set_scratch_size(size);
-        self
-    }
-
-    /// Like [`Self::scratch_size`], but consumes and returns `self` for chaining.
-    pub fn with_scratch_size(mut self, size: usize) -> Self {
-        self.scratch_size(size);
         self
     }
 
@@ -425,29 +349,15 @@ impl SandboxBuilder {
     /// would exceed [`SandboxConfiguration::MAX_GUEST_MSRS`]. The declared set
     /// is unchanged on error.
     #[cfg(target_arch = "x86_64")]
-    pub fn guest_msrs(&mut self, indices: &[u32]) -> std::result::Result<&mut Self, GuestMsrError> {
+    pub fn guest_msrs(mut self, indices: &[u32]) -> std::result::Result<Self, GuestMsrError> {
         self.cfg.guest_msrs(indices)?;
-        Ok(self)
-    }
-
-    /// Like [`Self::guest_msrs`], but consumes and returns `self` for chaining.
-    #[cfg(target_arch = "x86_64")]
-    pub fn with_guest_msrs(mut self, indices: &[u32]) -> std::result::Result<Self, GuestMsrError> {
-        self.guest_msrs(indices)?;
         Ok(self)
     }
 
     /// Set how long to wait between attempts to signal the VCPU thread.
     #[cfg(target_os = "linux")]
-    pub fn interrupt_retry_delay(&mut self, delay: Duration) -> &mut Self {
+    pub fn interrupt_retry_delay(mut self, delay: Duration) -> Self {
         self.cfg.set_interrupt_retry_delay(delay);
-        self
-    }
-
-    /// Like [`Self::interrupt_retry_delay`], but consumes and returns `self` for chaining.
-    #[cfg(target_os = "linux")]
-    pub fn with_interrupt_retry_delay(mut self, delay: Duration) -> Self {
-        self.interrupt_retry_delay(delay);
         self
     }
 
@@ -464,15 +374,8 @@ impl SandboxBuilder {
     ///
     /// Returns an error if `SIGRTMIN + offset` exceeds `SIGRTMAX`.
     #[cfg(target_os = "linux")]
-    pub fn interrupt_vcpu_sigrtmin_offset(&mut self, offset: u8) -> Result<&mut Self> {
+    pub fn interrupt_vcpu_sigrtmin_offset(mut self, offset: u8) -> Result<Self> {
         self.cfg.set_interrupt_vcpu_sigrtmin_offset(offset)?;
-        Ok(self)
-    }
-
-    /// Like [`Self::interrupt_vcpu_sigrtmin_offset`], but consumes and returns `self` for chaining.
-    #[cfg(target_os = "linux")]
-    pub fn with_interrupt_vcpu_sigrtmin_offset(mut self, offset: u8) -> Result<Self> {
-        self.interrupt_vcpu_sigrtmin_offset(offset)?;
         Ok(self)
     }
 
@@ -484,15 +387,8 @@ impl SandboxBuilder {
 
     /// Toggle guest core dump generation.
     #[cfg(crashdump)]
-    pub fn guest_core_dump(&mut self, enabled: bool) -> &mut Self {
+    pub fn guest_core_dump(mut self, enabled: bool) -> Self {
         self.cfg.set_guest_core_dump(enabled);
-        self
-    }
-
-    /// Like [`Self::guest_core_dump`], but consumes and returns `self` for chaining.
-    #[cfg(crashdump)]
-    pub fn with_guest_core_dump(mut self, enabled: bool) -> Self {
-        self.guest_core_dump(enabled);
         self
     }
 
@@ -504,15 +400,8 @@ impl SandboxBuilder {
 
     /// Set the guest debug configuration.
     #[cfg(gdb)]
-    pub fn guest_debug_info(&mut self, debug_info: DebugInfo) -> &mut Self {
+    pub fn guest_debug_info(mut self, debug_info: DebugInfo) -> Self {
         self.cfg.set_guest_debug_info(debug_info);
-        self
-    }
-
-    /// Like [`Self::guest_debug_info`], but consumes and returns `self` for chaining.
-    #[cfg(gdb)]
-    pub fn with_guest_debug_info(mut self, debug_info: DebugInfo) -> Self {
-        self.guest_debug_info(debug_info);
         self
     }
 
@@ -535,7 +424,7 @@ mod tests {
     fn build_from_file() {
         let path = simple_guest_as_string().unwrap();
         let mut sandbox = SandboxBuilder::new()
-            .with_input_data_size(0x8000)
+            .input_data_size(0x8000)
             .build_from_file(path)
             .unwrap();
 
@@ -574,14 +463,14 @@ mod tests {
 
         assert!(
             SandboxBuilder::new()
-                .with_init_data([0u8; 8], MemoryRegionFlags::READ)
+                .init_data([0u8; 8], MemoryRegionFlags::READ)
                 .build_from_snapshot(snapshot.clone())
                 .is_err()
         );
 
         assert!(
             SandboxBuilder::new()
-                .with_max_guest_log_level(LevelFilter::INFO)
+                .max_guest_log_level(LevelFilter::INFO)
                 .build_from_snapshot(snapshot)
                 .is_err()
         );

--- a/src/hyperlight_host/src/sandbox/builder.rs
+++ b/src/hyperlight_host/src/sandbox/builder.rs
@@ -27,6 +27,8 @@ use crate::mem::memory_region::{MemoryRegion, MemoryRegionFlags};
 use crate::sandbox::SandboxConfiguration;
 #[cfg(gdb)]
 use crate::sandbox::config::DebugInfo;
+#[cfg(target_arch = "x86_64")]
+use crate::sandbox::config::GuestMsrError;
 use crate::sandbox::host_funcs::FunctionEntry;
 use crate::sandbox::snapshot::Snapshot;
 use crate::sandbox::uninitialized::{GuestBlob, GuestEnvironment};
@@ -284,7 +286,9 @@ impl SandboxBuilder {
             return_type: Output::TYPE,
         };
 
-        self.host_funcs.inner_mut().register_host_function(name, entry);
+        self.host_funcs
+            .inner_mut()
+            .register_host_function(name, entry);
         self
     }
 
@@ -322,7 +326,9 @@ impl SandboxBuilder {
     /// [`Self::host_print`], which checks the signature at compile time.
     pub fn host_functions(&mut self, host_funcs: HostFunctions) -> &mut Self {
         for (func_name, func_entry) in host_funcs.into_iter() {
-            self.host_funcs.inner_mut().register_host_function(func_name, func_entry);
+            self.host_funcs
+                .inner_mut()
+                .register_host_function(func_name, func_entry);
         }
         self
     }
@@ -405,6 +411,30 @@ impl SandboxBuilder {
     /// How much writable memory is offered to the guest.
     pub fn get_scratch_size(&self) -> usize {
         self.cfg.get_scratch_size()
+    }
+
+    /// Declare MSRs the guest owns, saved and restored with the rest of the
+    /// sandbox state. Adds to the declared set, so repeated calls accumulate.
+    ///
+    /// See [`SandboxConfiguration::guest_msrs`] for the platform-specific
+    /// behavior and the capacity limit.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`GuestMsrError::CapacityExceeded`] if the distinct entries
+    /// would exceed [`SandboxConfiguration::MAX_GUEST_MSRS`]. The declared set
+    /// is unchanged on error.
+    #[cfg(target_arch = "x86_64")]
+    pub fn guest_msrs(&mut self, indices: &[u32]) -> std::result::Result<&mut Self, GuestMsrError> {
+        self.cfg.guest_msrs(indices)?;
+        Ok(self)
+    }
+
+    /// Like [`Self::guest_msrs`], but consumes and returns `self` for chaining.
+    #[cfg(target_arch = "x86_64")]
+    pub fn with_guest_msrs(mut self, indices: &[u32]) -> std::result::Result<Self, GuestMsrError> {
+        self.guest_msrs(indices)?;
+        Ok(self)
     }
 
     /// Set how long to wait between attempts to signal the VCPU thread.

--- a/src/hyperlight_host/src/sandbox/host_funcs.rs
+++ b/src/hyperlight_host/src/sandbox/host_funcs.rs
@@ -32,7 +32,7 @@ use crate::func::host_functions::TypeErasedHostFunction;
 #[derive(Default)]
 /// A Wrapper around details of functions exposed by the Host
 pub struct FunctionRegistry {
-    functions_map: HashMap<String, FunctionEntry>,
+    pub(super) functions_map: HashMap<String, FunctionEntry>,
 }
 
 /// A collection of host functions that can be supplied to a sandbox

--- a/src/hyperlight_host/src/sandbox/host_funcs.rs
+++ b/src/hyperlight_host/src/sandbox/host_funcs.rs
@@ -32,7 +32,7 @@ use crate::func::host_functions::TypeErasedHostFunction;
 #[derive(Default)]
 /// A Wrapper around details of functions exposed by the Host
 pub struct FunctionRegistry {
-    pub(super) functions_map: HashMap<String, FunctionEntry>,
+    functions_map: HashMap<String, FunctionEntry>,
 }
 
 /// A collection of host functions that can be supplied to a sandbox
@@ -72,6 +72,10 @@ impl HostFunctions {
     /// `write(2)`.
     pub fn empty() -> Self {
         Self(FunctionRegistry::default())
+    }
+
+    pub(crate) fn into_iter(self) -> impl Iterator<Item = (String, FunctionEntry)> {
+        self.0.functions_map.into_iter()
     }
 
     /// Consume this `HostFunctions` and return the inner registry.

--- a/src/hyperlight_host/src/sandbox/initialized_multi_use.rs
+++ b/src/hyperlight_host/src/sandbox/initialized_multi_use.rs
@@ -40,6 +40,7 @@ use crate::mem::shared_mem::{HostSharedMemory, SharedMemory as _};
 use crate::metrics::{
     METRIC_GUEST_ERROR, METRIC_GUEST_ERROR_LABEL_CODE, maybe_time_and_emit_guest_call,
 };
+use crate::sandbox::builder::SandboxBuilder;
 use crate::{HyperlightError, Result, log_then_return};
 
 /// A fully initialized sandbox that can execute guest functions multiple times.
@@ -110,6 +111,14 @@ pub struct MultiUseSandbox {
 pub type PtRootFinder = Box<dyn Fn(&[u8], &[u8], u64) -> Vec<u64> + Send>;
 
 impl MultiUseSandbox {
+    /// Start building a sandbox.
+    ///
+    /// Returns a [`SandboxBuilder`] with default settings. Adjust it, then call
+    /// one of its `build_from_*` methods to get a `MultiUseSandbox`.
+    pub fn builder() -> SandboxBuilder {
+        SandboxBuilder::new()
+    }
+
     /// Move an `UninitializedSandbox` into a new `MultiUseSandbox` instance.
     ///
     /// This function is not equivalent to doing an `evolve` from uninitialized

--- a/src/hyperlight_host/src/sandbox/mod.rs
+++ b/src/hyperlight_host/src/sandbox/mod.rs
@@ -14,6 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+/// Functionality for creating and configuring `Sandbox`es.
+pub mod builder;
 /// Configuration needed to establish a sandbox.
 pub mod config;
 /// Host-side file mapping preparation for `map_file_cow`.


### PR DESCRIPTION
## Description
`SandboxBuilder` is the entry point for creating a sandbox. It gathers machine configuration, host functions, init data and memory mappings, then builds a `MultiUseSandbox` from a guest binary on disk, a guest binary in memory, or a snapshot.

It merges the roles of `SandboxConfiguration`, `GuestEnvironment` and `UninitializedSandbox` into a single type, so all three can become implementation details.

Every setting has an in place accessor taking `&mut self` and a `with_*` counterpart consuming `self` for chaining. Machine configuration values are readable through `get_*`.

`map_memory_region` is `unsafe`, matching `MultiUseSandbox::map_region`. The mapped region must stay valid for the lifetime of the built sandbox.

`build_from_snapshot` errors when `init_data` or `max_guest_log_level` are set, as a snapshot already carries both.

## Scope
This PR only adds the new API, it does not deprecate any old API, and does not replace the use of the old API throughout the repo.