### PR TITLE
Configure Dependabot cooldown and Windows crate groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,8 @@ version: 2
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"
+    cooldown:
+      default-days: 7
     schedule:
       interval: "daily"
       time: "03:00"
@@ -9,6 +11,8 @@ updates:
       - "kind/dependencies"
   - package-ecosystem: "cargo"
     directory: "/"
+    cooldown:
+      default-days: 7
     schedule:
       interval: "daily"
       time: "03:00"
@@ -16,6 +20,9 @@ updates:
       - "kind/dependencies"
     open-pull-requests-limit: 20
     groups:
+      windows:
+        patterns:
+          - "windows-*"
       mshv:
         patterns:
           - "mshv-*"
@@ -26,6 +33,8 @@ updates:
           - "wit-component"
   - package-ecosystem: "cargo"
     directory: "/src/tests/rust_guests"
+    cooldown:
+      default-days: 7
     schedule:
       interval: "daily"
       time: "03:00"
@@ -33,3 +42,7 @@ updates:
       - "kind/dependencies"
       - "area/guest"
     open-pull-requests-limit: 5
+    groups:
+      windows:
+        patterns:
+          - "windows-*"


### PR DESCRIPTION
Give dependency releases seven days to settle before version updates and keep related Windows crates together.

* Set a 7-day cooldown for GitHub Actions and both Cargo update entries.
* Group `windows-*` crates in both Cargo update entries.


#1564 review conclusion is to enable the 7 day cooldown and then use cargo vet, this incorporates the former to get us moving on this.