### PR TITLE
Update cargo-hyperlight version to 0.1.14

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -8,7 +8,7 @@ bin-suffix := if os() == "windows" { ".bat" } else { ".sh" }
 nightly-toolchain := "nightly-2026-02-27"
 # Pinned cargo-hyperlight version used to build the guest sysroot. Keep this in
 # lockstep with the version pinned in flake.nix.
-cargo-hyperlight-version := "0.1.12"
+cargo-hyperlight-version := "0.1.14"
 
 ################
 ### cross-rs ###

--- a/dev/update-cargo-hyperlight-version.sh
+++ b/dev/update-cargo-hyperlight-version.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+## DESCRIPTION:
+##
+## Pins the latest published cargo-hyperlight in the Justfile and in
+## flake.nix. The Justfile only needs the version, flake.nix also needs
+## the SRI hash of the .crate tarball. Both come from the crates.io
+## sparse index, so no download and no Nix are needed.
+##
+## PRE-REQS:
+##
+## curl, jq, and sed.
+
+CRATE=cargo-hyperlight
+ROOT="$(git rev-parse --show-toplevel)"
+cd "$ROOT"
+
+for tool in curl jq sed; do
+    command -v "$tool" >/dev/null || { echo "error: $tool is required" >&2; exit 1; }
+done
+
+# `sed -i` takes different arguments on GNU and BSD, so edit via a temp file.
+sedi() {
+    local file=$1
+    shift
+    if ! sed "$@" "$file" > "$file.tmp"; then
+        rm -f "$file.tmp"
+        exit 1
+    fi
+    mv "$file.tmp" "$file"
+}
+
+check() {
+    grep -qF "$2" "$1" || { echo "error: failed to update $1 with: $2" >&2; exit 1; }
+}
+
+# Index paths are bucketed by the first four characters of the crate name.
+INDEX="https://index.crates.io/${CRATE:0:2}/${CRATE:2:2}/$CRATE"
+
+# Entries are in publication order, so the last released one is the latest.
+read -r VERSION CKSUM < <(curl -fsSL "$INDEX" |
+    jq -rs 'map(select((.yanked | not) and (.vers | contains("-") | not))) | last | "\(.vers) \(.cksum)"')
+
+# The index gives the checksum in hex, Nix wants it base64 encoded.
+# shellcheck disable=SC2001 # no parameter expansion pairs up hex digits
+HASH="sha256-$(printf %b "$(sed 's/../\\x&/g' <<< "$CKSUM")" | base64 | tr -d '\n')"
+echo "latest release: $VERSION ($HASH)"
+
+sedi Justfile "s|^cargo-hyperlight-version := \".*\"|cargo-hyperlight-version := \"$VERSION\"|"
+
+# Both fields are matched inside the fetchurl block, where they are unique.
+BLOCK='/cargo-hyperlight = let/,/^ *};$/'
+sedi flake.nix \
+    -e "$BLOCK s|version = \"[^\"]*\"|version = \"$VERSION\"|" \
+    -e "$BLOCK s|hash = \"[^\"]*\"|hash = \"$HASH\"|"
+
+check Justfile "cargo-hyperlight-version := \"$VERSION\""
+check flake.nix "version = \"$VERSION\""
+check flake.nix "hash = \"$HASH\""
+
+echo "pinned cargo-hyperlight $VERSION in Justfile and flake.nix"

--- a/flake.nix
+++ b/flake.nix
@@ -227,16 +227,26 @@
 
           buildRustPackageClang = rust-platform.buildRustPackage.override { stdenv = clangStdenv; };
 
-          cargo-hyperlight = buildRustPackageClang rec {
-            pname = "cargo-hyperlight";
-            version = "0.1.14-pre";
-            src = fetchFromGitHub {
-              owner = "hyperlight-dev";
-              repo = "cargo-hyperlight";
-              rev = "33384c0c4ed9dea4f0525943809fc444c41a27df";
-              hash = "sha256-A2/SNHCdPPzW86bd00IucZEyZHZWDqXVKPccZULcEu0=";
+          # Keep the version in lockstep with the one pinned in the Justfile.
+          # `dev/update-cargo-hyperlight-version.sh` updates both.
+          cargo-hyperlight = let
+            version = "0.1.14";
+            # The .crate tarball is hashed flat, so the pin can be refreshed
+            # from the checksum crates.io publishes, without running Nix.
+            src = fetchurl {
+              url = "https://static.crates.io/crates/cargo-hyperlight/cargo-hyperlight-${version}.crate";
+              name = "cargo-hyperlight-${version}.tar.gz";
+              hash = "sha256-xS8cnUthc677Zv3C4+ES3bNZ/i+9uq/hubol96xXizk=";
             };
-            cargoHash = "sha256-ImWnNzXvDKokML0BDyyjifrZ1bnG6ymXt5vAMRIpwUY==";
+          in buildRustPackageClang {
+            pname = "cargo-hyperlight";
+            inherit version src;
+            # The tarball ships a Cargo.lock, so the dependencies need no
+            # vendor hash of their own.
+            cargoDeps = rust-platform.importCargoLock {
+              lockFile = runCommand "cargo-hyperlight-${version}-Cargo.lock" {}
+                "tar -xzOf ${src} cargo-hyperlight-${version}/Cargo.lock > $out";
+            };
             doCheck = false;
           };
         in (buildRustPackageClang (mkDerivationAttrs: {


### PR DESCRIPTION
Closes https://github.com/hyperlight-dev/hyperlight/issues/1749, thanks!

**Edit:** this PR also adds an automatic update script to automate the `cargo-hyperlight` update bump. The most complicated part of that was updating the `flake.nix` files (see https://github.com/hyperlight-dev/hyperlight/pull/1754#pullrequestreview-4991829464 from review), hence the number of changes.