### PR TITLE
Avoid Cargo cache cleanup races on macOS

### DIFF
--- a/.github/workflows/dep_build_test.yml
+++ b/.github/workflows/dep_build_test.yml
@@ -87,6 +87,8 @@ jobs:
       - name: Rust cache
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
         with:
+          # Concurrent macOS runners share ~/.cargo/bin, so cleanup can remove Cargo from another job.
+          cache-bin: ${{ runner.os != 'macOS' }}
           shared-key: "${{ inputs.arch }}-${{ runner.os }}-${{ inputs.hypervisor }}-${{ inputs.config }}"
           cache-on-failure: "true"
           # Only save on main as caches are not shared across branches.


### PR DESCRIPTION
We have mutliple macos runners running concurrently on the same machine. https://github.com/swatinem/rust-cache has a [known issue](https://github.com/swatinem/rust-cache#known-issues) where ~/.cargo/bin gets cleared, which can interfere with concurrent jobs. This fix applies the recommended workaround which is to not cache (and therefore not clean) ~/.cargo/bin

This fix covers DailyArm64.yml and ValidatePullRequest.yml, which are the only jobs running macos concurrently with caching enabled. 

closes #1744 