### PR TITLE
Simplify GDB memory access by borrowing sandbox memory manager

### DIFF
--- a/src/hyperlight_host/src/hypervisor/gdb/mod.rs
+++ b/src/hyperlight_host/src/hypervisor/gdb/mod.rs
@@ -20,7 +20,7 @@ mod x86_64_target;
 
 use std::io::{self, ErrorKind};
 use std::net::TcpListener;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 use std::thread;
 
 use crossbeam_channel::{Receiver, Sender, TryRecvError};
@@ -78,12 +78,10 @@ impl From<GdbTargetError> for TargetError<GdbTargetError> {
     }
 }
 
-/// This abstracts the memory access functions that debugging needs from a sandbox
-pub(crate) struct DebugMemoryAccess {
-    /// Memory manager that provides access to the guest memory
-    pub(crate) dbg_mem_access_fn: Arc<Mutex<SandboxMemoryManager<HostSharedMemory>>>,
-    /// Guest mapped memory regions
-    pub(crate) guest_mmap_regions: Vec<MemoryRegion>,
+/// A borrowed view of the sandbox memory visible to GDB.
+pub(crate) struct DebugMemoryView<'a> {
+    mem_mgr: &'a SandboxMemoryManager<HostSharedMemory>,
+    guest_mmap_regions: Vec<MemoryRegion>,
 }
 
 /// Errors that can occur during debug memory access operations
