### PR TITLE
chore(deps): update and group mshv crates together

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,9 @@ updates:
       - "kind/dependencies"
     open-pull-requests-limit: 20
     groups:
+      mshv:
+        patterns:
+          - "mshv-*"
       wasm-tools:
         patterns:
           - "wasmparser"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2378,9 +2378,9 @@ dependencies = [
 
 [[package]]
 name = "mshv-bindings"
-version = "0.6.9"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83303108160c2b7a7bdd25000ee679384e19471386d23e501ed832574c9229ef"
+checksum = "9b4b2414499597c6e31b1cd25239f19e8e8c55023b3bf8fcfa44d927cff6a123"
 dependencies = [
  "libc",
  "num_enum",
@@ -2390,9 +2390,9 @@ dependencies = [
 
 [[package]]
 name = "mshv-ioctls"
-version = "0.6.9"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1db4449ac7012237b133da366f5b32ce4af1f8caf770486e5a9d54f7f6b73c4c"
+checksum = "c30d1b5b76a709e30b46248f52bbb44dde04a659d6d58255c7f06c88d528d210"
 dependencies = [
  "libc",
  "mshv-bindings",

--- a/src/hyperlight_host/Cargo.toml
+++ b/src/hyperlight_host/Cargo.toml
@@ -88,8 +88,8 @@ lazy_static = "1.4.0"
 [target.'cfg(target_os = "linux")'.dependencies]
 kvm-bindings = { version = "0.14", features = ["fam-wrappers"], optional = true }
 kvm-ioctls = { version = "0.25", optional = true }
-mshv-bindings = { version = "0.6", optional = true }
-mshv-ioctls = { version = "0.6", optional = true}
+mshv-bindings = { version = "0.7", optional = true }
+mshv-ioctls = { version = "0.7", optional = true}
 
 [dev-dependencies]
 uuid = { version = "1.23.3", features = ["v4"] }


### PR DESCRIPTION
## Summary

* Use `mshv-bindings` and `mshv-ioctls` 0.7.1 together. Mixing 0.6 and 0.7 creates incompatible binding types at the ioctl boundary.
* Group `mshv-*` Cargo updates in Dependabot.

Supersedes #1786 and #1785.

## Validation

* Linux `just clippy` passes with all targets and features.
* The dependency graph contains one `mshv-bindings` version, 0.7.1.
* Full runtime validation is incomplete. The initial test run lacked prebuilt guest binaries. Building them hit a Windows/WSL submodule-path error in `hyperlight-libc`.