### PR TITLE
fix: cherry-pick crates.io publish detection fix onto release/v0.17.0

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf

--- a/.github/workflows/CargoPublish.yml
+++ b/.github/workflows/CargoPublish.yml
@@ -51,34 +51,16 @@ jobs:
 
       - name: Determine which crates need publishing
         run: |
-          needs_publish() {
-            local crate=$1
-            local crate_env_var=$(echo "$crate" | tr '[:lower:]' '[:upper:]' | tr '-' '_')
-
-            if [ -z "$VERSION" ]; then
-              echo "No version set (dry run?), skipping crates.io existence checks."
-              echo "PUBLISH_${crate_env_var}=true" >> "$GITHUB_ENV"
-              return
-            fi
-
-            if curl -s "https://crates.io/api/v1/crates/$crate/$VERSION" | jq -e .version > /dev/null; then
-              echo "PUBLISH_${crate_env_var}=false" >> "$GITHUB_ENV"
-              echo "✅ $crate@$VERSION already exists."
-            else
-              echo "PUBLISH_${crate_env_var}=true" >> "$GITHUB_ENV"
-              echo "🚀 $crate@$VERSION will be published."
-            fi
-          }
-          
-          needs_publish hyperlight-libc
-          needs_publish hyperlight-common
-          needs_publish hyperlight-guest
-          needs_publish hyperlight-guest-macro
-          needs_publish hyperlight-guest-bin
-          needs_publish hyperlight-component-util
-          needs_publish hyperlight-component-macro
-          needs_publish hyperlight-host
-          needs_publish hyperlight-guest-tracing
+          ./dev/crates-to-publish.sh "$VERSION" \
+            hyperlight-libc \
+            hyperlight-common \
+            hyperlight-guest \
+            hyperlight-guest-macro \
+            hyperlight-guest-bin \
+            hyperlight-component-util \
+            hyperlight-component-macro \
+            hyperlight-host \
+            hyperlight-guest-tracing >> "$GITHUB_ENV"
 
       - name: Authenticate with crates.io
         uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18  # v1.0.5

--- a/dev/crates-to-publish.sh
+++ b/dev/crates-to-publish.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+set -euo pipefail
+
+if [ "$#" -lt 2 ]; then
+    echo "Usage: $0 VERSION CRATE..." >&2
+    exit 1
+fi
+
+VERSION=$1
+shift
+
+response_file=$(mktemp)
+trap 'rm -f "$response_file"' EXIT
+
+for crate in "$@"; do
+    crate_env_var=${crate^^}
+    crate_env_var=${crate_env_var//-/_}
+
+    if [ -z "$VERSION" ]; then
+        echo "No version set (dry run?), skipping crates.io existence checks." >&2
+        echo "PUBLISH_${crate_env_var}=true"
+        continue
+    fi
+
+    if ! http_status=$(
+        curl --silent --show-error \
+            --user-agent 'hyperlight-release-workflow (https://github.com/hyperlight-dev/hyperlight)' \
+            --retry 3 \
+            --retry-all-errors \
+            --connect-timeout 10 \
+            --max-time 30 \
+            --output "$response_file" \
+            --write-out '%{http_code}' \
+            "https://crates.io/api/v1/crates/$crate/$VERSION"
+    ); then
+        echo "Failed to query crates.io for $crate@$VERSION." >&2
+        exit 1
+    fi
+
+    case "$http_status" in
+        200)
+            if ! jq -e --arg version "$VERSION" '.version.num == $version' "$response_file" > /dev/null; then
+                echo "crates.io returned malformed or mismatched version data for $crate@$VERSION." >&2
+                exit 1
+            fi
+            echo "PUBLISH_${crate_env_var}=false"
+            echo "$crate@$VERSION already exists." >&2
+            ;;
+        404)
+            echo "PUBLISH_${crate_env_var}=true"
+            echo "$crate@$VERSION will be published." >&2
+            ;;
+        *)
+            echo "crates.io returned HTTP $http_status for $crate@$VERSION." >&2
+            exit 1
+            ;;
+    esac
+done


### PR DESCRIPTION
Cherry-picks #1781 onto the release branch so the crates.io publish workflow can correctly detect unpublished crates and publish them.

Without this fix, the publish detection incorrectly reports all crates as already published due to a bug in the crates.io API response parsing.