### PR TITLE
Use short-form license pragmas

### DIFF
--- a/dev/check-license-headers.sh
+++ b/dev/check-license-headers.sh
@@ -5,27 +5,15 @@
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd "$REPO_ROOT" || exit 1
 
-# Define the license header pattern to look for
-LICENSE_PATTERN="Copyright .* The Hyperlight Authors..*Licensed under the Apache License, Version 2.0"
+# Define the license patterns to look for
+SPDX_PATTERN="^// SPDX-License-Identifier: Apache-2\.0$"
+COPYRIGHT_PATTERN="^// Copyright .* The Hyperlight Authors\.$"
 
 # Define the full license header for files that need it
-LICENSE_HEADER='/*
-Copyright 2025 The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
-'
+YEAR="$(date +"%Y")"
+LICENSE_HEADER="// SPDX-License-Identifier: Apache-2.0
+// Copyright $YEAR The Hyperlight Authors.
+"
 
 # Initialize a variable to track missing headers
 MISSING_HEADERS=0
@@ -43,8 +31,8 @@ while IFS= read -r -d $'\0' file; do
         continue
     fi
 
-    # Check if the file has the license header (allowing for multi-line matching)
-    if ! grep -q -z "$LICENSE_PATTERN" "$file"; then
+    header="$(head -2 "$file")"
+    if ! grep -q "$SPDX_PATTERN" <<< "$header" || ! grep -q "$COPYRIGHT_PATTERN" <<< "$header"; then
         echo "Missing or invalid license header in $file"
         MISSING_FILES="$MISSING_FILES\n  $file"
         MISSING_HEADERS=$((MISSING_HEADERS + 1))

--- a/fuzz/fuzz_targets/guest_call.rs
+++ b/fuzz/fuzz_targets/guest_call.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 #![no_main]
 

--- a/fuzz/fuzz_targets/guest_estimate_trace_event.rs
+++ b/fuzz/fuzz_targets/guest_estimate_trace_event.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 #![no_main]
 
 #[cfg(not(feature = "trace"))]

--- a/fuzz/fuzz_targets/guest_trace.rs
+++ b/fuzz/fuzz_targets/guest_trace.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 #![no_main]
 

--- a/fuzz/fuzz_targets/host_call.rs
+++ b/fuzz/fuzz_targets/host_call.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 #![no_main]
 

--- a/fuzz/fuzz_targets/virtq_packed_ring.rs
+++ b/fuzz/fuzz_targets/virtq_packed_ring.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2026  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The Hyperlight Authors.
 
 #![no_main]
 

--- a/src/hyperlight_common/benches/buffer_pool.rs
+++ b/src/hyperlight_common/benches/buffer_pool.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2026  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The Hyperlight Authors.
 
 use std::hint::black_box;
 

--- a/src/hyperlight_common/benches/common/mod.rs
+++ b/src/hyperlight_common/benches/common/mod.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2026  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The Hyperlight Authors.
 
 //! Shared harness for the `virtq_api` benchmarks: an in-memory [`MemOps`]
 //! backend, a counting [`Notifier`], producer/consumer pair construction, pool

--- a/src/hyperlight_common/benches/virtq_api.rs
+++ b/src/hyperlight_common/benches/virtq_api.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2026  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The Hyperlight Authors.
 
 use std::hint::black_box;
 

--- a/src/hyperlight_common/src/arch/aarch64/exn.rs
+++ b/src/hyperlight_common/src/arch/aarch64/exn.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2026 The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The Hyperlight Authors.
 
 use crate::vmem::bits;
 

--- a/src/hyperlight_common/src/arch/aarch64/layout.rs
+++ b/src/hyperlight_common/src/arch/aarch64/layout.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 // TODO: consider using the upper half, like we do on x86;
 // this would require enabling ttbr1

--- a/src/hyperlight_common/src/arch/aarch64/vmem.rs
+++ b/src/hyperlight_common/src/arch/aarch64/vmem.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 use alloc::collections::BTreeMap;
 use alloc::collections::btree_map::Entry;

--- a/src/hyperlight_common/src/arch/amd64/layout.rs
+++ b/src/hyperlight_common/src/arch/amd64/layout.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 // The addresses in this file should be coordinated with
 // src/hyperlight_guest/src/arch/amd64/layout.rs and

--- a/src/hyperlight_common/src/arch/amd64/vmem.rs
+++ b/src/hyperlight_common/src/arch/amd64/vmem.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 //! x86-64 4-level page table manipulation code.
 //!

--- a/src/hyperlight_common/src/component.rs
+++ b/src/hyperlight_common/src/component.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2026 The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The Hyperlight Authors.
 
 //! Support types for the bindings that `host_bindgen!` generates.
 

--- a/src/hyperlight_common/src/flatbuffer_wrappers/function_call.rs
+++ b/src/hyperlight_common/src/flatbuffer_wrappers/function_call.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 use alloc::string::{String, ToString};
 use alloc::vec::Vec;

--- a/src/hyperlight_common/src/flatbuffer_wrappers/function_types.rs
+++ b/src/hyperlight_common/src/flatbuffer_wrappers/function_types.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 use alloc::string::{String, ToString};
 use alloc::vec::Vec;

--- a/src/hyperlight_common/src/flatbuffer_wrappers/guest_error.rs
+++ b/src/hyperlight_common/src/flatbuffer_wrappers/guest_error.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 extern crate flatbuffers;
 

--- a/src/hyperlight_common/src/flatbuffer_wrappers/guest_log_data.rs
+++ b/src/hyperlight_common/src/flatbuffer_wrappers/guest_log_data.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 use alloc::string::{String, ToString};
 use alloc::vec::Vec;

--- a/src/hyperlight_common/src/flatbuffer_wrappers/guest_log_level.rs
+++ b/src/hyperlight_common/src/flatbuffer_wrappers/guest_log_level.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 use anyhow::{Error, Result, bail};
 use log::Level;

--- a/src/hyperlight_common/src/flatbuffer_wrappers/guest_trace_data.rs
+++ b/src/hyperlight_common/src/flatbuffer_wrappers/guest_trace_data.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 //! Guest trace data structures and (de)serialization logic.
 //! This module defines the data structures used for tracing spans and events

--- a/src/hyperlight_common/src/flatbuffer_wrappers/host_function_definition.rs
+++ b/src/hyperlight_common/src/flatbuffer_wrappers/host_function_definition.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025 The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 use alloc::string::{String, ToString};
 use alloc::vec::Vec;

--- a/src/hyperlight_common/src/flatbuffer_wrappers/host_function_details.rs
+++ b/src/hyperlight_common/src/flatbuffer_wrappers/host_function_details.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025 The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 use alloc::vec::Vec;
 

--- a/src/hyperlight_common/src/flatbuffer_wrappers/mod.rs
+++ b/src/hyperlight_common/src/flatbuffer_wrappers/mod.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 pub mod function_call;
 pub mod function_types;

--- a/src/hyperlight_common/src/flatbuffer_wrappers/util.rs
+++ b/src/hyperlight_common/src/flatbuffer_wrappers/util.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 use alloc::vec::Vec;
 

--- a/src/hyperlight_common/src/func/error.rs
+++ b/src/hyperlight_common/src/func/error.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025 The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 use alloc::string::String;
 

--- a/src/hyperlight_common/src/func/functions.rs
+++ b/src/hyperlight_common/src/func/functions.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 use super::utils::for_each_tuple;
 use super::{Error, ParameterTuple, ResultType, SupportedReturnType};

--- a/src/hyperlight_common/src/func/mod.rs
+++ b/src/hyperlight_common/src/func/mod.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 /// Error types related to function support
 pub(crate) mod error;

--- a/src/hyperlight_common/src/func/param_type.rs
+++ b/src/hyperlight_common/src/func/param_type.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 use alloc::string::String;
 use alloc::vec;

