### PR TITLE
chore(deps): use workspace dependencies for shared deps across crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,33 @@ hyperlight-libc = { path = "src/hyperlight_libc", version = "0.17.0", default-fe
 hyperlight-component-util = { path = "src/hyperlight_component_util", version = "0.17.0", default-features = false }
 hyperlight-component-macro = { path = "src/hyperlight_component_macro", version = "0.17.0", default-features = false }
 
+# Third-party dependencies shared by two or more workspace member crates.
+# Keep this list unified: one version per dependency, chosen from the
+# versions already in use unless that breaks a no_std guest crate.
+anyhow = "1.0.102"
+bindgen = "0.72"
+bitflags = "2.13.0"
+blake3 = "1.8.5"
+bytemuck = "1.24"
+cc = "1.2"
+criterion = "0.8.2"
+env_logger = "0.11.10"
+flatbuffers = { version = "25.12.19", default-features = false }
+itertools = "0.15.0"
+log = "0.4.32"
+prettyplease = "0.3.0"
+proc-macro2 = "1.0.106"
+quote = "1.0.45"
+rand = "0.10.1"
+serde = "1.0"
+serde_json = "1.0"
+spin = "0.12.0"
+syn = "3.0.1"
+thiserror = "2.0.18"
+tracing = "0.1.44"
+tracing-core = "0.1.36"
+tracing-serde = "0.2.0"
+
 [workspace.lints.rust]
 unsafe_op_in_unsafe_fn = "deny"
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(loom)'] }

--- a/src/hyperlight_common/Cargo.toml
+++ b/src/hyperlight_common/Cargo.toml
@@ -17,16 +17,16 @@ workspace = true
 [dependencies]
 arbitrary = {version = "1.4.2", optional = true, features = ["derive"]}
 anyhow = { version = "1.0.102", default-features = false }
-bitflags = "2.13.0"
-bytemuck = { version = "1.24", features = ["derive"] }
+bitflags = { workspace = true }
+bytemuck = { workspace = true, features = ["derive"] }
 bytes = { version = "1", default-features = false }
 fixedbitset = { version = "0.5.7", default-features = false }
-flatbuffers = { version = "25.12.19", default-features = false }
-log = "0.4.32"
+flatbuffers = { workspace = true }
+log = { workspace = true }
 smallvec = "1.15.1"
-spin = "0.12.0"
+spin = { workspace = true }
 thiserror = { version = "2.0.18", default-features = false }
-tracing = { version = "0.1.44", optional = true }
+tracing = { workspace = true, optional = true }
 tracing-core = { version = "0.1.36", default-features = false }
 
 [features]
@@ -38,10 +38,10 @@ mem_profile = []
 std = ["thiserror/std", "log/std", "tracing/std"]
 
 [dev-dependencies]
-criterion = "0.8.1"
+criterion = { workspace = true }
 hyperlight-testing = { workspace = true }
 quickcheck = "1.0.3"
-rand = "0.10.1"
+rand = { workspace = true }
 
 [target.'cfg(loom)'.dev-dependencies]
 loom = "0.7"

--- a/src/hyperlight_component_macro/Cargo.toml
+++ b/src/hyperlight_component_macro/Cargo.toml
@@ -16,10 +16,10 @@ name = "hyperlight_component_macro"
 proc-macro = true
 
 [dependencies]
-quote = { version = "1.0.45" }
-proc-macro2 = { version = "1.0.106" }
-syn = { version = "3.0.1" }
-itertools = { version = "0.15.0" }
-prettyplease = { version = "0.3.0" }
+quote = { workspace = true }
+proc-macro2 = { workspace = true }
+syn = { workspace = true }
+itertools = { workspace = true }
+prettyplease = { workspace = true }
 hyperlight-component-util = { workspace = true }
-env_logger = { version = "0.11.10" }
+env_logger = { workspace = true }

--- a/src/hyperlight_component_util/Cargo.toml
+++ b/src/hyperlight_component_util/Cargo.toml
@@ -19,9 +19,9 @@ wasmparser = { version = "0.257.1" }
 wat = { version = "1.256.0" }
 wit-component = { version = "0.257.1" }
 wit-parser = { version = "0.257.1" }
-quote = { version = "1.0.45" }
-proc-macro2 = { version = "1.0.106" }
-syn = { version = "3.0.1" }
-itertools = { version = "0.15.0" }
-prettyplease = { version = "0.3.0" }
-tracing = { version = "0.1.44", features = ["log"]}
+quote = { workspace = true }
+proc-macro2 = { workspace = true }
+syn = { workspace = true }
+itertools = { workspace = true }
+prettyplease = { workspace = true }
+tracing = { workspace = true, features = ["log"] }

--- a/src/hyperlight_guest/Cargo.toml
+++ b/src/hyperlight_guest/Cargo.toml
@@ -15,7 +15,7 @@ Provides only the essential building blocks for interacting with the host enviro
 anyhow = { version = "1.0.102", default-features = false }
 serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
 hyperlight-common = { workspace = true, default-features = false }
-flatbuffers = { version= "25.12.19", default-features = false }
+flatbuffers = { workspace = true }
 tracing = { version = "0.1.44", default-features = false, features = ["attributes"] }
 
 [target.'cfg(target_arch = "x86_64")'.dependencies]

--- a/src/hyperlight_guest_bin/Cargo.toml
+++ b/src/hyperlight_guest_bin/Cargo.toml
@@ -26,10 +26,10 @@ hyperlight-guest-tracing = { workspace = true, default-features = false }
 hyperlight-guest-macro = { workspace = true, default-features = false, optional = true }
 hyperlight-libc = { workspace = true, default-features = false, optional = true }
 buddy_system_allocator = "0.13.0"
-log = { version = "0.4", default-features = false }
+log = { version = "0.4.32", default-features = false }
 linkme = { version = "0.3.36", optional = true }
-spin = "0.12.0"
-flatbuffers = { version = "25.12.19", default-features = false }
+spin = { workspace = true }
+flatbuffers = { workspace = true }
 tracing = { version = "0.1.44", default-features = false, features = ["attributes"] }
 
 [lints]

--- a/src/hyperlight_guest_capi/Cargo.toml
+++ b/src/hyperlight_guest_capi/Cargo.toml
@@ -16,8 +16,8 @@ hyperlight-guest = { workspace = true, default-features = false }
 hyperlight-guest-bin = { workspace = true, default-features = true }
 hyperlight-common = { workspace = true, default-features = false }
 
-flatbuffers = { version = "25.12.19", default-features = false }
-log = { version = "0.4", default-features = false }
+flatbuffers = { workspace = true }
+log = { version = "0.4.32", default-features = false }
 
 [build-dependencies]
 cbindgen = "0.29.4"

--- a/src/hyperlight_guest_macro/Cargo.toml
+++ b/src/hyperlight_guest_macro/Cargo.toml
@@ -12,9 +12,9 @@ Macros for registering guest and host functions on hyperlight guests binaries.
 """
 
 [dependencies]
-syn = { version = "3", features = ["full"] }
-quote = "1"
-proc-macro2 = "1.0"
+syn = { workspace = true, features = ["full"] }
+quote = { workspace = true }
+proc-macro2 = { workspace = true }
 proc-macro-crate = "3.5.0"
 
 [lib]

--- a/src/hyperlight_guest_tracing/Cargo.toml
+++ b/src/hyperlight_guest_tracing/Cargo.toml
@@ -11,7 +11,7 @@ description = """Provides the tracing functionality for the hyperlight guest."""
 
 [dependencies]
 hyperlight-common = { workspace = true, default-features = false }
-spin = "0.12.0"
+spin = { workspace = true }
 tracing = { version = "0.1.44", default-features = false, features = ["attributes"] }
 tracing-core = { version = "0.1.36", default-features = false }
 

--- a/src/hyperlight_host/Cargo.toml
+++ b/src/hyperlight_host/Cargo.toml
@@ -24,32 +24,32 @@ workspace = true
 gdbstub = { version = "0.7.10", optional = true }
 gdbstub_arch = { version = "0.3.3", optional = true }
 goblin = { version = "0.10", default-features = false, features = ["std", "elf32", "elf64", "endian_fd"] }
-rand = { version = "0.10" }
+rand = { workspace = true }
 cfg-if = { version = "1.0.4" }
 libc = { version = "0.2.186" }
 flatbuffers = "25.12.19"
 framehop = { version = "0.16.0", optional = true }
 fallible-iterator = { version = "0.3.0", optional = true }
-blake3 = "1.8.5"
-bytemuck = { version = "1.24", features = ["derive"] }
+blake3 = { workspace = true }
+bytemuck = { workspace = true, features = ["derive"] }
 page_size = "0.6.0"
 termcolor = "1.2.0"
-bitflags = "2.13.0"
-log = "0.4.32"
+bitflags = { workspace = true }
+log = { workspace = true }
 opentelemetry = { version = "0.32.0", optional = true }
-tracing = { version = "0.1.44", features = ["log"] }
-tracing-core = "0.1.36"
+tracing = { workspace = true, features = ["log"] }
+tracing-core = { workspace = true }
 tracing-opentelemetry = { version = "0.33.0", optional = true }
 hyperlight-common = { workspace = true, default-features = true, features = [ "std" ] }
 hyperlight-guest-tracing = { workspace = true, default-features = true, optional = true }
 vmm-sys-util = "0.15.0"
 crossbeam-channel = "0.5.15"
-thiserror = "2.0.18"
+thiserror = { workspace = true }
 chrono = { version = "0.4", optional = true }
-anyhow = "1.0"
+anyhow = { workspace = true }
 metrics = "0.24.6"
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
 elfcore = { version = "2.0", optional = true }
 uuid = { version = "1.23.3", features = ["v4"] }
 oci-spec = { version = "0.10", default-features = false, features = ["image"] }
@@ -97,12 +97,12 @@ signal-hook-registry = "1.4.8"
 iced-x86 = { version = "1.21", default-features = false, features = ["std", "code_asm"] }
 proptest = "1.11.0"
 crossbeam-queue = "0.3.12"
-tracing-serde = "0.2.0"
+tracing-serde = { workspace = true }
 serial_test = "4.0.1"
 hyperlight-testing = { workspace = true }
-env_logger = "0.11.10"
+env_logger = { workspace = true }
 tracing-forest = { version = "0.3.1", features = ["uuid", "chrono", "smallvec", "serde", "env-filter"] }
-tracing = "0.1.44"
+tracing = { workspace = true }
 tracing-subscriber = {version = "0.3.23", features = ["std", "env-filter"]}
 tracing-opentelemetry = "0.33.0"
 opentelemetry = "0.32.0"
@@ -110,11 +110,11 @@ opentelemetry-otlp = { version = "0.32.0", default-features = false, features = 
 opentelemetry-semantic-conventions = "0.32"
 opentelemetry_sdk = { version = "0.32.0", features = ["rt-tokio"] }
 tokio = { version = "1.52.3", features = ["full"] }
-criterion = "0.8.2"
+criterion = { workspace = true }
 tracing-chrome = "0.7.2"
 metrics-util = "0.20.4"
 metrics-exporter-prometheus = { version = "0.18.3", default-features = false }
-serde_json = "1.0"
+serde_json = { workspace = true }
 hyperlight-component-macro = { workspace = true }
 libtest-mimic = "0.8.2"
 
@@ -127,11 +127,11 @@ windows = { version = "0.62", features = [
 proc-maps = "0.5.0"
 
 [build-dependencies]
-anyhow = { version = "1.0.102" }
+anyhow = { workspace = true }
 cfg_aliases = "0.2.1"
 built = { version = "0.8.1", optional = true, features = ["chrono", "git2"] }
-bindgen = { version = "0.72", features = ["prettyplease"] }
-cc = "1.2"
+bindgen = { workspace = true, features = ["prettyplease"] }
+cc = { workspace = true }
 
 [features]
 default = ["kvm", "mshv3", "hvf", "build-metadata"]

--- a/src/hyperlight_libc/Cargo.toml
+++ b/src/hyperlight_libc/Cargo.toml
@@ -22,7 +22,7 @@ default = []
 workspace = true
 
 [build-dependencies]
-anyhow = "1"
-cc = "1.2"
+anyhow = { workspace = true }
+cc = { workspace = true }
 glob = "0.3.3"
-bindgen = { version = "0.72", features = ["prettyplease"] }
+bindgen = { workspace = true, features = ["prettyplease"] }

--- a/src/hyperlight_testing/Cargo.toml
+++ b/src/hyperlight_testing/Cargo.toml
@@ -3,15 +3,15 @@ name = "hyperlight-testing"
 edition = "2021"
 
 [dependencies]
-anyhow = "1.0.102"
-log = "0.4"
+anyhow = { workspace = true }
+log = { workspace = true }
 once_cell = "1.21"
-tracing = { version = "0.1.44", features = ["log"] }
+tracing = { workspace = true, features = ["log"] }
 tracing-log = "0.2.0"
-tracing-core = "0.1.36"
-tracing-serde = "0.2"
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
+tracing-core = { workspace = true }
+tracing-serde = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
 
 [lib]
 bench = false # see https://bheisler.github.io/criterion.rs/book/faq.html#cargo-bench-gives-unrecognized-option-errors-for-valid-command-line-options

--- a/src/trace_dump/Cargo.toml
+++ b/src/trace_dump/Cargo.toml
@@ -10,7 +10,7 @@ addr2line = "0.27.0"
 # Fixes #1490 through #1495 by using upstream piet commit 618083f,
 # which replaces the unmaintained unic-bidi dependency with icu_properties.
 piet-common = { git = "https://github.com/linebender/piet", rev = "618083f8a6671c7ab8c198724487348d2ccf9a8f", features = [ "png" ] }
-blake3 = { version = "1.8.5" }
+blake3 = { workspace = true }
 
 [[bin]]
 name = "trace_dump"


### PR DESCRIPTION
## What was wrong

The root `Cargo.toml` only used `[workspace.dependencies]` for the workspace's
own internal crates (path dependencies). Every member crate
(`hyperlight_common`, `hyperlight_guest`, `hyperlight_host`, etc.) pinned its
own version string for third-party dependencies, and several deps had
diverged to different versions in different crates, e.g.:

- `criterion`: `0.8.1` in `hyperlight-common` (dev) vs `0.8.2` in `hyperlight-host` (dev)
- `rand`: `0.10` in `hyperlight-host` vs `0.10.1` in `hyperlight-common` (dev)
- `quote`/`proc-macro2`/`syn`: loose requirements (`"1"`, `"1.0"`, `"3"`) in
  `hyperlight-guest-macro` vs exact pins in `hyperlight-component-macro` /
  `hyperlight-component-util`
- `log`: `"0.4"` in the guest crates vs `"0.4.32"` elsewhere

## What changed

- Added a `[workspace.dependencies]` block in the root `Cargo.toml` for every
  third-party dependency that is used by **2 or more** member crates (found
  by parsing every member manifest's `[dependencies]`, `[dev-dependencies]`
  and `[build-dependencies]`, including target-specific tables). Deps used by
  only one crate were left untouched.
- Each member now declares those deps as `dep = { workspace = true, ... }`,
  keeping its own `features`/`optional` locally (workspace dependency entries
  can't carry `optional`, and per-crate `features` stay additive).
- For every unified dep, the chosen workspace version is the **newest version
  already in use** anywhere in the workspace — nothing is bumped past a
  version some crate was already depending on.
- Cargo does not allow a member to override `default-features` on an
  inherited (`workspace = true`) dependency at all (this is a hard error, not
  just a lint — confirmed against `cargo metadata` on this branch). For the
  handful of deps where crates genuinely disagree on `default-features`
  (`anyhow`, `flatbuffers`, `log`, `thiserror`, `tracing`, `tracing-core`),
  the minority of crates keep a direct version pin instead of
  `workspace = true` for just that one dependency, so every no_std guest
  crate keeps `default-features = false` exactly as it had before.
- `Cargo.lock` is unchanged — every version chosen was already resolvable to
  the same lockfile entry.

### Deps unified (before → after)

| Dependency | Crates using it | Version before | Version after (workspace) |
|---|---|---|---|
| anyhow | hyperlight-common, hyperlight-guest, hyperlight-host, hyperlight-testing, hyperlight-libc (build) | 1.0.102 / 1.0.102 / 1.0 & 1.0.102(build) / 1.0.102 / 1 | 1.0.102 (common & guest keep a direct pin — see default-features note) |
| flatbuffers | hyperlight-common, hyperlight-guest, hyperlight-guest-bin, hyperlight-guest-capi, hyperlight-host | 25.12.19 (all) | 25.12.19, workspace default-features=false (host keeps a direct pin — needs default features on) |
| log | hyperlight-common, hyperlight-guest-bin, hyperlight-guest-capi, hyperlight-host, hyperlight-testing | 0.4.32 / 0.4 / 0.4 / 0.4.32 / 0.4 | 0.4.32 (guest-bin & guest-capi keep a direct pin at 0.4.32 — default-features=false) |
| thiserror | hyperlight-common, hyperlight-host | 2.0.18 / 2.0.18 | 2.0.18 (common keeps a direct pin — default-features=false) |
| tracing | hyperlight-common, hyperlight-component-util, hyperlight-guest, hyperlight-guest-bin, hyperlight-guest-tracing, hyperlight-host, hyperlight-testing | 0.1.44 everywhere | 0.1.44 (guest, guest-bin & guest-tracing keep a direct pin — default-features=false) |
| tracing-core | hyperlight-common, hyperlight-guest-tracing, hyperlight-host, hyperlight-testing | 0.1.36 everywhere | 0.1.36 (common & guest-tracing keep a direct pin — default-features=false) |
| bitflags | hyperlight-common, hyperlight-host | 2.13.0 / 2.13.0 | 2.13.0 |
| bytemuck | hyperlight-common, hyperlight-host | 1.24 / 1.24 | 1.24 |
| spin | hyperlight-common, hyperlight-guest-bin, hyperlight-guest-tracing | 0.12.0 (all) | 0.12.0 |
| serde | hyperlight-testing, hyperlight-host | 1.0 / 1.0 | 1.0 |
| serde_json | hyperlight-testing, hyperlight-host | 1.0 / 1.0 | 1.0 |
| quote | hyperlight-component-macro, hyperlight-component-util, hyperlight-guest-macro | 1.0.45 / 1.0.45 / 1 | **1.0.45** |
| proc-macro2 | hyperlight-component-macro, hyperlight-component-util, hyperlight-guest-macro | 1.0.106 / 1.0.106 / 1.0 | **1.0.106** |
| syn | hyperlight-component-macro, hyperlight-component-util, hyperlight-guest-macro | 3.0.1 / 3.0.1 / 3 | **3.0.1** |
| itertools | hyperlight-component-macro, hyperlight-component-util | 0.15.0 / 0.15.0 | 0.15.0 |
| prettyplease | hyperlight-component-macro, hyperlight-component-util | 0.3.0 / 0.3.0 | 0.3.0 |
| env_logger | hyperlight-component-macro, hyperlight-host (dev) | 0.11.10 / 0.11.10 | 0.11.10 |
| tracing-serde | hyperlight-testing, hyperlight-host (dev) | 0.2 / 0.2.0 | 0.2.0 |
| bindgen | hyperlight-libc (build), hyperlight-host (build) | 0.72 / 0.72 | 0.72 |
| cc | hyperlight-libc (build), hyperlight-host (build) | 1.2 / 1.2 | 1.2 |
| criterion | hyperlight-common (dev), hyperlight-host (dev) | **0.8.1** / **0.8.2** | **0.8.2** |
| rand | hyperlight-common (dev), hyperlight-host | **0.10.1** / **0.10** | **0.10.1** |
| blake3 | hyperlight-host, trace_dump | 1.8.5 / 1.8.5 | 1.8.5 |

Bold entries are the ones where crates genuinely diverged before this
change; the rest were already the same version, just declared with
different precision, and are now expressed once.

Deps that appear in only one member crate (e.g. `libc`, `chrono`, `uuid`,
`gdbstub`, `windows`, `wasmparser`, `wit-parser`, `buddy_system_allocator`,
`opentelemetry`, the `kvm-*`/`mshv-*` crates, etc.) were left untouched, per
the issue.

## How this was verified

```
$ cargo metadata --format-version 1 > /dev/null
# succeeds

$ cargo check
# Finished `dev` profile [unoptimized + debuginfo] target(s) in 16.06s

$ just check
cargo check
cargo check -p hyperlight-host --features crashdump
cargo check -p hyperlight-host --features print_debug
cargo check -p hyperlight-host --features gdb
cargo check -p hyperlight-host --features trace_guest,mem_profile
cargo check -p hyperlight-host --features hw-interrupts
cargo check -p hyperlight-host --features executable_heap
# all succeed

$ rustup target add x86_64-unknown-none
$ cargo check -p hyperlight-guest -p hyperlight-common --no-default-features --target x86_64-unknown-none
$ cargo check -p hyperlight-guest-bin -p hyperlight-guest-tracing --no-default-features --target x86_64-unknown-none
$ cargo check -p hyperlight-component-macro -p hyperlight-component-util -p hyperlight-guest-macro -p hyperlight-testing
# all succeed

$ just fmt-check
# clean, no diff (nightly-2026-02-27, as pinned in the Justfile)

$ git diff --stat -- Cargo.lock
# (empty — lockfile unchanged)
```

`hyperlight-libc` (and therefore `hyperlight_guest_capi`, which pulls it in
via its default `libc` feature) needs a `clang` toolchain plus its
`picolibc` git submodule to build its C shim; this Windows dev box doesn't
have `clang` installed. I confirmed with `git stash` that `cargo check -p
hyperlight-libc` fails with the exact same `cc-rs: failed to find tool
"clang"` error on the unmodified `main` branch, so this is a pre-existing
environment limitation, not a regression from this change.

Fixes #1454