### PR TITLE
Fix ARM workflow runner routing

### DIFF
--- a/.github/workflows/PrimeCaches.yml
+++ b/.github/workflows/PrimeCaches.yml
@@ -90,7 +90,7 @@ jobs:
             github.run_id,
             github.run_number,
             github.run_attempt)
-        || '["self-hosted", "Linux", "arm64", "kvm", "ubuntu-24.04"]') }}
+        || '["self-hosted", "Linux", "arm64", "kvm"]') }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 

--- a/.github/workflows/dep_benchmarks.yml
+++ b/.github/workflows/dep_benchmarks.yml
@@ -84,7 +84,7 @@ jobs:
             github.run_id,
             github.run_number,
             github.run_attempt)
-        || '["self-hosted", "Linux", "arm64", "kvm", "ubuntu-24.04"]') }}
+        || '["self-hosted", "Linux", "arm64", "kvm"]') }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 

--- a/.github/workflows/dep_build_guests.yml
+++ b/.github/workflows/dep_build_guests.yml
@@ -39,7 +39,7 @@ jobs:
             github.run_id,
             github.run_number,
             github.run_attempt)
-        || '["self-hosted", "Linux", "arm64", "ubuntu-24.04"]') }}
+        || '["self-hosted", "Linux", "arm64"]') }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 

--- a/.github/workflows/dep_fuzzing.yml
+++ b/.github/workflows/dep_fuzzing.yml
@@ -33,7 +33,7 @@ jobs:
             github.run_id,
             github.run_number,
             github.run_attempt)
-        || '["self-hosted", "Linux", "arm64", "kvm", "ubuntu-24.04"]') }}
+        || '["self-hosted", "Linux", "arm64", "kvm"]') }}
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1

--- a/.github/workflows/dep_run_examples.yml
+++ b/.github/workflows/dep_run_examples.yml
@@ -52,7 +52,7 @@ jobs:
             github.run_number,
             github.run_attempt)
         || format('["self-hosted", "{0}", "arm64", "{1}"]',
-            inputs.hypervisor == 'hvf' && 'macos' || 'Linux',
+            inputs.hypervisor == 'hvf' && 'macOS' || 'Linux',
             inputs.hypervisor)) }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1

--- a/.github/workflows/dep_run_examples.yml
+++ b/.github/workflows/dep_run_examples.yml
@@ -51,7 +51,9 @@ jobs:
             github.run_id,
             github.run_number,
             github.run_attempt)
-        || '["self-hosted", "Linux", "arm64", "kvm", "ubuntu-24.04"]') }}
+        || format('["self-hosted", "{0}", "arm64", "{1}"]',
+            inputs.hypervisor == 'hvf' && 'macos' || 'Linux',
+            inputs.hypervisor)) }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
@@ -69,6 +71,8 @@ jobs:
       - name: Rust cache
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
         with:
+          # Concurrent macOS runners share ~/.cargo/bin, so cleanup can remove Cargo from another job.
+          cache-bin: ${{ runner.os != 'macOS' }}
           shared-key: "${{ inputs.arch }}-${{ runner.os }}-${{ inputs.hypervisor }}-${{ inputs.config }}"
           save-if: "false"
 
@@ -87,14 +91,14 @@ jobs:
           name: c-guests-${{ inputs.arch }}-${{ inputs.config }}
           path: src/tests/c_guests/bin/${{ inputs.config }}/
 
-      - name: Run Rust examples - windows
-        if: runner.os == 'Windows'
+      - name: Run Rust examples - windows and macOS
+        if: runner.os == 'Windows' || runner.os == 'macOS'
         env:
           RUST_LOG: debug
         run: just run-rust-examples ${{ inputs.config }}
 
       - name: Run Rust examples - linux
-        if: runner.os != 'Windows'
+        if: runner.os == 'Linux'
         env:
           RUST_LOG: debug
         run: just run-rust-examples-linux ${{ inputs.config }}


### PR DESCRIPTION
## Summary

Removed the `ubuntu-24.04` label from ARM jobs in preparation for remvoing the label from the self-hosted runners (the presence of this label caused any job that uses `ubuntu-24.04` as a runs-on label to potentially target the ARM runners.

Also fixed a bug where examples were being run on kvm instead of hvf.

* ARM Linux selectors use the built-in OS and architecture labels, with `kvm` where required. Guest builds need no hypervisor label.
* ARM HVF examples run on native macOS runners using the shared metrics and logging recipe. 

* macOS Rust cache cleanup excludes shared Cargo binaries, matching the build-test workflow.