@@ -91,15 +89,27 @@ pub(crate) struct DebugMemoryAccess {
 pub enum DebugMemoryAccessError {
     #[error("Failed to copy memory: {0}")]
     CopyFailed(Box<HyperlightError>),
-    #[error("Failed to acquire lock at {0}:{1} - {2}")]
-    LockFailed(&'static str, u32, String),
     #[error("Failed to translate guest address {0:#x}")]
     TranslateGuestAddress(u64),
     #[error("Failed to write to read-only region")]
     WriteToReadOnly,
 }
 
-impl DebugMemoryAccess {
+impl<'a> DebugMemoryView<'a> {
+    pub(crate) fn new(
+        mem_mgr: &'a SandboxMemoryManager<HostSharedMemory>,
+        guest_mmap_regions: Vec<MemoryRegion>,
+    ) -> Self {
+        Self {
+            mem_mgr,
+            guest_mmap_regions,
+        }
+    }
+
+    pub(crate) fn code_section_offset(&self) -> u64 {
+        self.mem_mgr.layout.get_guest_code_address() as u64
+    }
+
     /// Reads memory from the guest's address space with a maximum length of a PAGE_SIZE
     ///
     /// # Arguments
@@ -113,15 +123,11 @@ impl DebugMemoryAccess {
         data: &mut [u8],
         gpa: u64,
     ) -> std::result::Result<(), DebugMemoryAccessError> {
-        let mgr = self
-            .dbg_mem_access_fn
-            .try_lock()
-            .map_err(|e| DebugMemoryAccessError::LockFailed(file!(), line!(), e.to_string()))?;
-
-        mgr.layout
+        self.mem_mgr
+            .layout
             .resolve_gpa(gpa, &self.guest_mmap_regions)
             .ok_or(DebugMemoryAccessError::TranslateGuestAddress(gpa))?
-            .with_memories(&mgr.shared_mem, &mgr.scratch_mem)
+            .with_memories(&self.mem_mgr.shared_mem, &self.mem_mgr.scratch_mem)
             .copy_to_slice(data)
             .map_err(|e| DebugMemoryAccessError::CopyFailed(Box::new(e)))
     }
@@ -139,12 +145,8 @@ impl DebugMemoryAccess {
         data: &[u8],
         gpa: u64,
     ) -> std::result::Result<(), DebugMemoryAccessError> {
-        let mgr = self
-            .dbg_mem_access_fn
-            .try_lock()
-            .map_err(|e| DebugMemoryAccessError::LockFailed(file!(), line!(), e.to_string()))?;
-
-        let resolved = mgr
+        let resolved = self
+            .mem_mgr
             .layout
             .resolve_gpa(gpa, &self.guest_mmap_regions)
             .ok_or(DebugMemoryAccessError::TranslateGuestAddress(gpa))?;
@@ -153,11 +155,13 @@ impl DebugMemoryAccess {
         // process) if the address is in the scratch region
         match resolved.base {
             #[cfg(unshared_snapshot_mem)]
-            BaseGpaRegion::Snapshot(()) => mgr
+            BaseGpaRegion::Snapshot(()) => self
+                .mem_mgr
                 .shared_mem
                 .copy_from_slice(data, resolved.offset)
                 .map_err(|e| DebugMemoryAccessError::CopyFailed(Box::new(e))),
-            BaseGpaRegion::Scratch(()) => mgr
+            BaseGpaRegion::Scratch(()) => self
+                .mem_mgr
                 .scratch_mem
                 .copy_from_slice(data, resolved.offset)
                 .map_err(|e| DebugMemoryAccessError::CopyFailed(Box::new(e))),
@@ -373,7 +377,6 @@ mod tests {
     mod mem_access_tests {
         use std::os::fd::AsRawFd;
         use std::os::linux::fs::MetadataExt;
-        use std::sync::{Arc, Mutex};
 
         use hyperlight_testing::dummy_guest_as_pathbuf;
 
@@ -387,117 +390,115 @@ mod tests {
         #[cfg(target_os = "linux")]
         const BASE_VIRT: usize = 0x10000000 + SandboxMemoryLayout::BASE_ADDRESS;
 
-        /// Dummy memory region to test memory access
-        /// This maps a file into memory and uses it as guest memory
-        fn get_mem_access() -> crate::Result<DebugMemoryAccess> {
-            let filename = dummy_guest_as_pathbuf();
-
-            let file = std::fs::File::options()
-                .read(true)
-                .write(true)
-                .open(&filename)?;
-            let file_size = file.metadata()?.st_size();
-            let page_size = page_size::get();
-            let size = (file_size as usize).div_ceil(page_size) * page_size;
-            let mapped_mem = unsafe {
-                libc::mmap(
-                    std::ptr::null_mut(),
-                    size,
-                    libc::PROT_READ | libc::PROT_WRITE | libc::PROT_EXEC,
-                    libc::MAP_PRIVATE,
-                    file.as_raw_fd(),
-                    0,
-                )
-            };
-            if mapped_mem == libc::MAP_FAILED {
-                log_then_return!("mmap error: {:?}", std::io::Error::last_os_error());
-            }
-
-            // Create a sandbox memory manager with the mapped memory region
-            let sandbox = UninitializedSandbox::new(GuestBinary::FilePath(filename.clone()), None)
-                .inspect_err(|_| unsafe {
-                    libc::munmap(mapped_mem, size);
-                })?;
-            let (mem_mgr, _) = sandbox.mgr.build()?;
-
-            // Create the memory access struct
-            let mem_access = DebugMemoryAccess {
-                dbg_mem_access_fn: Arc::new(Mutex::new(mem_mgr)),
-                guest_mmap_regions: vec![MemoryRegion {
-                    host_region: mapped_mem as usize..mapped_mem.wrapping_add(size) as usize,
-                    guest_region: BASE_VIRT..BASE_VIRT + size,
-                    flags: MemoryRegionFlags::READ | MemoryRegionFlags::EXECUTE,
-                    region_type: MemoryRegionType::Heap,
-                }],
-            };
-
-            Ok(mem_access)
+        struct TestMemory {
+            mem_mgr: SandboxMemoryManager<HostSharedMemory>,
+            mmap_region: MemoryRegion,
         }
 
-        /// Gets a slice to the mapped memory region to be able to modify it
-        ///
-        /// NOTE: By returning a mutable slice from a mutable reference, we ensure
-        /// that the memory is not deallocated while the slice is in use.
-        unsafe fn get_mmap_slice(mem_access: &mut DebugMemoryAccess) -> &mut [u8] {
-            unsafe {
-                std::slice::from_raw_parts_mut(
-                    mem_access.guest_mmap_regions[0].host_region.start as *mut u8,
-                    mem_access.guest_mmap_regions[0].host_region.end
-                        - mem_access.guest_mmap_regions[0].host_region.start,
-                )
+        impl TestMemory {
+            fn new() -> crate::Result<Self> {
+                let filename = dummy_guest_as_pathbuf();
+                let file = std::fs::File::options()
+                    .read(true)
+                    .write(true)
+                    .open(&filename)?;
+                let file_size = file.metadata()?.st_size();
+                let page_size = page_size::get();
+                let size = (file_size as usize).div_ceil(page_size) * page_size;
+                let mapped_mem = unsafe {
+                    libc::mmap(
+                        std::ptr::null_mut(),
+                        size,
+                        libc::PROT_READ | libc::PROT_WRITE | libc::PROT_EXEC,
+                        libc::MAP_PRIVATE,
+                        file.as_raw_fd(),
+                        0,
+                    )
+                };
+                if mapped_mem == libc::MAP_FAILED {
+                    log_then_return!("mmap error: {:?}", std::io::Error::last_os_error());
+                }
+
+                let sandbox = UninitializedSandbox::new(GuestBinary::FilePath(filename), None)
+                    .inspect_err(|_| unsafe {
+                        libc::munmap(mapped_mem, size);
+                    })?;
+                let (mem_mgr, _) = sandbox.mgr.build()?;
+
+                Ok(Self {
+                    mem_mgr,
+                    mmap_region: MemoryRegion {
+                        host_region: mapped_mem as usize..mapped_mem.wrapping_add(size) as usize,
+                        guest_region: BASE_VIRT..BASE_VIRT + size,
+                        flags: MemoryRegionFlags::READ | MemoryRegionFlags::EXECUTE,
+                        region_type: MemoryRegionType::Heap,
+                    },
+                })
+            }
+
+            fn access(&self) -> DebugMemoryView<'_> {
+                DebugMemoryView::new(&self.mem_mgr, vec![self.mmap_region.clone()])
+            }
+
+            unsafe fn mmap_slice(&mut self) -> &mut [u8] {
+                unsafe {
+                    std::slice::from_raw_parts_mut(
+                        self.mmap_region.host_region.start as *mut u8,
+                        self.mmap_region.host_region.len(),
+                    )
+                }
             }
         }
 
-        /// Drops the mapped memory region
-        fn drop_mem_access(mem_access: DebugMemoryAccess) {
-            let mapped_mem =
-                mem_access.guest_mmap_regions[0].host_region.start as *mut libc::c_void;
-            let size = mem_access.guest_mmap_regions[0].host_region.end
-                - mem_access.guest_mmap_regions[0].host_region.start;
-
-            unsafe {
-                libc::munmap(mapped_mem, size);
+        impl Drop for TestMemory {
+            fn drop(&mut self) {
+                unsafe {
+                    libc::munmap(
+                        self.mmap_region.host_region.start as *mut libc::c_void,
+                        self.mmap_region.host_region.len(),
+                    );
+                }
             }
         }
 
         #[test]
         fn test_mem_access_read_single_byte() -> crate::Result<()> {
-            let mut mem_access = get_mem_access()?;
+            let mut memory = TestMemory::new()?;
             let offset = 2000;
 
             // Modify the memory directly to have a known value to read
             {
-                let slice = unsafe { get_mmap_slice(&mut mem_access) };
+                let slice = unsafe { memory.mmap_slice() };
                 slice[offset] = 0xAA;
             }
 
             let mut read_data = [0u8; 1];
-            mem_access
+            memory
+                .access()
                 .read(&mut read_data, (BASE_VIRT + offset) as u64)
                 .unwrap();
 
             assert_eq!(read_data[0], 0xAA);
-
-            drop_mem_access(mem_access);
 
             Ok(())
         }
 
         #[test]
         fn test_mem_access_read_multiple_bytes() -> crate::Result<()> {
-            let mut mem_access = get_mem_access()?;
+            let mut memory = TestMemory::new()?;
             let offset = 20;
 
             // Modify the memory directly to have a known value to read
             {
-                let slice = unsafe { get_mmap_slice(&mut mem_access) };
+                let slice = unsafe { memory.mmap_slice() };
                 for i in 0..16 {
                     slice[offset + i] = i as u8;
                 }
             }
 
             let mut read_data = [0u8; 16];
-            mem_access
+            memory
+                .access()
                 .read(&mut read_data, (BASE_VIRT + offset) as u64)
                 .unwrap();
 
@@ -505,50 +506,49 @@ mod tests {
                 read_data,
                 [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
             );
-            drop_mem_access(mem_access);
             Ok(())
         }
 
         #[test]
         fn test_mem_access_write_single_byte() -> crate::Result<()> {
-            let mut mem_access = get_mem_access()?;
+            let mut memory = TestMemory::new()?;
             let offset = 3000;
             {
-                let slice = unsafe { get_mmap_slice(&mut mem_access) };
+                let slice = unsafe { memory.mmap_slice() };
                 slice[offset] = 0xBB;
             }
 
             let write_data = [0xCCu8; 1];
-            mem_access
+            memory
+                .access()
                 .write(&write_data, (BASE_VIRT + offset) as u64)
                 .unwrap();
 
-            let slice = unsafe { get_mmap_slice(&mut mem_access) };
+            let slice = unsafe { memory.mmap_slice() };
             assert_eq!(slice[offset], write_data[0]);
-            drop_mem_access(mem_access);
 
             Ok(())
         }
 
         #[test]
         fn test_mem_access_write_multiple_bytes() -> crate::Result<()> {
-            let mut mem_access = get_mem_access()?;
+            let mut memory = TestMemory::new()?;
             let offset = 56;
             {
-                let slice = unsafe { get_mmap_slice(&mut mem_access) };
+                let slice = unsafe { memory.mmap_slice() };
                 for i in 0..16 {
                     slice[offset + i] = i as u8;
                 }
             }
 
             let write_data = [0xAAu8; 16];
-            mem_access
+            memory
+                .access()
                 .write(&write_data, (BASE_VIRT + offset) as u64)
                 .unwrap();
 
-            let slice = unsafe { get_mmap_slice(&mut mem_access) };
+            let slice = unsafe { memory.mmap_slice() };
             assert_eq!(slice[offset..offset + 16], write_data);
-            drop_mem_access(mem_access);
 
             Ok(())
         }

--- a/src/hyperlight_host/src/hypervisor/hyperlight_vm/aarch64.rs
+++ b/src/hyperlight_host/src/hypervisor/hyperlight_vm/aarch64.rs
@@ -115,9 +115,6 @@ impl HyperlightVm {
         mem_mgr: &mut SandboxMemoryManager<HostSharedMemory>,
         host_funcs: &Arc<std::sync::Mutex<FunctionRegistry>>,
         guest_max_log_level: Option<tracing_core::LevelFilter>,
-        #[cfg(gdb)] dbg_mem_access_fn: Arc<
-            std::sync::Mutex<SandboxMemoryManager<HostSharedMemory>>,
-        >,
     ) -> Result<(), InitializeError> {
         let NextAction::Initialise(initialise) = self.next_action else {
             return Ok(());
@@ -136,13 +133,8 @@ impl HyperlightVm {
         };
         self.vm.set_regs(&regs)?;
 
-        self.run(
-            mem_mgr,
-            host_funcs,
-            #[cfg(gdb)]
-            dbg_mem_access_fn,
-        )
-        .map_err(InitializeError::Run)?;
+        self.run(mem_mgr, host_funcs)
+            .map_err(InitializeError::Run)?;
 
         let regs = self.vm.regs()?;
         if !regs.sp.is_multiple_of(16) {
@@ -158,9 +150,6 @@ impl HyperlightVm {
         &mut self,
         mem_mgr: &mut SandboxMemoryManager<HostSharedMemory>,
         host_funcs: &Arc<std::sync::Mutex<FunctionRegistry>>,
-        #[cfg(gdb)] dbg_mem_access_fn: Arc<
-            std::sync::Mutex<SandboxMemoryManager<HostSharedMemory>>,
-        >,
     ) -> Result<(), DispatchGuestCallError> {
         let NextAction::Call(dispatch_func_addr) = self.next_action else {
             return Err(DispatchGuestCallError::Uninitialized);
@@ -182,12 +171,7 @@ impl HyperlightVm {
             .set_fpu(&CommonFpu::default())
             .map_err(DispatchGuestCallError::SetupRegs)?;
         let result = self
-            .run(
-                mem_mgr,
-                host_funcs,
-                #[cfg(gdb)]
-                dbg_mem_access_fn,
-            )
+            .run(mem_mgr, host_funcs)
             .map_err(DispatchGuestCallError::Run);
         self.pending_tlb_flush = false;
         result

--- a/src/hyperlight_host/src/hypervisor/hyperlight_vm/mod.rs
+++ b/src/hyperlight_host/src/hypervisor/hyperlight_vm/mod.rs
@@ -598,7 +598,6 @@ impl HyperlightVm {
         &mut self,
         mem_mgr: &mut SandboxMemoryManager<HostSharedMemory>,
         host_funcs: &Arc<Mutex<FunctionRegistry>>,
-        #[cfg(gdb)] dbg_mem_access_fn: Arc<Mutex<SandboxMemoryManager<HostSharedMemory>>>,
     ) -> std::result::Result<(), RunVmError> {
         // Keeps the trace context and open spans
         #[cfg(feature = "trace_guest")]
@@ -694,7 +693,7 @@ impl HyperlightVm {
                             self.one_shot_entry_bp = None;
                         }
                     }
-                    if let Err(e) = self.handle_debug(dbg_mem_access_fn.clone(), stop_reason) {
+                    if let Err(e) = self.handle_debug(mem_mgr, stop_reason) {
                         break Err(e.into());
                     }
                 }
@@ -759,9 +758,7 @@ impl HyperlightVm {
                     #[cfg(gdb)]
                     {
                         self.interrupt_handle.clear_debug_interrupt();
-                        if let Err(e) =
-                            self.handle_debug(dbg_mem_access_fn.clone(), VcpuStopReason::Interrupt)
-                        {
+                        if let Err(e) = self.handle_debug(mem_mgr, VcpuStopReason::Interrupt) {
                             break Err(e.into());
                         }
                     }
@@ -796,7 +793,7 @@ impl HyperlightVm {
                 // Disregard return value as we want to return the error
                 #[cfg(gdb)]
                 if self.gdb_conn.is_some() {
-                    self.handle_debug(dbg_mem_access_fn.clone(), VcpuStopReason::Crash)?
+                    self.handle_debug(mem_mgr, VcpuStopReason::Crash)?
                 }
                 Err(e)
             }

--- a/src/hyperlight_host/src/hypervisor/hyperlight_vm/x86_64.rs
+++ b/src/hyperlight_host/src/hypervisor/hyperlight_vm/x86_64.rs
@@ -221,7 +221,6 @@ impl HyperlightVm {
         mem_mgr: &mut SandboxMemoryManager<HostSharedMemory>,
         host_funcs: &Arc<Mutex<FunctionRegistry>>,
         guest_max_log_level: Option<LevelFilter>,
-        #[cfg(gdb)] dbg_mem_access_fn: Arc<Mutex<SandboxMemoryManager<HostSharedMemory>>>,
     ) -> std::result::Result<(), InitializeError> {
         let NextAction::Initialise(initialise) = self.next_action else {
             return Ok(());
@@ -248,13 +247,8 @@ impl HyperlightVm {
         };
         self.vm.set_regs(&regs)?;
 
-        self.run(
-            mem_mgr,
-            host_funcs,
-            #[cfg(gdb)]
-            dbg_mem_access_fn,
-        )
-        .map_err(InitializeError::Run)?;
+        self.run(mem_mgr, host_funcs)
+            .map_err(InitializeError::Run)?;
 
         let regs = self.vm.regs()?;
         // todo(portability): this is architecture-specific
@@ -317,7 +311,6 @@ impl HyperlightVm {
         &mut self,
         mem_mgr: &mut SandboxMemoryManager<HostSharedMemory>,
         host_funcs: &Arc<Mutex<FunctionRegistry>>,
-        #[cfg(gdb)] dbg_mem_access_fn: Arc<Mutex<SandboxMemoryManager<HostSharedMemory>>>,
     ) -> std::result::Result<(), DispatchGuestCallError> {
         let NextAction::Call(dispatch_func_addr) = self.next_action else {
             return Err(DispatchGuestCallError::Uninitialized);
@@ -352,12 +345,7 @@ impl HyperlightVm {
             .map_err(DispatchGuestCallError::SetupRegs)?;
 
         let result = self
-            .run(
-                mem_mgr,
-                host_funcs,
-                #[cfg(gdb)]
-                dbg_mem_access_fn,
-            )
+            .run(mem_mgr, host_funcs)
             .map_err(DispatchGuestCallError::Run);
 
         // Clear the TLB flush flag only after run() returns. The guest
@@ -418,24 +406,19 @@ impl HyperlightVm {
     #[cfg(gdb)]
     pub(super) fn handle_debug(
         &mut self,
-        dbg_mem_access_fn: Arc<Mutex<SandboxMemoryManager<HostSharedMemory>>>,
+        mem_mgr: &SandboxMemoryManager<HostSharedMemory>,
         stop_reason: VcpuStopReason,
     ) -> std::result::Result<(), HandleDebugError> {
         use debug::ProcessDebugRequestError;
 
-        use crate::hypervisor::gdb::DebugMemoryAccess;
+        use crate::hypervisor::gdb::DebugMemoryView;
 
         if self.gdb_conn.is_none() {
             return Err(HandleDebugError::DebugNotEnabled);
         }
 
-        let mem_access = DebugMemoryAccess {
-            // TODO: dbg_mem_access_fn could be out of sync with the
-            // actual snapshot/scratch regions, if a snapshot restore
-            // has caused either of those to change.
-            dbg_mem_access_fn,
-            guest_mmap_regions: self.get_mapped_regions().cloned().collect(),
-        };
+        let mem_access =
+            DebugMemoryView::new(mem_mgr, self.get_mapped_regions().cloned().collect());
 
         match stop_reason {
             // If the vCPU stopped because of a crash, we need to handle it differently
@@ -650,7 +633,7 @@ pub(super) mod debug {
     use super::HyperlightVm;
     use crate::hypervisor::gdb::arch::{SW_BP, SW_BP_SIZE};
     use crate::hypervisor::gdb::{
-        DebugError, DebugMemoryAccess, DebugMemoryAccessError, DebugMsg, DebugResponse,
+        DebugError, DebugMemoryAccessError, DebugMemoryView, DebugMsg, DebugResponse,
     };
     use crate::hypervisor::virtual_machine::VmError;
 
@@ -659,8 +642,6 @@ pub(super) mod debug {
     pub enum ProcessDebugRequestError {
         #[error("Debug is not enabled")]
         DebugNotEnabled,
-        #[error("Failed to acquire lock at {0}:{1}")]
-        TryLockError(&'static str, u32),
         #[error("VM operation error: {0}")]
         Vm(#[from] VmError),
         #[error("Debug operation error: {0}")]
@@ -677,7 +658,7 @@ pub(super) mod debug {
         pub(crate) fn process_dbg_request(
             &mut self,
             req: DebugMsg,
-            mem_access: &DebugMemoryAccess,
+            mem_access: &DebugMemoryView<'_>,
         ) -> std::result::Result<DebugResponse, ProcessDebugRequestError> {
             if self.gdb_conn.is_some() {
                 match req {
@@ -717,16 +698,9 @@ pub(super) mod debug {
 
                         Ok(DebugResponse::DisableDebug)
                     }
-                    DebugMsg::GetCodeSectionOffset => {
-                        let offset = mem_access
-                            .dbg_mem_access_fn
-                            .try_lock()
-                            .map_err(|_| ProcessDebugRequestError::TryLockError(file!(), line!()))?
-                            .layout
-                            .get_guest_code_address();
-
-                        Ok(DebugResponse::GetCodeSectionOffset(offset as u64))
-                    }
+                    DebugMsg::GetCodeSectionOffset => Ok(DebugResponse::GetCodeSectionOffset(
+                        mem_access.code_section_offset(),
+                    )),
                     DebugMsg::ReadAddr(addr, len) => {
                         let mut data = vec![0u8; len];
 
@@ -826,7 +800,7 @@ pub(super) mod debug {
             &mut self,
             mut gva: u64,
             mut data: &mut [u8],
-            mem_access: &DebugMemoryAccess,
+            mem_access: &DebugMemoryView<'_>,
         ) -> std::result::Result<(), ProcessDebugRequestError> {
             let data_len = data.len();
             tracing::debug!("Read addr: {:X} len: {:X}", gva, data_len);
@@ -854,7 +828,7 @@ pub(super) mod debug {
             &mut self,
             mut gva: u64,
             mut data: &[u8],
-            mem_access: &DebugMemoryAccess,
+            mem_access: &DebugMemoryView<'_>,
         ) -> std::result::Result<(), ProcessDebugRequestError> {
             let data_len = data.len();
             tracing::debug!("Write addr: {:X} len: {:X}", gva, data_len);
@@ -883,7 +857,7 @@ pub(super) mod debug {
         fn add_sw_breakpoint(
             &mut self,
             gva: u64,
-            mem_access: &DebugMemoryAccess,
+            mem_access: &DebugMemoryView<'_>,
         ) -> std::result::Result<(), ProcessDebugRequestError> {
             // Check if breakpoint already exists
             if self.sw_breakpoints.contains_key(&gva) {
@@ -904,7 +878,7 @@ pub(super) mod debug {
         fn remove_sw_breakpoint(
             &mut self,
             gva: u64,
-            mem_access: &DebugMemoryAccess,
+            mem_access: &DebugMemoryView<'_>,
         ) -> std::result::Result<(), ProcessDebugRequestError> {
             if let Some(saved_data) = self.sw_breakpoints.remove(&gva) {
                 // Restore saved data to the guest's memory
@@ -948,8 +922,6 @@ mod tests {
         vm: HyperlightVm,
         hshm: SandboxMemoryManager<HostSharedMemory>,
         host_funcs: Arc<Mutex<FunctionRegistry>>,
-        #[cfg(gdb)]
-        dbg_mem_access_hdl: Arc<Mutex<SandboxMemoryManager<HostSharedMemory>>>,
     }
 
     // ==========================================================================
@@ -1574,28 +1546,15 @@ mod tests {
         let seed = rand::rng().random::<u64>();
         let peb_addr = RawPtr::from(u64::try_from(peb_address).unwrap());
 
-        #[cfg(gdb)]
-        let dbg_mem_access_hdl = Arc::new(Mutex::new(hshm.clone()));
-
         let host_funcs = Arc::new(Mutex::new(FunctionRegistry::default()));
 
-        vm.initialise(
-            peb_addr,
-            seed,
-            &mut hshm,
-            &host_funcs,
-            None,
-            #[cfg(gdb)]
-            dbg_mem_access_hdl.clone(),
-        )
-        .unwrap();
+        vm.initialise(peb_addr, seed, &mut hshm, &host_funcs, None)
+            .unwrap();
 
         TestVmContext {
             vm,
             hshm,
             host_funcs,
-            #[cfg(gdb)]
-            dbg_mem_access_hdl,
         }
     }
 
@@ -2184,12 +2143,7 @@ mod tests {
             fn run(&mut self) {
                 self.ctx
                     .vm
-                    .run(
-                        &mut self.ctx.hshm,
-                        &self.ctx.host_funcs,
-                        #[cfg(gdb)]
-                        self.ctx.dbg_mem_access_hdl.clone(),
-                    )
+                    .run(&mut self.ctx.hshm, &self.ctx.host_funcs)
                     .unwrap();
             }
 

--- a/src/hyperlight_host/src/hypervisor/mod.rs
+++ b/src/hyperlight_host/src/hypervisor/mod.rs
@@ -506,9 +506,6 @@ pub(crate) mod tests {
         let host_funcs = Arc::new(Mutex::new(FunctionRegistry::default()));
         let guest_max_log_level = Some(tracing_core::LevelFilter::ERROR);
 
-        #[cfg(gdb)]
-        let dbg_mem_access_fn = Arc::new(Mutex::new(mem_mgr.clone()));
-
         // Test the initialise method
         vm.initialise(
             peb_addr,
@@ -516,8 +513,6 @@ pub(crate) mod tests {
             &mut mem_mgr,
             &host_funcs,
             guest_max_log_level,
-            #[cfg(gdb)]
-            dbg_mem_access_fn,
         )
         .unwrap();
 

--- a/src/hyperlight_host/src/mem/mgr.rs
+++ b/src/hyperlight_host/src/mem/mgr.rs
@@ -132,7 +132,6 @@ impl ReadonlySharedMemory {
 pub(crate) use unused_hack::SnapshotSharedMemory;
 /// A struct that is responsible for laying out and managing the memory
 /// for a given `Sandbox`.
-#[derive(Clone)]
 pub(crate) struct SandboxMemoryManager<S: SharedMemory> {
     /// Shared memory for the Sandbox
     pub(crate) shared_mem: SnapshotSharedMemory<S>,

--- a/src/hyperlight_host/src/sandbox/initialized_multi_use.rs
+++ b/src/hyperlight_host/src/sandbox/initialized_multi_use.rs
@@ -86,8 +86,6 @@ pub struct MultiUseSandbox {
     pub(crate) host_funcs: Arc<Mutex<FunctionRegistry>>,
     pub(crate) mem_mgr: SandboxMemoryManager<HostSharedMemory>,
     vm: HyperlightVm,
-    #[cfg(gdb)]
-    dbg_mem_access_fn: Arc<Mutex<SandboxMemoryManager<HostSharedMemory>>>,
     /// If the current state of the sandbox has been captured in a snapshot,
     /// that snapshot is stored here.
     pub(crate) snapshot: Option<Arc<Snapshot>>,
@@ -120,15 +118,12 @@ impl MultiUseSandbox {
         host_funcs: Arc<Mutex<FunctionRegistry>>,
         mgr: SandboxMemoryManager<HostSharedMemory>,
         vm: HyperlightVm,
-        #[cfg(gdb)] dbg_mem_access_fn: Arc<Mutex<SandboxMemoryManager<HostSharedMemory>>>,
     ) -> MultiUseSandbox {
         Self {
             poisoned: false,
             host_funcs,
             mem_mgr: mgr,
             vm,
-            #[cfg(gdb)]
-            dbg_mem_access_fn,
             snapshot: None,
             pt_root_finder: None,
         }
@@ -281,20 +276,9 @@ impl MultiUseSandbox {
         };
         let peb_addr = RawPtr::from(u64::try_from(hshm.layout.peb_address())?);
 
-        #[cfg(gdb)]
-        let dbg_mem_access_hdl = Arc::new(Mutex::new(hshm.clone()));
-
         // noop for NextAction::Call
-        vm.initialise(
-            peb_addr,
-            seed,
-            &mut hshm,
-            &host_funcs,
-            None,
-            #[cfg(gdb)]
-            dbg_mem_access_hdl,
-        )
-        .map_err(crate::hypervisor::hyperlight_vm::HyperlightVmError::Initialize)?;
+        vm.initialise(peb_addr, seed, &mut hshm, &host_funcs, None)
+            .map_err(crate::hypervisor::hyperlight_vm::HyperlightVmError::Initialize)?;
 
         // If the snapshot was taken from an already-initialized guest
         // (NextAction::Call), apply the captured special registers so
@@ -319,16 +303,7 @@ impl MultiUseSandbox {
             })?;
         }
 
-        #[cfg(gdb)]
-        let dbg_mem_wrapper = Arc::new(Mutex::new(hshm.clone()));
-
-        let sbox = MultiUseSandbox::from_uninit(
-            host_funcs,
-            hshm,
-            vm,
-            #[cfg(gdb)]
-            dbg_mem_wrapper,
-        );
+        let sbox = MultiUseSandbox::from_uninit(host_funcs, hshm, vm);
         Ok(sbox)
     }
 
@@ -921,12 +896,9 @@ impl MultiUseSandbox {
 
             self.mem_mgr.write_guest_function_call(buffer)?;
 
-            let dispatch_res = self.vm.dispatch_call_from_host(
-                &mut self.mem_mgr,
-                &self.host_funcs,
-                #[cfg(gdb)]
-                self.dbg_mem_access_fn.clone(),
-            );
+            let dispatch_res = self
+                .vm
+                .dispatch_call_from_host(&mut self.mem_mgr, &self.host_funcs);
 
             // Convert dispatch errors to HyperlightErrors to maintain backwards compatibility
             // but first determine if sandbox should be poisoned

--- a/src/hyperlight_host/src/sandbox/uninitialized_evolve.rs
+++ b/src/hyperlight_host/src/sandbox/uninitialized_evolve.rs
@@ -13,9 +13,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-#[cfg(gdb)]
-use std::sync::{Arc, Mutex};
-
 use rand::RngExt;
 use tracing::{Span, instrument};
 
@@ -63,9 +60,6 @@ pub(super) fn evolve_impl_multi_use(u_sbox: UninitializedSandbox) -> Result<Mult
         RawPtr::from(peb_u64)
     };
 
-    #[cfg(gdb)]
-    let dbg_mem_access_hdl = Arc::new(Mutex::new(hshm.clone()));
-
     #[cfg(target_os = "linux")]
     setup_signal_handlers(&u_sbox.config)?;
 
@@ -101,21 +95,10 @@ pub(super) fn evolve_impl_multi_use(u_sbox: UninitializedSandbox) -> Result<Mult
         &mut hshm,
         &u_sbox.host_funcs,
         u_sbox.max_guest_log_level,
-        #[cfg(gdb)]
-        dbg_mem_access_hdl,
     )
     .map_err(HyperlightVmError::Initialize)?;
 
-    #[cfg(gdb)]
-    let dbg_mem_wrapper = Arc::new(Mutex::new(hshm.clone()));
-
-    Ok(MultiUseSandbox::from_uninit(
-        u_sbox.host_funcs,
-        hshm,
-        vm,
-        #[cfg(gdb)]
-        dbg_mem_wrapper,
-    ))
+    Ok(MultiUseSandbox::from_uninit(u_sbox.host_funcs, hshm, vm))
 }
 
 pub(crate) fn set_up_hypervisor_partition(


### PR DESCRIPTION
Noticed this ugly code when reviewing another PR and thought it could be cleaned up. MemoryManager already contains everything needed for gdb so no need to clone it as we can borrow it instead. Also fixes potential stale memory access since snapshot restore can replace snapshot and scratch memory, and the cloned manager could potentially be out of sync. Also removed some now unnecessary synchronization and plumbing