--- a/src/hyperlight_common/src/func/ret_type.rs
+++ b/src/hyperlight_common/src/func/ret_type.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 use alloc::string::String;
 use alloc::vec::Vec;

--- a/src/hyperlight_common/src/func/utils.rs
+++ b/src/hyperlight_common/src/func/utils.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025 The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 /// An utility macro to execute a macro for each tuple of parameters
 /// up to 32 parameters. This is useful to implement traits on functions

--- a/src/hyperlight_common/src/layout.rs
+++ b/src/hyperlight_common/src/layout.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 #[cfg_attr(target_arch = "x86_64", path = "arch/amd64/layout.rs")]
 #[cfg_attr(target_arch = "aarch64", path = "arch/aarch64/layout.rs")]

--- a/src/hyperlight_common/src/lib.rs
+++ b/src/hyperlight_common/src/lib.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 #![cfg_attr(not(any(test, debug_assertions)), warn(clippy::panic))]
 #![cfg_attr(not(any(test, debug_assertions)), warn(clippy::expect_used))]

--- a/src/hyperlight_common/src/log_level.rs
+++ b/src/hyperlight_common/src/log_level.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 /// This type is a unified definition of log level filters between the guest and host.
 ///

--- a/src/hyperlight_common/src/mem.rs
+++ b/src/hyperlight_common/src/mem.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 /// A memory region in the guest address space
 #[derive(Debug, Clone, Copy, PartialEq, bytemuck::Pod, bytemuck::Zeroable)]

--- a/src/hyperlight_common/src/outb.rs
+++ b/src/hyperlight_common/src/outb.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025 The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 use core::convert::TryFrom;
 

--- a/src/hyperlight_common/src/resource.rs
+++ b/src/hyperlight_common/src/resource.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025 The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 //! Shared operations around resources
 

--- a/src/hyperlight_common/src/version_note.rs
+++ b/src/hyperlight_common/src/version_note.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 //! ELF note types for embedding hyperlight version metadata in guest binaries.
 //!

--- a/src/hyperlight_common/src/virtq/access.rs
+++ b/src/hyperlight_common/src/virtq/access.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2026  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The Hyperlight Authors.
 
 //! Memory Access Traits for Virtqueue Operations
 //!

--- a/src/hyperlight_common/src/virtq/buffer.rs
+++ b/src/hyperlight_common/src/virtq/buffer.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2026  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The Hyperlight Authors.
 
 //! Buffer allocation traits and shared types for virtqueue buffer management.
 

--- a/src/hyperlight_common/src/virtq/concurrency.rs
+++ b/src/hyperlight_common/src/virtq/concurrency.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2026  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The Hyperlight Authors.
 
 //! Loom-based concurrency testing for the virtqueue implementation.
 //!

--- a/src/hyperlight_common/src/virtq/consumer.rs
+++ b/src/hyperlight_common/src/virtq/consumer.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2026  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The Hyperlight Authors.
 
 use alloc::vec;
 

--- a/src/hyperlight_common/src/virtq/desc.rs
+++ b/src/hyperlight_common/src/virtq/desc.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2026  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The Hyperlight Authors.
 
 //! Virtqueue Descriptor Types
 //!

--- a/src/hyperlight_common/src/virtq/event.rs
+++ b/src/hyperlight_common/src/virtq/event.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2026  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The Hyperlight Authors.
 
 //! Event Suppression for Virtqueue Notifications
 //!

--- a/src/hyperlight_common/src/virtq/mod.rs
+++ b/src/hyperlight_common/src/virtq/mod.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2026  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The Hyperlight Authors.
 
 //! Packed Virtqueue Implementation
 //!

--- a/src/hyperlight_common/src/virtq/msg.rs
+++ b/src/hyperlight_common/src/virtq/msg.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2026  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The Hyperlight Authors.
 
 //! Wire format header for all virtqueue messages.
 //!

--- a/src/hyperlight_common/src/virtq/pool.rs
+++ b/src/hyperlight_common/src/virtq/pool.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2026  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The Hyperlight Authors.
 //! Buffer pool implementations for virtqueue buffer management.
 //!
 //! This module provides concrete buffer allocators:

--- a/src/hyperlight_common/src/virtq/producer.rs
+++ b/src/hyperlight_common/src/virtq/producer.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2026  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The Hyperlight Authors.
 
 use alloc::collections::VecDeque;
 use alloc::vec::Vec;

--- a/src/hyperlight_common/src/virtq/ring.rs
+++ b/src/hyperlight_common/src/virtq/ring.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2026  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The Hyperlight Authors.
 
 //! Packed Virtqueue Ring Implementation
 //!

--- a/src/hyperlight_common/src/vmem.rs
+++ b/src/hyperlight_common/src/vmem.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 #[cfg_attr(target_arch = "x86_64", path = "arch/amd64/vmem.rs")]
 #[cfg_attr(target_arch = "aarch64", path = "arch/aarch64/vmem.rs")]

--- a/src/hyperlight_component_macro/src/lib.rs
+++ b/src/hyperlight_component_macro/src/lib.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025 The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 //! # Component-model bindgen macros
 //!

--- a/src/hyperlight_component_util/src/component.rs
+++ b/src/hyperlight_component_util/src/component.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025 The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 //! Just enough component parsing support to get at the actual types
 

--- a/src/hyperlight_component_util/src/elaborate.rs
+++ b/src/hyperlight_component_util/src/elaborate.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025 The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 //! Component type elaboration
 //!

--- a/src/hyperlight_component_util/src/emit.rs
+++ b/src/hyperlight_component_util/src/emit.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025 The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 //! A bunch of utilities used by the actual code emit functions
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet, VecDeque};

--- a/src/hyperlight_component_util/src/etypes.rs
+++ b/src/hyperlight_component_util/src/etypes.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025 The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 /// Elaborated component model types
 ///

--- a/src/hyperlight_component_util/src/guest.rs
+++ b/src/hyperlight_component_util/src/guest.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025 The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};

--- a/src/hyperlight_component_util/src/hl.rs
+++ b/src/hyperlight_component_util/src/hl.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025 The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 use itertools::Itertools;
 use proc_macro2::{Ident, TokenStream};

--- a/src/hyperlight_component_util/src/host.rs
+++ b/src/hyperlight_component_util/src/host.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025 The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 use proc_macro2::{Ident, TokenStream};
 use quote::{ToTokens, format_ident, quote};

--- a/src/hyperlight_component_util/src/lib.rs
+++ b/src/hyperlight_component_util/src/lib.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025 The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 // This, unlike the rest of hyperlight, isn't really a library (since
 // it's only used by our own build-time tools), so the reasons not to

--- a/src/hyperlight_component_util/src/resource.rs
+++ b/src/hyperlight_component_util/src/resource.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025 The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 use proc_macro2::{Ident, TokenStream};
 use quote::{format_ident, quote};

--- a/src/hyperlight_component_util/src/rtypes.rs
+++ b/src/hyperlight_component_util/src/rtypes.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025 The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 //! The Rust representation of a component type (etype)
 

--- a/src/hyperlight_component_util/src/structure.rs
+++ b/src/hyperlight_component_util/src/structure.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025 The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 /// core:sort in the specification
 #[derive(Debug, Clone, Copy)]

--- a/src/hyperlight_component_util/src/substitute.rs
+++ b/src/hyperlight_component_util/src/substitute.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025 The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 //! Capture-avoiding substitution
 

--- a/src/hyperlight_component_util/src/subtype.rs
+++ b/src/hyperlight_component_util/src/subtype.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025 The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 use itertools::Itertools;
 

