### PR TITLE
fix: tolerate existing GH release so cargo-publish can run

### DIFF
--- a/.github/workflows/CreateRelease.yml
+++ b/.github/workflows/CreateRelease.yml
@@ -188,7 +188,7 @@ jobs:
             benchmarks_Linux_mshv3_amd.tar.gz \
             benchmarks_Linux_mshv3_intel.tar.gz \
             hyperlight-guest-c-api-linux.tar.gz \
-            include.tar.gz
+            include.tar.gz || echo "Release already exists, continuing..."
         env:
             GH_TOKEN: ${{ github.token }}
       


### PR DESCRIPTION
Makes the `gh release create` step in CreateRelease.yml not fail when the release already exists. This allows re-triggering the full CreateRelease pipeline to publish crates via trusted publishing (which requires the OIDC token to come from `CreateRelease.yml`, not `CargoPublish.yml` directly).

This is needed because the v0.17.0 GitHub release was already created, but crate publishing failed due to the bug fixed in #1781.