### PR TITLE
Correct deprecated-since attribute

### DIFF
--- a/src/hyperlight_host/src/sandbox/initialized_multi_use.rs
+++ b/src/hyperlight_host/src/sandbox/initialized_multi_use.rs
@@ -1081,7 +1081,7 @@ impl MultiUseSandbox {
     /// # Ok(())
     /// # }
     /// ```
-    #[deprecated(since = "0.16.0", note = "use status().is_poisoned()")]
+    #[deprecated(since = "0.17.0", note = "use status().is_poisoned()")]
     pub fn poisoned(&self) -> bool {
         self.status.is_poisoned()
     }


### PR DESCRIPTION
This should be the next unreleased version, i.e. next release that will first contain the deprecation.... 0.16 is already released