--- a/src/hyperlight_component_util/src/tv.rs
+++ b/src/hyperlight_component_util/src/tv.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025 The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 use crate::etypes::{
     BoundedTyvar, Ctx, Defined, FreeTyvar, Handleable, ImportExport, TypeBound, Tyvar,

--- a/src/hyperlight_component_util/src/util.rs
+++ b/src/hyperlight_component_util/src/util.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025 The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 //! General utilities for bindgen macros
 use crate::etypes;

--- a/src/hyperlight_component_util/src/wf.rs
+++ b/src/hyperlight_component_util/src/wf.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025 The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 //! Component type well-formedness
 //!

--- a/src/hyperlight_component_util/tests/wasmtime_guest_codegen.rs
+++ b/src/hyperlight_component_util/tests/wasmtime_guest_codegen.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2026 The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The Hyperlight Authors.
 
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};

--- a/src/hyperlight_guest/src/arch/aarch64/exit.rs
+++ b/src/hyperlight_guest/src/arch/aarch64/exit.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 // TODO(aarch64): implement VM exit mechanism (e.g. hvc instruction)
 

--- a/src/hyperlight_guest/src/arch/aarch64/layout.rs
+++ b/src/hyperlight_guest/src/arch/aarch64/layout.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 // TODO(aarch64): these values are placeholders copied from amd64
 pub const MAIN_STACK_TOP_GVA: u64 = 0x0000_ff00_0000_0000;

--- a/src/hyperlight_guest/src/arch/aarch64/prim_alloc.rs
+++ b/src/hyperlight_guest/src/arch/aarch64/prim_alloc.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 use hyperlight_common::flatbuffer_wrappers::guest_error::ErrorCode;
 use hyperlight_common::{layout, vmem};

--- a/src/hyperlight_guest/src/arch/amd64/exit.rs
+++ b/src/hyperlight_guest/src/arch/amd64/exit.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 use core::arch::asm;
 

--- a/src/hyperlight_guest/src/arch/amd64/layout.rs
+++ b/src/hyperlight_guest/src/arch/amd64/layout.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 // The addresses in this file should be coordinated with
 // src/hyperlight_common/src/arch/amd64/layout.rs and

--- a/src/hyperlight_guest/src/arch/amd64/prim_alloc.rs
+++ b/src/hyperlight_guest/src/arch/amd64/prim_alloc.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 use hyperlight_common::flatbuffer_wrappers::guest_error::ErrorCode;
 

--- a/src/hyperlight_guest/src/error.rs
+++ b/src/hyperlight_guest/src/error.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 use alloc::format;
 use alloc::string::{String, ToString as _};

--- a/src/hyperlight_guest/src/exit.rs
+++ b/src/hyperlight_guest/src/exit.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 use core::ffi::{CStr, c_char};
 

--- a/src/hyperlight_guest/src/guest_handle/handle.rs
+++ b/src/hyperlight_guest/src/guest_handle/handle.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 use hyperlight_common::mem::HyperlightPEB;
 

--- a/src/hyperlight_guest/src/guest_handle/host_comm.rs
+++ b/src/hyperlight_guest/src/guest_handle/host_comm.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 use alloc::format;
 use alloc::string::ToString;

--- a/src/hyperlight_guest/src/guest_handle/io.rs
+++ b/src/hyperlight_guest/src/guest_handle/io.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 use alloc::format;
 use alloc::string::ToString;

--- a/src/hyperlight_guest/src/layout.rs
+++ b/src/hyperlight_guest/src/layout.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 #[cfg_attr(target_arch = "x86_64", path = "arch/amd64/layout.rs")]
 #[cfg_attr(target_arch = "aarch64", path = "arch/aarch64/layout.rs")]

--- a/src/hyperlight_guest/src/lib.rs
+++ b/src/hyperlight_guest/src/lib.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 #![no_std]
 #[cfg(all(feature = "trace_guest", not(target_arch = "x86_64")))]

--- a/src/hyperlight_guest/src/prim_alloc.rs
+++ b/src/hyperlight_guest/src/prim_alloc.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 #[cfg_attr(target_arch = "x86_64", path = "arch/amd64/prim_alloc.rs")]
 #[cfg_attr(target_arch = "aarch64", path = "arch/aarch64/prim_alloc.rs")]

