### PR TITLE
WHP: releasing file mappings after deleting partition in WhpVm::Drop

### DIFF
--- a/src/hyperlight_host/src/hypervisor/virtual_machine/whp.rs
+++ b/src/hyperlight_host/src/hypervisor/virtual_machine/whp.rs
@@ -1360,11 +1360,6 @@ impl WhpVm {
 
 impl Drop for WhpVm {
     fn drop(&mut self) {
-        // Clean up any remaining file mappings that weren't explicitly unmapped.
-        for (handle, view) in self.file_mappings.drain(..) {
-            release_file_mapping(view, handle);
-        }
-
         // Stop the software timer thread before tearing down the partition.
         #[cfg(feature = "hw-interrupts")]
         if let Some(mut t) = self.timer.take() {
@@ -1378,6 +1373,11 @@ impl Drop for WhpVm {
         // set_dropped() completes before this Drop impl runs.)
         if let Err(e) = unsafe { WHvDeletePartition(self.partition) } {
             tracing::error!("Failed to delete partition: {}", e);
+        }
+
+        // Clean up any remaining file mappings that weren't explicitly unmapped.
+        for (handle, view) in self.file_mappings.drain(..) {
+            release_file_mapping(view, handle);
         }
     }
 }


### PR DESCRIPTION
Keep mapped-file views alive while WHP may still reference them. With surrogate processes disabled (`HYPERLIGHT_MAX_SURROGATES=0`), `WHvMapGpaRange` uses the host view directly. Releasing that view during VM teardown leaves an active GPA mapping backed by an invalid virtual address.

This is a defensive change, I don't know of any current impact