--- a/src/hyperlight_guest/src/types.rs
+++ b/src/hyperlight_guest/src/types.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2026  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The Hyperlight Authors.
 
 pub use hyperlight_common::flatbuffer_wrappers::function_call::FunctionCall;
 pub use hyperlight_common::flatbuffer_wrappers::function_types::{

--- a/src/hyperlight_guest_bin/src/arch/aarch64/exception/entry.rs
+++ b/src/hyperlight_guest_bin/src/arch/aarch64/exception/entry.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2026 The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The Hyperlight Authors.
 
 use core::arch::global_asm;
 use core::mem::{offset_of, size_of};

--- a/src/hyperlight_guest_bin/src/arch/aarch64/exception/handle.rs
+++ b/src/hyperlight_guest_bin/src/arch/aarch64/exception/handle.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2026 The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The Hyperlight Authors.
 use core::fmt::Write;
 
 use hyperlight_common::arch::exn::{DataFault, DataFaultKind, Exception, decode_syndrome};

--- a/src/hyperlight_guest_bin/src/arch/aarch64/exception/mod.rs
+++ b/src/hyperlight_guest_bin/src/arch/aarch64/exception/mod.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2026 The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The Hyperlight Authors.
 
 pub(super) mod entry;
 pub mod handle;

--- a/src/hyperlight_guest_bin/src/arch/aarch64/exception/types.rs
+++ b/src/hyperlight_guest_bin/src/arch/aarch64/exception/types.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2026 The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The Hyperlight Authors.
 
 use core::mem::{offset_of, size_of};
 

--- a/src/hyperlight_guest_bin/src/arch/aarch64/layout.rs
+++ b/src/hyperlight_guest_bin/src/arch/aarch64/layout.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 // The addresses in this file should be coordinated with
 // src/hyperlight_common/src/arch/aarc64/layout.rs and

--- a/src/hyperlight_guest_bin/src/arch/aarch64/mod.rs
+++ b/src/hyperlight_guest_bin/src/arch/aarch64/mod.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 // TODO(aarch64): implement aarch64 guest runtime
 

--- a/src/hyperlight_guest_bin/src/arch/aarch64/paging.rs
+++ b/src/hyperlight_guest_bin/src/arch/aarch64/paging.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 use hyperlight_common::vmem;
 use hyperlight_guest::prim_alloc::alloc_phys_pages;

--- a/src/hyperlight_guest_bin/src/arch/amd64/context.rs
+++ b/src/hyperlight_guest_bin/src/arch/amd64/context.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 use super::machine::ExceptionInfo;
 

--- a/src/hyperlight_guest_bin/src/arch/amd64/dispatch.rs
+++ b/src/hyperlight_guest_bin/src/arch/amd64/dispatch.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 //! This module contains the architecture-specific dispatch function
 //! entry sequence

--- a/src/hyperlight_guest_bin/src/arch/amd64/exception/entry.rs
+++ b/src/hyperlight_guest_bin/src/arch/amd64/exception/entry.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 // Note: this code takes reference from
 // https://github.com/nanvix/nanvix/blob/dev/src/kernel/src/hal/arch/x86/hooks.S

--- a/src/hyperlight_guest_bin/src/arch/amd64/exception/handle.rs
+++ b/src/hyperlight_guest_bin/src/arch/amd64/exception/handle.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025 The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 use core::fmt::Write;
 

--- a/src/hyperlight_guest_bin/src/arch/amd64/exception/mod.rs
+++ b/src/hyperlight_guest_bin/src/arch/amd64/exception/mod.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025 The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 pub(super) mod entry;
 pub mod handle;

--- a/src/hyperlight_guest_bin/src/arch/amd64/init.rs
+++ b/src/hyperlight_guest_bin/src/arch/amd64/init.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 use core::arch::asm;
 use core::mem;

--- a/src/hyperlight_guest_bin/src/arch/amd64/layout.rs
+++ b/src/hyperlight_guest_bin/src/arch/amd64/layout.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 // The addresses in this file should be coordinated with
 // src/hyperlight_common/src/arch/amd64/layout.rs and

--- a/src/hyperlight_guest_bin/src/arch/amd64/machine.rs
+++ b/src/hyperlight_guest_bin/src/arch/amd64/machine.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 use core::mem;
 

--- a/src/hyperlight_guest_bin/src/arch/amd64/mod.rs
+++ b/src/hyperlight_guest_bin/src/arch/amd64/mod.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025 The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 pub(crate) mod context;
 pub(crate) mod dispatch;

--- a/src/hyperlight_guest_bin/src/arch/amd64/paging.rs
+++ b/src/hyperlight_guest_bin/src/arch/amd64/paging.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 use core::arch::asm;
 

--- a/src/hyperlight_guest_bin/src/error.rs
+++ b/src/hyperlight_guest_bin/src/error.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2026  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The Hyperlight Authors.
 
 pub use hyperlight_guest::error::*;
 pub use hyperlight_guest::{bail, ensure};

--- a/src/hyperlight_guest_bin/src/exception.rs
+++ b/src/hyperlight_guest_bin/src/exception.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025 The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 pub mod arch {
     pub use crate::arch::context::Context;

--- a/src/hyperlight_guest_bin/src/guest_function/call.rs
+++ b/src/hyperlight_guest_bin/src/guest_function/call.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 use alloc::format;
 use alloc::vec::Vec;

--- a/src/hyperlight_guest_bin/src/guest_function/definition.rs
+++ b/src/hyperlight_guest_bin/src/guest_function/definition.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 use alloc::format;
 use alloc::string::String;

--- a/src/hyperlight_guest_bin/src/guest_function/register.rs
+++ b/src/hyperlight_guest_bin/src/guest_function/register.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 use alloc::collections::BTreeMap;
 use alloc::string::String;

--- a/src/hyperlight_guest_bin/src/guest_logger.rs
+++ b/src/hyperlight_guest_bin/src/guest_logger.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 use alloc::format;
 

--- a/src/hyperlight_guest_bin/src/host_comm.rs
+++ b/src/hyperlight_guest_bin/src/host_comm.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 use alloc::string::ToString;
 use alloc::vec::Vec;

--- a/src/hyperlight_guest_bin/src/init.rs
+++ b/src/hyperlight_guest_bin/src/init.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 /// To initialise the main stack, we just pre-emptively map the first
 /// page of it. We assume the architecture-specific exception handler

--- a/src/hyperlight_guest_bin/src/lib.rs
+++ b/src/hyperlight_guest_bin/src/lib.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 #![no_std]
 
 // === Dependencies ===

--- a/src/hyperlight_guest_bin/src/libc_stubs.rs
+++ b/src/hyperlight_guest_bin/src/libc_stubs.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 use alloc::string::String;
 use alloc::vec;

--- a/src/hyperlight_guest_bin/src/memory.rs
+++ b/src/hyperlight_guest_bin/src/memory.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 use core::alloc::Layout;
 use core::ffi::c_void;

--- a/src/hyperlight_guest_bin/src/paging.rs
+++ b/src/hyperlight_guest_bin/src/paging.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 #[cfg_attr(target_arch = "x86_64", path = "arch/amd64/paging.rs")]
 #[cfg_attr(target_arch = "aarch64", path = "arch/aarch64/paging.rs")]

--- a/src/hyperlight_guest_capi/build.rs
+++ b/src/hyperlight_guest_capi/build.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025 The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 use std::env;
 

--- a/src/hyperlight_guest_capi/src/dispatch.rs
+++ b/src/hyperlight_guest_capi/src/dispatch.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025 The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 use alloc::boxed::Box;
 use alloc::slice;

--- a/src/hyperlight_guest_capi/src/error.rs
+++ b/src/hyperlight_guest_capi/src/error.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025 The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 use core::ffi::{CStr, c_char};
 

--- a/src/hyperlight_guest_capi/src/flatbuffer.rs
+++ b/src/hyperlight_guest_capi/src/flatbuffer.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025 The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 use alloc::boxed::Box;
 use alloc::ffi::CString;

--- a/src/hyperlight_guest_capi/src/lib.rs
+++ b/src/hyperlight_guest_capi/src/lib.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025 The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 #![no_std]
 #![allow(non_snake_case, non_camel_case_types, non_upper_case_globals)]

--- a/src/hyperlight_guest_capi/src/logging.rs
+++ b/src/hyperlight_guest_capi/src/logging.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025 The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 use core::ffi::c_char;
 

--- a/src/hyperlight_guest_capi/src/types.rs
+++ b/src/hyperlight_guest_capi/src/types.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025 The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 mod function_call;
 pub use function_call::*;

--- a/src/hyperlight_guest_capi/src/types/function_call.rs
+++ b/src/hyperlight_guest_capi/src/types/function_call.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025 The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 use alloc::boxed::Box;
 use alloc::ffi::CString;

--- a/src/hyperlight_guest_capi/src/types/parameter.rs
+++ b/src/hyperlight_guest_capi/src/types/parameter.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025 The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 use alloc::ffi::CString;
 use core::ffi::{CStr, c_char};

--- a/src/hyperlight_guest_capi/src/types/vec.rs
+++ b/src/hyperlight_guest_capi/src/types/vec.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025 The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 use alloc::boxed::Box;
 use alloc::slice;

--- a/src/hyperlight_guest_macro/src/lib.rs
+++ b/src/hyperlight_guest_macro/src/lib.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025 The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 use proc_macro::TokenStream;
 use proc_macro_crate::{FoundCrate, crate_name};

--- a/src/hyperlight_guest_tracing/src/invariant_tsc.rs
+++ b/src/hyperlight_guest_tracing/src/invariant_tsc.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 /// Module for checking invariant TSC support and reading the timestamp counter
 use core::arch::x86_64::{__cpuid, _rdtsc};

--- a/src/hyperlight_guest_tracing/src/lib.rs
+++ b/src/hyperlight_guest_tracing/src/lib.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 #![no_std]
 

--- a/src/hyperlight_guest_tracing/src/state.rs
+++ b/src/hyperlight_guest_tracing/src/state.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 extern crate alloc;
 
 use alloc::string::String;

--- a/src/hyperlight_guest_tracing/src/subscriber.rs
+++ b/src/hyperlight_guest_tracing/src/subscriber.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 extern crate alloc;
 
 use alloc::sync::Arc;

--- a/src/hyperlight_guest_tracing/src/visitor.rs
+++ b/src/hyperlight_guest_tracing/src/visitor.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 extern crate alloc;
 
 use alloc::string::String;

--- a/src/hyperlight_host/benches/benchmarks.rs
+++ b/src/hyperlight_host/benches/benchmarks.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 use std::sync::{Arc, Barrier, Mutex};
 use std::thread;

--- a/src/hyperlight_host/build.rs
+++ b/src/hyperlight_host/build.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 use anyhow::{Context, Result};
 #[cfg(feature = "build-metadata")]

--- a/src/hyperlight_host/examples/crashdump/main.rs
+++ b/src/hyperlight_host/examples/crashdump/main.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 //! # Crash Dump Example
 //!

--- a/src/hyperlight_host/examples/func_ctx/main.rs
+++ b/src/hyperlight_host/examples/func_ctx/main.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 use hyperlight_host::GuestBinary;
 use hyperlight_host::sandbox::UninitializedSandbox;

--- a/src/hyperlight_host/examples/guest-debugging/main.rs
+++ b/src/hyperlight_host/examples/guest-debugging/main.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 use std::thread;
 
 use hyperlight_host::sandbox::SandboxConfiguration;

--- a/src/hyperlight_host/examples/hello-world/main.rs
+++ b/src/hyperlight_host/examples/hello-world/main.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 use std::thread;
 
 use hyperlight_host::{MultiUseSandbox, UninitializedSandbox};

--- a/src/hyperlight_host/examples/logging/main.rs
+++ b/src/hyperlight_host/examples/logging/main.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 extern crate hyperlight_host;
 
 use std::sync::{Arc, Barrier};

--- a/src/hyperlight_host/examples/map-file-cow-test/main.rs
+++ b/src/hyperlight_host/examples/map-file-cow-test/main.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 // Test that map_file_cow works end-to-end: UninitializedSandbox::new →
 // map_file_cow → evolve → guest function call. Exercises the cross-process
 // section mapping via MapViewOfFileNuma2 on Windows (the surrogate process

--- a/src/hyperlight_host/examples/metrics/main.rs
+++ b/src/hyperlight_host/examples/metrics/main.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 extern crate hyperlight_host;
 use std::sync::{Arc, Barrier};
 use std::thread::{JoinHandle, spawn};

--- a/src/hyperlight_host/examples/tracing-chrome/main.rs
+++ b/src/hyperlight_host/examples/tracing-chrome/main.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 use hyperlight_host::sandbox::uninitialized::UninitializedSandbox;
 use hyperlight_host::{GuestBinary, Result};
 use hyperlight_testing::simple_guest_as_pathbuf;

--- a/src/hyperlight_host/examples/tracing-otlp/main.rs
+++ b/src/hyperlight_host/examples/tracing-otlp/main.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 use opentelemetry_sdk::trace::SdkTracerProvider;
 use tracing::{Level, span};
 use tracing_opentelemetry::OpenTelemetryLayer;

--- a/src/hyperlight_host/examples/tracing/main.rs
+++ b/src/hyperlight_host/examples/tracing/main.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 use tracing::{Level, span};
 extern crate hyperlight_host;
 use std::sync::{Arc, Barrier};

--- a/src/hyperlight_host/src/error.rs
+++ b/src/hyperlight_host/src/error.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 use std::array::TryFromSliceError;
 use std::cell::{BorrowError, BorrowMutError};

--- a/src/hyperlight_host/src/func/host_functions.rs
+++ b/src/hyperlight_host/src/func/host_functions.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 use std::sync::{Arc, Mutex};
 

--- a/src/hyperlight_host/src/func/mod.rs
+++ b/src/hyperlight_host/src/func/mod.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 /// Definitions and functionality to enable guest-to-host function calling,
 /// also called "host functions"

--- a/src/hyperlight_host/src/hyperlight_surrogate/build.rs
+++ b/src/hyperlight_host/src/hyperlight_surrogate/build.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 fn main() {
     if std::env::var("CARGO_CFG_TARGET_OS").as_deref() != Ok("windows") {

--- a/src/hyperlight_host/src/hyperlight_surrogate/src/main.rs
+++ b/src/hyperlight_host/src/hyperlight_surrogate/src/main.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 // This binary is used solely as an address-space host for WHvMapGpaRange2.
 // It is created with CREATE_SUSPENDED and never executes user code.
@@ -35,7 +22,7 @@ unsafe extern "system" {
 ///
 /// # Safety
 ///
-/// This is the raw PE entry point called by the OS loader. 
+/// This is the raw PE entry point called by the OS loader.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn mainCRTStartup() -> ! {
     // INFINITE = 0xFFFFFFFF

--- a/src/hyperlight_host/src/hypervisor/crashdump.rs
+++ b/src/hyperlight_host/src/hypervisor/crashdump.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025 The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 use std::cmp::min;
 use std::io::Write;

--- a/src/hyperlight_host/src/hypervisor/gdb/arch.rs
+++ b/src/hyperlight_host/src/hypervisor/gdb/arch.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 //! This file contains architecture specific code for the x86_64
 

--- a/src/hyperlight_host/src/hypervisor/gdb/event_loop.rs
+++ b/src/hyperlight_host/src/hypervisor/gdb/event_loop.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 use gdbstub::common::Signal;
 use gdbstub::conn::ConnectionExt;

--- a/src/hyperlight_host/src/hypervisor/gdb/mod.rs
+++ b/src/hyperlight_host/src/hypervisor/gdb/mod.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 pub(crate) mod arch;
 mod event_loop;

--- a/src/hyperlight_host/src/hypervisor/gdb/x86_64_target.rs
+++ b/src/hyperlight_host/src/hypervisor/gdb/x86_64_target.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 use std::sync::Arc;
 

--- a/src/hyperlight_host/src/hypervisor/hyperlight_vm/aarch64.rs
+++ b/src/hyperlight_host/src/hypervisor/hyperlight_vm/aarch64.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 // TODO(aarch64): implement arch-specific HyperlightVm methods
 

--- a/src/hyperlight_host/src/hypervisor/hyperlight_vm/mod.rs
+++ b/src/hyperlight_host/src/hypervisor/hyperlight_vm/mod.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025 The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 #[cfg(target_arch = "x86_64")]
 mod x86_64;

--- a/src/hyperlight_host/src/hypervisor/hyperlight_vm/test_support.rs
+++ b/src/hyperlight_host/src/hypervisor/hyperlight_vm/test_support.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025 The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 use std::collections::VecDeque;
 

--- a/src/hyperlight_host/src/hypervisor/hyperlight_vm/x86_64.rs
+++ b/src/hyperlight_host/src/hypervisor/hyperlight_vm/x86_64.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025 The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 #[cfg(gdb)]
 use std::collections::HashMap;

--- a/src/hyperlight_host/src/hypervisor/mod.rs
+++ b/src/hyperlight_host/src/hypervisor/mod.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 /// GDB debugging support
 #[cfg(gdb)]

--- a/src/hyperlight_host/src/hypervisor/regs.rs
+++ b/src/hyperlight_host/src/hypervisor/regs.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 #[cfg(target_arch = "x86_64")]
 mod x86_64;

--- a/src/hyperlight_host/src/hypervisor/regs/aarch64/common_fpu.rs
+++ b/src/hyperlight_host/src/hypervisor/regs/aarch64/common_fpu.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2026 The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The Hyperlight Authors.
 
 #[derive(Debug, Default, Copy, Clone, PartialEq)]
 pub(crate) struct CommonFpu {

--- a/src/hyperlight_host/src/hypervisor/regs/aarch64/common_regs.rs
+++ b/src/hyperlight_host/src/hypervisor/regs/aarch64/common_regs.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2026 The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The Hyperlight Authors.
 
 #[derive(Debug, Default, Copy, Clone, PartialEq)]
 pub(crate) struct CommonRegisters {

--- a/src/hyperlight_host/src/hypervisor/regs/aarch64/kvm_reg.rs
+++ b/src/hyperlight_host/src/hypervisor/regs/aarch64/kvm_reg.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2026 The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The Hyperlight Authors.
 
 use core::marker::PhantomData;
 use core::mem::{self, MaybeUninit};

--- a/src/hyperlight_host/src/hypervisor/regs/aarch64/mod.rs
+++ b/src/hyperlight_host/src/hypervisor/regs/aarch64/mod.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 // TODO(aarch64): implement real register definitions
 

--- a/src/hyperlight_host/src/hypervisor/regs/aarch64/special_regs.rs
+++ b/src/hyperlight_host/src/hypervisor/regs/aarch64/special_regs.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2026 The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The Hyperlight Authors.
 
 use serde::{Deserialize, Serialize};
 

--- a/src/hyperlight_host/src/hypervisor/regs/x86_64/debug_regs.rs
+++ b/src/hyperlight_host/src/hypervisor/regs/x86_64/debug_regs.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 #[cfg(kvm)]
 use kvm_bindings::kvm_debugregs;

--- a/src/hyperlight_host/src/hypervisor/regs/x86_64/fpu.rs
+++ b/src/hyperlight_host/src/hypervisor/regs/x86_64/fpu.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2024 The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2024 The Hyperlight Authors.
 
 #[cfg(target_os = "windows")]
 use std::collections::HashSet;

--- a/src/hyperlight_host/src/hypervisor/regs/x86_64/mod.rs
+++ b/src/hyperlight_host/src/hypervisor/regs/x86_64/mod.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 mod debug_regs;
 mod fpu;

--- a/src/hyperlight_host/src/hypervisor/regs/x86_64/msrs.rs
+++ b/src/hyperlight_host/src/hypervisor/regs/x86_64/msrs.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 //! Model-specific register (MSR) state restored with a snapshot.
 //!

--- a/src/hyperlight_host/src/hypervisor/regs/x86_64/special_regs.rs
+++ b/src/hyperlight_host/src/hypervisor/regs/x86_64/special_regs.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 #[cfg(target_os = "windows")]
 use std::collections::HashSet;

--- a/src/hyperlight_host/src/hypervisor/regs/x86_64/standard_regs.rs
+++ b/src/hyperlight_host/src/hypervisor/regs/x86_64/standard_regs.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 #[cfg(kvm)]
 use kvm_bindings::kvm_regs;

--- a/src/hyperlight_host/src/hypervisor/surrogate_process.rs
+++ b/src/hyperlight_host/src/hypervisor/surrogate_process.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 use core::ffi::c_void;
 use std::collections::HashMap;

--- a/src/hyperlight_host/src/hypervisor/surrogate_process_manager.rs
+++ b/src/hyperlight_host/src/hypervisor/surrogate_process_manager.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 use core::ffi::c_void;
 use std::fs::File;

--- a/src/hyperlight_host/src/hypervisor/virtual_machine/hvf/bindings.h
+++ b/src/hyperlight_host/src/hypervisor/virtual_machine/hvf/bindings.h
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 #include <Hypervisor/Hypervisor.h>
 

--- a/src/hyperlight_host/src/hypervisor/virtual_machine/hvf/fp_abi.c
+++ b/src/hyperlight_host/src/hypervisor/virtual_machine/hvf/fp_abi.c
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 #include "bindings.h"
 

--- a/src/hyperlight_host/src/hypervisor/virtual_machine/hvf/mod.rs
+++ b/src/hyperlight_host/src/hypervisor/virtual_machine/hvf/mod.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 //! # Bridging Hyperlight's assumptions with Hypervisor.framework
 //!

--- a/src/hyperlight_host/src/hypervisor/virtual_machine/kvm/aarch64.rs
+++ b/src/hyperlight_host/src/hypervisor/virtual_machine/kvm/aarch64.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025 The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 // TODO(aarch64): implement KVM backend
 

--- a/src/hyperlight_host/src/hypervisor/virtual_machine/kvm/mod.rs
+++ b/src/hyperlight_host/src/hypervisor/virtual_machine/kvm/mod.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 #[cfg(target_arch = "x86_64")]
 mod x86_64;

--- a/src/hyperlight_host/src/hypervisor/virtual_machine/kvm/x86_64.rs
+++ b/src/hyperlight_host/src/hypervisor/virtual_machine/kvm/x86_64.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 use std::sync::LazyLock;
 

--- a/src/hyperlight_host/src/hypervisor/virtual_machine/mod.rs
+++ b/src/hyperlight_host/src/hypervisor/virtual_machine/mod.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025 The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 use std::fmt::Debug;
 use std::sync::OnceLock;

--- a/src/hyperlight_host/src/hypervisor/virtual_machine/mshv/aarch64.rs
+++ b/src/hyperlight_host/src/hypervisor/virtual_machine/mshv/aarch64.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025 The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 use tracing::{Span, instrument};
 

--- a/src/hyperlight_host/src/hypervisor/virtual_machine/mshv/mod.rs
+++ b/src/hyperlight_host/src/hypervisor/virtual_machine/mshv/mod.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 #[cfg(target_arch = "x86_64")]
 mod x86_64;

--- a/src/hyperlight_host/src/hypervisor/virtual_machine/mshv/x86_64.rs
+++ b/src/hyperlight_host/src/hypervisor/virtual_machine/mshv/x86_64.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 #[cfg(gdb)]
 use std::fmt::Debug;

--- a/src/hyperlight_host/src/hypervisor/virtual_machine/whp.rs
+++ b/src/hyperlight_host/src/hypervisor/virtual_machine/whp.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 use std::os::raw::c_void;
 use std::sync::atomic::{AtomicBool, Ordering};

--- a/src/hyperlight_host/src/hypervisor/virtual_machine/x86_64/hw_interrupts.rs
+++ b/src/hyperlight_host/src/hypervisor/virtual_machine/x86_64/hw_interrupts.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 //! Shared x86-64 helpers for the `hw-interrupts` feature, used by
 //! MSHV and WHP backends.  KVM uses an in-kernel IRQ chip so it

--- a/src/hyperlight_host/src/hypervisor/virtual_machine/x86_64/mod.rs
+++ b/src/hyperlight_host/src/hypervisor/virtual_machine/x86_64/mod.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 //! x86-64 specific helpers for hardware interrupt support.
 pub(crate) mod hw_interrupts;

--- a/src/hyperlight_host/src/hypervisor/wrappers.rs
+++ b/src/hyperlight_host/src/hypervisor/wrappers.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 use std::ffi::CString;
 

--- a/src/hyperlight_host/src/lib.rs
+++ b/src/hyperlight_host/src/lib.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 #![warn(dead_code, missing_docs, unused_mut)]
 //! Hyperlight host runtime for executing guest code in lightweight virtual machines.
 //!

--- a/src/hyperlight_host/src/mem/elf.rs
+++ b/src/hyperlight_host/src/mem/elf.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 #[cfg(feature = "mem_profile")]
 use std::sync::Arc;

--- a/src/hyperlight_host/src/mem/exe.rs
+++ b/src/hyperlight_host/src/mem/exe.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 use std::fs::File;
 use std::io::Read;

--- a/src/hyperlight_host/src/mem/layout.rs
+++ b/src/hyperlight_host/src/mem/layout.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 //! This module describes the virtual and physical addresses of a
 //! number of special regions in the hyperlight VM, although we hope
 //! to reduce the number of these over time.

--- a/src/hyperlight_host/src/mem/memory_region.rs
+++ b/src/hyperlight_host/src/mem/memory_region.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 use std::ops::Range;
 

--- a/src/hyperlight_host/src/mem/mgr.rs
+++ b/src/hyperlight_host/src/mem/mgr.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 use flatbuffers::FlatBufferBuilder;
 use hyperlight_common::flatbuffer_wrappers::function_call::{

--- a/src/hyperlight_host/src/mem/mod.rs
+++ b/src/hyperlight_host/src/mem/mod.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 /// A simple ELF loader
 pub(crate) mod elf;

--- a/src/hyperlight_host/src/mem/ptr.rs
+++ b/src/hyperlight_host/src/mem/ptr.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 use std::ops::Add;
 

--- a/src/hyperlight_host/src/mem/ptr_addr_space.rs
+++ b/src/hyperlight_host/src/mem/ptr_addr_space.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 use tracing::{Span, instrument};
 

--- a/src/hyperlight_host/src/mem/ptr_offset.rs
+++ b/src/hyperlight_host/src/mem/ptr_offset.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 use std::cmp::{Eq, Ord, Ordering, PartialEq, PartialOrd};
 use std::convert::From;

--- a/src/hyperlight_host/src/mem/shared_mem.rs
+++ b/src/hyperlight_host/src/mem/shared_mem.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 use std::any::type_name;
 use std::ffi::c_void;

--- a/src/hyperlight_host/src/mem/shared_mem_tests.rs
+++ b/src/hyperlight_host/src/mem/shared_mem_tests.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 use std::clone::Clone;
 use std::cmp::PartialEq;

--- a/src/hyperlight_host/src/metrics/mod.rs
+++ b/src/hyperlight_host/src/metrics/mod.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 // Counter metric that counter number of times a guest error occurred
 pub(crate) static METRIC_GUEST_ERROR: &str = "guest_errors_total";

--- a/src/hyperlight_host/src/sandbox/builder.rs
+++ b/src/hyperlight_host/src/sandbox/builder.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025 The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 use std::path::Path;
 use std::sync::{Arc, Mutex};

--- a/src/hyperlight_host/src/sandbox/callable.rs
+++ b/src/hyperlight_host/src/sandbox/callable.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025 The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 use crate::Result;
 use crate::func::{ParameterTuple, SupportedReturnType};

--- a/src/hyperlight_host/src/sandbox/config.rs
+++ b/src/hyperlight_host/src/sandbox/config.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 use std::cmp::max;
 use std::time::Duration;

--- a/src/hyperlight_host/src/sandbox/file_mapping.rs
+++ b/src/hyperlight_host/src/sandbox/file_mapping.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 //! Host-side file mapping preparation for [`map_file_cow`].
 //!

--- a/src/hyperlight_host/src/sandbox/host_funcs.rs
+++ b/src/hyperlight_host/src/sandbox/host_funcs.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 use std::collections::HashMap;
 use std::io::{IsTerminal, Write};

--- a/src/hyperlight_host/src/sandbox/initialized_multi_use.rs
+++ b/src/hyperlight_host/src/sandbox/initialized_multi_use.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 use std::path::Path;
 #[cfg(crashdump)]

--- a/src/hyperlight_host/src/sandbox/mod.rs
+++ b/src/hyperlight_host/src/sandbox/mod.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 /// Functionality for creating and configuring `Sandbox`es.
 pub mod builder;

--- a/src/hyperlight_host/src/sandbox/outb.rs
+++ b/src/hyperlight_host/src/sandbox/outb.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 use std::sync::{Arc, Mutex};
 

--- a/src/hyperlight_host/src/sandbox/snapshot/file/config.rs
+++ b/src/hyperlight_host/src/sandbox/snapshot/file/config.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025 The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 use hyperlight_common::flatbuffer_wrappers::function_types::{ParameterType, ReturnType};
 use hyperlight_common::flatbuffer_wrappers::host_function_definition::HostFunctionDefinition;

--- a/src/hyperlight_host/src/sandbox/snapshot/file/digest.rs
+++ b/src/hyperlight_host/src/sandbox/snapshot/file/digest.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025 The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 use std::io::{Read, Seek, SeekFrom};
 

--- a/src/hyperlight_host/src/sandbox/snapshot/file/fsutil.rs
+++ b/src/hyperlight_host/src/sandbox/snapshot/file/fsutil.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025 The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 use std::io::{Read, Write};
 use std::path::Path;

--- a/src/hyperlight_host/src/sandbox/snapshot/file/media_types.rs
+++ b/src/hyperlight_host/src/sandbox/snapshot/file/media_types.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025 The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 // Media types are versioned by suffix. The writer emits `_CURRENT`.
 // The loader matches each version explicitly. See

--- a/src/hyperlight_host/src/sandbox/snapshot/file/mod.rs
+++ b/src/hyperlight_host/src/sandbox/snapshot/file/mod.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025 The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 //! OCI Image Layout serde for [`Snapshot`]. See
 //! `docs/snapshot-oci-format.md` for the on-disk format.

--- a/src/hyperlight_host/src/sandbox/snapshot/file/reference.rs
+++ b/src/hyperlight_host/src/sandbox/snapshot/file/reference.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025 The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 //! Validated identifiers for snapshots stored in an OCI Image Layout:
 //! a human-readable tag, a content digest, and the reference enum that

--- a/src/hyperlight_host/src/sandbox/snapshot/file_tests.rs
+++ b/src/hyperlight_host/src/sandbox/snapshot/file_tests.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025 The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 //! Tests for the OCI Image Layout snapshot format (`super::file`).
 

--- a/src/hyperlight_host/src/sandbox/snapshot/mod.rs
+++ b/src/hyperlight_host/src/sandbox/snapshot/mod.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025 The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 mod file;
 mod file_tests;

--- a/src/hyperlight_host/src/sandbox/snapshot/tripwires.rs
+++ b/src/hyperlight_host/src/sandbox/snapshot/tripwires.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025 The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 //! Compile-time tripwires for the snapshot ABI.
 //!

--- a/src/hyperlight_host/src/sandbox/trace/context.rs
+++ b/src/hyperlight_host/src/sandbox/trace/context.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 use std::collections::HashMap;
 use std::time::{Duration, Instant, SystemTime};

--- a/src/hyperlight_host/src/sandbox/trace/mem_profile.rs
+++ b/src/hyperlight_host/src/sandbox/trace/mem_profile.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 use std::io::Write;
 use std::sync::{Arc, Mutex};
 

--- a/src/hyperlight_host/src/sandbox/trace/mod.rs
+++ b/src/hyperlight_host/src/sandbox/trace/mod.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 /// Tracing context support for sandboxes.
 mod context;

--- a/src/hyperlight_host/src/sandbox/uninitialized.rs
+++ b/src/hyperlight_host/src/sandbox/uninitialized.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 use std::fmt::Debug;
 use std::option::Option;

--- a/src/hyperlight_host/src/sandbox/uninitialized_evolve.rs
+++ b/src/hyperlight_host/src/sandbox/uninitialized_evolve.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 use rand::RngExt;
 use tracing::{Span, instrument};
 

--- a/src/hyperlight_host/src/signal_handlers/mod.rs
+++ b/src/hyperlight_host/src/signal_handlers/mod.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 use libc::c_int;
 

--- a/src/hyperlight_host/src/testing/log_values.rs
+++ b/src/hyperlight_host/src/testing/log_values.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 use serde_json::{Map, Value};
 

--- a/src/hyperlight_host/src/testing/mod.rs
+++ b/src/hyperlight_host/src/testing/mod.rs
@@ -1,16 +1,3 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 pub(crate) mod log_values;

--- a/src/hyperlight_host/tests/common/mod.rs
+++ b/src/hyperlight_host/tests/common/mod.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 use std::path::PathBuf;
 

--- a/src/hyperlight_host/tests/integration_test.rs
+++ b/src/hyperlight_host/tests/integration_test.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Barrier};
 use std::thread;

--- a/src/hyperlight_host/tests/sandbox_host_tests.rs
+++ b/src/hyperlight_host/tests/sandbox_host_tests.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 use core::f64;
 use std::sync::mpsc::channel;
 use std::sync::{Arc, Mutex};

--- a/src/hyperlight_host/tests/snapshot_goldens/checks.rs
+++ b/src/hyperlight_host/tests/snapshot_goldens/checks.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025 The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 //! Functional checks against goldens loaded from the on-disk goldens
 //! directory.

--- a/src/hyperlight_host/tests/snapshot_goldens/fixtures.rs
+++ b/src/hyperlight_host/tests/snapshot_goldens/fixtures.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025 The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 //! Canonical fixture builders. These define exactly what bytes a
 //! goldens push contains. Any change here is a snapshot content

--- a/src/hyperlight_host/tests/snapshot_goldens/goldens_version.rs
+++ b/src/hyperlight_host/tests/snapshot_goldens/goldens_version.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025 The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 //! The goldens version string, kept in its own file.
 //!

--- a/src/hyperlight_host/tests/snapshot_goldens/main.rs
+++ b/src/hyperlight_host/tests/snapshot_goldens/main.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025 The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 use std::ffi::OsString;
 use std::path::{Path, PathBuf};

--- a/src/hyperlight_host/tests/snapshot_goldens/oci.rs
+++ b/src/hyperlight_host/tests/snapshot_goldens/oci.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025 The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 use std::path::PathBuf;
 

--- a/src/hyperlight_host/tests/snapshot_goldens/platform.rs
+++ b/src/hyperlight_host/tests/snapshot_goldens/platform.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025 The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 //! Local platform detection and tag naming for snapshot goldens.
 //!

--- a/src/hyperlight_host/tests/wit_test.rs
+++ b/src/hyperlight_host/tests/wit_test.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025 The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 use std::sync::{Arc, Mutex};
 

--- a/src/hyperlight_libc/build.rs
+++ b/src/hyperlight_libc/build.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 mod build_files;
 

--- a/src/hyperlight_libc/build_files.rs
+++ b/src/hyperlight_libc/build_files.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 pub(crate) const LIBC_FILES: &[&str] = &[
     "argz/argz_add.c",

--- a/src/hyperlight_libc/include/picolibc.h
+++ b/src/hyperlight_libc/include/picolibc.h
@@ -1,18 +1,5 @@
-/*
-Copyright 2026  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The Hyperlight Authors.
 
 #pragma once
 
@@ -29,43 +16,43 @@ limitations under the License.
 
 // static configuration - enabled features
 #define __ASSERT_VERBOSE
-#define __SINGLE_THREAD // -Dsingle-thread=true
-#define __GLOBAL_ERRNO // -Dnewlib-global-errno=true
+#define __SINGLE_THREAD   // -Dsingle-thread=true
+#define __GLOBAL_ERRNO    // -Dnewlib-global-errno=true
 #define __INIT_FINI_ARRAY // -Dinitfini-array=true
-#define __TINY_STDIO // tinystdio is now the only stdio
-#define __IO_DEFAULT 'd' // -Dformat-default=double
-#define __IO_FLOAT_EXACT // default
-#define __IO_WCHAR // -Dio-wchar=true
-#define __IEEE_LIBM // math library without errno
-#define __FAST_STRCMP // default optimization
-#define __FAST_BUFIO // -Dfast-bufio=true
-#define __IO_SMALL_ULTOA // avoid division in conversion
+#define __TINY_STDIO      // tinystdio is now the only stdio
+#define __IO_DEFAULT 'd'  // -Dformat-default=double
+#define __IO_FLOAT_EXACT  // default
+#define __IO_WCHAR        // -Dio-wchar=true
+#define __IEEE_LIBM       // math library without errno
+#define __FAST_STRCMP     // default optimization
+#define __FAST_BUFIO      // -Dfast-bufio=true
+#define __IO_SMALL_ULTOA  // avoid division in conversion
 
 // static configuration - disabled features
-#undef __ARM_SEMIHOST // -Dsemihost=false
-#undef __SEMIHOST // -Dsemihost=false
+#undef __ARM_SEMIHOST         // -Dsemihost=false
+#undef __SEMIHOST             // -Dsemihost=false
 #undef __THREAD_LOCAL_STORAGE // -Dthread-local-storage=false
 #undef __THREAD_LOCAL_STORAGE_API
 #undef __THREAD_LOCAL_STORAGE_RP2040
 #undef __THREAD_LOCAL_STORAGE_STACK_GUARD
 #undef __ENABLE_MALLOC // -Denable-malloc=false
 #undef __MALLOC_CLEAR_FREED
-#undef __MB_CAPABLE // no multibyte support
-#undef __HAVE_FCNTL // freestanding environment
-#undef __STDIO_LOCKING // single-thread
+#undef __MB_CAPABLE     // no multibyte support
+#undef __HAVE_FCNTL     // freestanding environment
+#undef __STDIO_LOCKING  // single-thread
 #undef __IO_C99_FORMATS // -Dio-c99-formats=false
 #undef __IO_LONG_DOUBLE // not enabled
-#undef __IO_LONG_LONG // minimal format
+#undef __IO_LONG_LONG   // minimal format
 #undef __IO_MINIMAL_LONG_LONG
 #undef __IO_PERCENT_B // not enabled
 #undef __IO_PERCENT_N // not enabled
-#undef __IO_POS_ARGS // not enabled
-#undef __MATH_ERRNO // IEEE math only
+#undef __IO_POS_ARGS  // not enabled
+#undef __MATH_ERRNO   // IEEE math only
 #undef __OBSOLETE_MATH
 #undef __OBSOLETE_MATH_DOUBLE
 #undef __OBSOLETE_MATH_FLOAT
 #undef __PREFER_SIZE_OVER_SPEED // release build
-#undef __ATOMIC_UNGETC // single-thread
+#undef __ATOMIC_UNGETC          // single-thread
 #undef __IEEEFP_FUNCS
 #undef __INIT_FINI_FUNCS // using INIT_FINI_ARRAY instead
 #undef __HAVE_BITFIELDS_IN_PACKED_STRUCTS

--- a/src/hyperlight_libc/src/lib.rs
+++ b/src/hyperlight_libc/src/lib.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 //! Hyperlight libc crate
 //!

--- a/src/hyperlight_libc/src/stubs.rs
+++ b/src/hyperlight_libc/src/stubs.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2026  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The Hyperlight Authors.
 
 use crate::{CLOCK_REALTIME, EINVAL, c_int, c_void, clock_gettime, errno, timespec, timeval};
 

--- a/src/hyperlight_testing/src/lib.rs
+++ b/src/hyperlight_testing/src/lib.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 // This crate contains testing utilities which need to be shared across multiple
 // crates in this project.

--- a/src/hyperlight_testing/src/logger.rs
+++ b/src/hyperlight_testing/src/logger.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 use std::cell::RefCell;
 use std::sync::Once;

--- a/src/hyperlight_testing/src/simplelogger.rs
+++ b/src/hyperlight_testing/src/simplelogger.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 #![allow(static_mut_refs)]
 // this is a non threadsafe logger for testing purposes, to test the log messages emitted by the guest.
 // it will only log messages from the hyperlight_guest target. It will not log messages from other targets.

--- a/src/hyperlight_testing/src/tracing_subscriber.rs
+++ b/src/hyperlight_testing/src/tracing_subscriber.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 use std::cell::RefCell;
 use std::collections::HashMap;

--- a/src/tests/rust_guests/dummyguest/src/main.rs
+++ b/src/tests/rust_guests/dummyguest/src/main.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 #![no_std]
 #![no_main]

--- a/src/tests/rust_guests/simpleguest/src/main.rs
+++ b/src/tests/rust_guests/simpleguest/src/main.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025  The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 #![no_std]
 #![no_main]

--- a/src/tests/rust_guests/witguest/src/bindings.rs
+++ b/src/tests/rust_guests/witguest/src/bindings.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025 The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 extern crate alloc;
 

--- a/src/tests/rust_guests/witguest/src/main.rs
+++ b/src/tests/rust_guests/witguest/src/main.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025 The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 #![no_std]
 #![no_main]

--- a/src/trace_dump/main.rs
+++ b/src/trace_dump/main.rs
@@ -1,18 +1,5 @@
-/*
-Copyright 2025 The Hyperlight Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Hyperlight Authors.
 
 use std::collections::HashMap;
 use std::env;


### PR DESCRIPTION
As I've been reading the Hyperlight source, I noticed we're using long-form license pragmas in each file. I assume we have a reason for that, so I don't want to suggest we remove these outright. But what I figured we could do is move to the short-form pragma format that is a bit more compact.

The format I'm introducing here is for example also used by the Linux kernel ([example](https://github.com/torvalds/linux/blob/a4ff2be345d0abc943da8dd8da98151843b750dc/mm/Kconfig)). As I understand it, tools like FOSSA also know how to ingest this, and can ensure appropriate attribution. As far as I can tell there are no downsides to adopting this shorter format, other than the cost of making the change itself (e.g. this PR). But admittedly this is the first time I'm involved in a migration of this kind, so it might be that I've missed something.

Anyway, I figured this might be a relatively easy way to delete some code with no real downsides. As well as to familiarize myself with the Hyperlight contribution process. Keen to hear what folks think; thanks!